### PR TITLE
docs: onboarding guide + README discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,23 @@ Point it at a URL (behind login, with a saved Playwright `storageState`) and it 
 - **`automate`** — generate `@playwright/test` code from approved `ATC-*` cases (skips `MTC-*` manual ones).
 - **`explore`** — the full pipeline at once (cases → code → validation → repair → Pilot verdict).
 
+## How it works — the full cycle
+
+New to this? The bot writes two kinds of test case:
+- **ATC** (*Automatable Test Case*) — the bot is confident it can drive reliably (read-only checks, verified locators) → it generates Playwright code for these.
+- **MTC** (*Manual Test Case*) — needs a human (full form submits, security/XSS, visual/UX, irreversible actions) → left for you to run by hand.
+
+The typical flow:
+
+1. **Capture a session** (once) — log in so the bot can reach pages behind auth.
+2. **Design** — the bot studies the page and writes test cases (`ATC-*` / `MTC-*` `.md` files with recorded selectors). No code yet.
+3. **Review** — you read the cases (in the TUI: *Browse past runs* → open a run → *Cases*).
+4. **Promote** *(optional)* — reviewed an `MTC` and decided it's actually automatable? `lex-bot promote …` (or `a` in the TUI) converts it to an `ATC` in place. It's then picked up by automate.
+5. **Automate** — generate `@playwright/test` code from the `ATC` cases.
+6. **Validate** — run the generated tests, classify pass/fail/flaky, and self-repair failures.
+
+`explore` runs steps 2–6 in one go; `design` + `automate` split them so you can review (and promote) in between. Full walkthrough: **[docs/getting-started.md](docs/getting-started.md)**.
+
 ## Install
 
 ```bash
@@ -40,12 +57,17 @@ npm run session:save -- --url https://app.example.com/ --name myapp
 # 2. Design test cases (no code) — review the .md files it writes
 lex-bot design --url https://app.example.com/page --session myapp --checklist plan.md
 
-# 3. Automate the approved cases
+# 3. (optional) Promote a manual case you decided is automatable: MTC → ATC
+lex-bot promote --run runs/<id> --cases MTC-LOGIN-001
+
+# 4. Automate the approved (ATC) cases → @playwright/test code, and run them
 lex-bot automate --run runs/<id> --validate --session myapp
 
 # …or do everything at once:
 lex-bot explore --url https://app.example.com/page --session myapp --checklist plan.md
 ```
+
+New here? Read the **[Getting started guide](docs/getting-started.md)** — it walks the whole cycle with explanations.
 
 ## Interactive TUI
 
@@ -132,6 +154,12 @@ npm test             # vitest (unit + integration; LLM/browser are mocked in uni
 npm run test:coverage
 npm run lint
 ```
+
+## Documentation
+
+- **[Getting started](docs/getting-started.md)** — step-by-step onboarding (session → design → review → promote → automate → validate), written for people new to the tool.
+- **[Architecture overview](docs/architecture/overview.md)** — how the agent works inside (the LangGraph state machine, locator grounding, self-improvement).
+- **[Architecture Decision Records](docs/adr/)** — why it's built this way (0001–0009, incl. the interactive TUI and the `@playwright/test` output format).
 
 ## License
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,131 @@
+# Getting started with lex-bot
+
+New to lex-bot — or to UI test automation in general? This guide takes you from zero to a generated,
+validated `@playwright/test` suite, explaining each step as you go.
+
+## What lex-bot does (in one paragraph)
+
+You point it at a web page; it logs in (with a saved session), studies the page, and writes **test cases**
+in a human-readable Markdown format. Cases it's confident it can automate become **ATC** files; cases that
+need a human stay as **MTC** files. From the ATC cases it generates real `@playwright/test` code, runs it,
+and repairs failures. You stay in control: review the cases first, automate only what you approve.
+
+## Two kinds of test case: ATC vs MTC
+
+- **ATC — Automatable Test Case.** Read-only checks (visibility, enabled state, text) on elements with
+  reliable, verified locators. The bot generates Playwright code for these.
+- **MTC — Manual Test Case.** Things a bot shouldn't drive blindly: full form submission, security/XSS,
+  visual/UX judgment, irreversible actions. Left for a human to run.
+
+If you review an MTC and decide it really is safe to automate, **promote** it — see Step 5.
+
+## Prerequisites
+
+- **Node.js 20+**.
+- An **LLM API key**: `ANTHROPIC_API_KEY` (default) or `OPENROUTER_API_KEY` (cheaper). This is the only
+  required key — Langfuse and the rest are optional.
+- For pages behind a login: a **saved session** (Step 2).
+
+## Step 1 — Install and configure
+
+```bash
+npm install -g @plune-ai/lex-bot
+```
+
+Create a `.env` (copy `.env.example`) with at least your LLM key:
+
+```
+ANTHROPIC_API_KEY=sk-ant-...
+# or:  OPENROUTER_API_KEY=sk-or-...   and   LLM_PROFILE=openrouter
+```
+
+## Step 2 — Capture a session (for pages behind login)
+
+```bash
+npm run session:save -- --url https://app.example.com/ --name myapp
+```
+
+A browser opens; log in manually. Your cookies + localStorage are saved to `.auth/myapp.storageState.json`.
+Skip this step for public pages.
+
+## Step 3 — Your first run
+
+The easiest way to start is the **interactive TUI** — run the bot with no arguments:
+
+```bash
+lex-bot
+```
+
+Pick **Design** (writes test cases, no code yet), fill in the URL and pick your session, and watch the live
+dashboard as it works. When it finishes you'll see the cases and where they were written
+(`runs/<id>/testcases/`).
+
+Prefer the command line?
+
+```bash
+lex-bot design --url https://app.example.com/page --session myapp
+```
+
+## Step 4 — Review the cases
+
+In the TUI: from the launcher choose **Browse past runs**, open your run, and look at the **Cases** tab.
+Navigation: switch tabs with `1`/`2`/`3` or `←→`, scroll with `↑↓`, move between cases with `n`/`p`.
+
+Each `ATC-*.md` / `MTC-*.md` file has a title, preconditions, steps, expected result, and recorded selectors.
+Read them like a checklist of what will (ATC) and won't (MTC) be automated.
+
+## Step 5 — Promote a manual case (optional)
+
+Decided an `MTC` case is actually automatable? Promote it to `ATC`:
+
+- **In the TUI:** on the Cases tab, with an MTC case open, press **`a`**.
+- **On the CLI:**
+  ```bash
+  lex-bot promote --run runs/<id> --cases MTC-LOGIN-001,MTC-LOGIN-002
+  ```
+
+Promote renames the file to the next free `ATC-*` number, flips it to automatable, and refills selectors
+from the run's data. It does **not** generate code — that's the next step. (If a case has no usable selectors,
+add `--session <name>` so it can verify locators live in a browser.)
+
+## Step 6 — Automate and validate
+
+Generate `@playwright/test` code from the approved `ATC` cases, and run them:
+
+```bash
+lex-bot automate --run runs/<id> --validate --session myapp
+```
+
+You get `.spec.ts` files under `runs/<id>/tests/`, a pass/fail/flaky report, and automatic repair of
+failures (a repair never makes the suite worse).
+
+## …or do it all at once
+
+If you just want the full pipeline without stopping to review:
+
+```bash
+lex-bot explore --url https://app.example.com/page --session myapp
+```
+
+This runs design → code → validate → repair → a holistic "Pilot" verdict in one go.
+
+## Guiding what gets tested
+
+- **Checklist:** pass `--checklist plan.md` (a Markdown list of what to cover) to steer the design.
+- **Domain knowledge:** drop `*.md` files in `./knowledge/` (with a `url:` front-matter) to inject
+  credentials / validation rules / notes for matching pages.
+- **Planning style:** `--style happy | negative | coverage | all`.
+
+## Troubleshooting
+
+- **"session is expired"** — re-run `npm run session:save` for that page.
+- **TUI won't start / "Raw mode is not supported"** — run it in a real terminal, not a pipe/CI.
+- **Missing-API-key error** — set `ANTHROPIC_API_KEY` or `OPENROUTER_API_KEY` in `.env`.
+- **Empty selectors after promote** — the case referenced elements not in the run's `study.json`; re-run
+  `promote` with `--session` to verify locators live, or re-`design` the page.
+
+## Where to go next
+
+- [Architecture overview](architecture/overview.md) — how the agent works inside.
+- [Architecture Decision Records](adr/) — the locked design decisions (0001–0009).
+- The root [README](../README.md) — full command reference and configuration.


### PR DESCRIPTION
## Summary
Makes the project usable by a newcomer who only has the npm package (where only README ships).

- **README:** `promote` now appears in Quickstart; new **"How it works — the full cycle"** section explains ATC vs MTC and the session→design→review→promote→automate→validate flow; new **"Documentation"** section links the GitHub docs (architecture, ADRs, getting-started) that aren't in the tarball.
- **docs/getting-started.md (new):** beginner-friendly step-by-step walkthrough of the whole cycle (incl. promote), with prerequisites, a TUI-first first run, guidance knobs, and troubleshooting.

## Test plan
- [x] Internal links resolve (`docs/getting-started.md`, `docs/architecture/overview.md`, `docs/adr/`)
- [ ] Render check on GitHub (headings, code blocks, table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)