### PR TITLE
C0 — rename Lex-Bot → Cairn (code)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# Cairn configuration. Every variable below can also be set with a CAIRN_ prefix
+# (e.g. CAIRN_LLM_PROFILE, CAIRN_MAX_REPAIR). Legacy LEX_/LEXBOT_ prefixes still work
+# but print a one-time deprecation warning — prefer CAIRN_ or the bare name.
+
 # ── LLM providers (ADR-0002) ────────────────────────────────────────────────
 # The profile selects which provider/models are used for each tier:
 #   anthropic  — quality (Opus/Sonnet/Haiku), more expensive

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,7 +80,7 @@ jobs:
           else echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
-      # --- Phase 1: GitHub Packages (no provenance; package name @plune-ai/lex-bot does NOT change) ---
+      # --- Phase 1: GitHub Packages (no provenance; package name @plune-ai/cairn does NOT change) ---
       - name: Setup Node for GitHub Packages
         uses: actions/setup-node@v4
         with:
@@ -90,8 +90,8 @@ jobs:
       - name: Publish to GitHub Packages
         run: |
           VER="${{ steps.meta.outputs.version }}"
-          if npm view "@plune-ai/lex-bot@$VER" version --registry https://npm.pkg.github.com >/dev/null 2>&1; then
-            echo "@plune-ai/lex-bot@$VER already in GitHub Packages — skipping (idempotent)."
+          if npm view "@plune-ai/cairn@$VER" version --registry https://npm.pkg.github.com >/dev/null 2>&1; then
+            echo "@plune-ai/cairn@$VER already in GitHub Packages — skipping (idempotent)."
           else
             npm pkg set publishConfig.registry=https://npm.pkg.github.com
             npm publish --tag ${{ steps.dist.outputs.tag }}
@@ -112,8 +112,8 @@ jobs:
       - name: Publish to npm
         run: |
           VER="${{ steps.meta.outputs.version }}"
-          if npm view "@plune-ai/lex-bot@$VER" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
-            echo "@plune-ai/lex-bot@$VER already on npm — skipping (idempotent)."
+          if npm view "@plune-ai/cairn@$VER" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "@plune-ai/cairn@$VER already on npm — skipping (idempotent)."
           else
             npm publish --provenance --tag ${{ steps.dist.outputs.tag }}
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to @plune-ai/lex-bot
+# Contributing to @plune-ai/cairn
 
 Thanks for your interest in improving the bot! This guide covers local setup, the
 development workflow, and conventions.
@@ -41,7 +41,7 @@ npm run test:coverage  # coverage gate on core logic
 - `src/observe`, `src/analyze`, `src/design`, `src/codegen`, `src/validate` — the pipeline stages.
 - `src/eval/` — deterministic scorers, LLM judge, Pilot supervisor, experiments.
 - `src/prompts/local/*.ts` — the methodology prompts (the bot's "brain").
-- `src/cli/` — the `lex-bot` CLI.
+- `src/cli/` — the `cairn` CLI.
 
 ## Editing prompts
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
-# @plune-ai/lex-bot
+# Cairn
+
+> **Cairn — an AI that walks your system and leaves a trail of tests: UI, API, unit, docs.**
+
+<!-- asciinema: docs/demo/cairn.cast (record before launch — see docs/demo/README.md) -->
+[![Cairn demo](https://asciinema.org/a/REPLACE_ME.svg)](https://asciinema.org/a/REPLACE_ME)
 
 > Autonomous QA agent (Node.js / TypeScript) that logs into a web app with a saved session, explores
 > pages (ARIA snapshot + screenshot), designs methodology-based UI test cases (ISO/IEC/IEEE 29119-4),
 > generates runnable `@playwright/test` code, self-validates and self-repairs, and **self-improves**
 > via Langfuse. A portable utility (CLI + library) for embedding into other TypeScript projects.
+
+**Cairn is the generation layer** — it produces tests across surfaces (UI today; API / unit / docs planned),
+each arriving by demand, one at a time. A separate **Plune** layer owns record / management / eval.
+
+> **Renamed from Lex-Bot → Cairn.** The old `lex-bot` command and the `@plune-ai/lex-bot` package still
+> work — the CLI prints a one-line deprecation notice — but switch to `cairn` / `@plune-ai/cairn`; the old
+> names will be removed in 1–2 releases. Legacy `LEX_`/`LEXBOT_` env vars still work too; prefer `CAIRN_`.
 
 ## What it does
 
@@ -32,7 +44,7 @@ The typical flow:
 1. **Capture a session** (once) — log in so the bot can reach pages behind auth.
 2. **Design** — the bot studies the page and writes test cases (`ATC-*` / `MTC-*` `.md` files with recorded selectors). No code yet.
 3. **Review** — you read the cases (in the TUI: *Browse past runs* → open a run → *Cases*).
-4. **Promote** *(optional)* — reviewed an `MTC` and decided it's actually automatable? `lex-bot promote …` (or `a` in the TUI) converts it to an `ATC` in place. It's then picked up by automate.
+4. **Promote** *(optional)* — reviewed an `MTC` and decided it's actually automatable? `cairn promote …` (or `a` in the TUI) converts it to an `ATC` in place. It's then picked up by automate.
 5. **Automate** — generate `@playwright/test` code from the `ATC` cases.
 6. **Validate** — run the generated tests, classify pass/fail/flaky, and self-repair failures.
 
@@ -41,9 +53,9 @@ The typical flow:
 ## Install
 
 ```bash
-npm install -g @plune-ai/lex-bot     # CLI
+npm install -g @plune-ai/cairn     # CLI
 # or as a library:
-npm install @plune-ai/lex-bot
+npm install @plune-ai/cairn
 ```
 
 Requires Node.js 20+. Copy `.env.example` → `.env` and fill in your keys.
@@ -55,26 +67,26 @@ Requires Node.js 20+. Copy `.env.example` → `.env` and fill in your keys.
 npm run session:save -- --url https://app.example.com/ --name myapp
 
 # 2. Design test cases (no code) — review the .md files it writes
-lex-bot design --url https://app.example.com/page --session myapp --checklist plan.md
+cairn design --url https://app.example.com/page --session myapp --checklist plan.md
 
 # 3. (optional) Promote a manual case you decided is automatable: MTC → ATC
-lex-bot promote --run runs/<id> --cases MTC-LOGIN-001
+cairn promote --run runs/<id> --cases MTC-LOGIN-001
 
 # 4. Automate the approved (ATC) cases → @playwright/test code, and run them
-lex-bot automate --run runs/<id> --validate --session myapp
+cairn automate --run runs/<id> --validate --session myapp
 
 # …or do everything at once:
-lex-bot explore --url https://app.example.com/page --session myapp --checklist plan.md
+cairn explore --url https://app.example.com/page --session myapp --checklist plan.md
 ```
 
 New here? Read the **[Getting started guide](docs/getting-started.md)** — it walks the whole cycle with explanations.
 
 ## Interactive TUI
 
-Run `lex-bot` with **no arguments** in a terminal to open the interactive TUI (built with Ink):
+Run `cairn` with **no arguments** in a terminal to open the interactive TUI (built with Ink):
 
 ```bash
-lex-bot          # launches the terminal UI
+cairn          # launches the terminal UI
 ```
 
 Pick a command (explore / design / automate), fill parameters (URL, session, checklist, style) via a
@@ -82,19 +94,21 @@ guided form, watch a **live dashboard** of the graph nodes as the run progresses
 (scores, green %, Pilot verdict, test cases), and **browse past runs** in `./runs` — opening any run to
 read its test cases, report and logs.
 
-The commands below stay available for scripting/CI; in a non-interactive (piped/CI) shell, `lex-bot` with
+The commands below stay available for scripting/CI; in a non-interactive (piped/CI) shell, `cairn` with
 no arguments prints help instead of starting the UI.
 
 ## Commands
 
 | Command | Purpose |
 |---|---|
-| `lex-bot observe --url <u> [--session <s>]` | ARIA snapshot + interactive elements + screenshot |
-| `lex-bot design --url <u> --session <s> [--checklist <f>] [--style <s>]` | Test cases only (ATC/MTC `.md` + selectors), no code |
-| `lex-bot automate --run <dir> [--validate --session <s>]` | `@playwright/test` from `ATC-*` cases |
-| `lex-bot promote --run <dir> --cases <ids> [--session <s>]` | Promote manual MTC case(s) to ATC (.md only; then `automate`) |
-| `lex-bot explore --url <u> --session <s> [--checklist <f>]` | Full pipeline (cases → code → validate → repair → Pilot) |
-| `lex-bot experiment --dataset <d> --candidate name=file` | Compare prompt versions on a dataset |
+| `cairn observe --url <u> [--session <s>]` | ARIA snapshot + interactive elements + screenshot |
+| `cairn design --url <u> --session <s> [--checklist <f>] [--style <s>]` | Test cases only (ATC/MTC `.md` + selectors), no code |
+| `cairn automate --run <dir> [--validate --session <s>]` | `@playwright/test` from `ATC-*` cases |
+| `cairn promote --run <dir> --cases <ids> [--session <s>]` | Promote manual MTC case(s) to ATC (.md only; then `automate`) |
+| `cairn explore --url <u> --session <s> [--checklist <f>]` | Full pipeline (cases → code → validate → repair → Pilot) |
+| `cairn experiment --dataset <d> --candidate name=file` | Compare prompt versions on a dataset |
+
+> `lex-bot <command>` still runs every command above (deprecated alias — prints a notice, then runs `cairn`).
 
 ## Configuration (env)
 
@@ -108,6 +122,7 @@ no arguments prints help instead of starting the UI.
 | `BROWSER_CHANNEL` | `chrome` to use real Chrome (helps with OAuth) |
 | `MAX_REPAIR` | repair attempts (default 2) |
 
+- **Env var prefix:** every variable above is read as-is **or** with a `CAIRN_` prefix (e.g. `CAIRN_LLM_PROFILE`, `CAIRN_MAX_REPAIR`). Legacy `LEX_`/`LEXBOT_` prefixes still work but print a one-time deprecation warning — prefer `CAIRN_`.
 - **Domain knowledge:** put `*.md` files in `./knowledge/` with a `url:` front-matter to inject credentials/validation rules into design.
 - **Prompt overrides:** drop `./prompts/<name>.md` to override any built-in prompt without rebuilding.
 
@@ -119,7 +134,7 @@ deterministic scorers, self-repair, and results-level learning (best cases are r
 `runs/<id>/report.json`). Prompts fall back to the built-in defaults — override any of them with `./prompts/<name>.md`.
 
 Set the three `LANGFUSE_*` variables to **additionally** get: traces in the Langfuse UI, scores/datasets
-recorded centrally, and versioned prompts (with production labels & A/B prompt experiments via `lex-bot experiment`).
+recorded centrally, and versioned prompts (with production labels & A/B prompt experiments via `cairn experiment`).
 
 **Cloud or self-hosted — same setup.** Langfuse Cloud and a self-hosted instance are configured identically:
 you only pass the host URL and the API keys, nothing else changes.
@@ -139,7 +154,7 @@ LANGFUSE_SECRET_KEY=sk-lf-...
 ## Library API
 
 ```ts
-import { runDesign, runAutomate, runExploration, loadConfig } from "@plune-ai/lex-bot";
+import { runDesign, runAutomate, runExploration, loadConfig } from "@plune-ai/cairn";
 
 const config = loadConfig(process.env);
 const result = await runDesign({ url, config, sessionName: "myapp", checklistText });
@@ -159,7 +174,7 @@ npm run lint
 
 - **[Getting started](docs/getting-started.md)** — step-by-step onboarding (session → design → review → promote → automate → validate), written for people new to the tool.
 - **[Architecture overview](docs/architecture/overview.md)** — how the agent works inside (the LangGraph state machine, locator grounding, self-improvement).
-- **[Architecture Decision Records](docs/adr/)** — why it's built this way (0001–0009, incl. the interactive TUI and the `@playwright/test` output format).
+- **[Architecture Decision Records](docs/adr/)** — why it's built this way (0001–0010, incl. the interactive TUI, the `@playwright/test` output format, and the Lex-Bot → Cairn rename).
 
 ## License
 

--- a/docs/adr/0010-rename-to-cairn.md
+++ b/docs/adr/0010-rename-to-cairn.md
@@ -1,0 +1,67 @@
+# ADR-0010: Rename Lex-Bot → Cairn
+
+- **Status:** Accepted · **Date:** 2026-06-13
+- **Decision in code:** package `@plune-ai/cairn`, CLI `cairn` (deprecated `lex-bot` alias), env prefix `CAIRN_`
+- **Supersedes the product name only** — the architecture (ADR-0001…0009) is unchanged.
+
+## Context
+
+The tool is about to spread publicly (npm + docs + demo). Before that, the name should carry the
+product's actual ambition. Two problems with **Lex-Bot**:
+
+1. **The `-bot` suffix is a me-too pattern.** The adjacent ecosystem is already full of it —
+   *Explorbot*, *ApiBot*, *DocBot*. A `…Bot` name reads as "one more single-purpose bot" and fights
+   for the same mental shelf, which is exactly the wrong framing for what we're building.
+2. **We are not a single-surface bot.** The roadmap is an **umbrella** CLI that generates tests across
+   surfaces — UI today; API, unit, and living docs by demand. The name needs to be a container for
+   many modalities, not a label for one.
+
+## Decision
+
+Rename the product to **Cairn**.
+
+A *cairn* is a trail of stacked stone markers that proves a path was walked and guides whoever follows.
+That is precisely the product metaphor:
+
+> **Cairn — an AI that walks your system and leaves a trail of tests: UI, API, unit, docs.**
+
+Concrete renames (this PR — code side only):
+- npm package `@plune-ai/lex-bot` → **`@plune-ai/cairn`**.
+- CLI command `lex-bot` → **`cairn`**; `lex-bot` stays as a **hidden, deprecated alias** that prints a
+  one-line notice and runs the same code path (removal planned in 1–2 releases).
+- Env prefix → **`CAIRN_`** (resolution order `CAIRN_` → legacy `LEXBOT_`/`LEX_` → bare name; legacy
+  prefixes warn once).
+
+### Naming alternatives considered
+
+- **Nib** — short, evocative (pen nib → "writes" tests). **Ruled out:** a live npm package already owns
+  `nib`, and `.nib` collides with Apple Interface Builder bundles — a present, not dormant, collision on
+  both the registry and the filename namespace.
+- **Keep `Lex-Bot`** — rejected: the `-bot` me-too problem above, and it under-sells the umbrella scope.
+- **Cairn** — **chosen.** The npm/name collision risk is *dormant* (no significant conflicting package),
+  and the "trail of markers left by walking the terrain" metaphor maps cleanly onto a multi-surface,
+  evidence-leaving test generator.
+
+## Product boundary (framing, not a build dependency)
+
+- **Cairn = the generation layer** — it walks a system and *produces* tests across surfaces.
+- **Plune = the record / management / eval layer** — it *stores, manages, and evaluates* what Cairn (and
+  humans) produce.
+
+Cairn is self-contained: it has **no build/runtime dependency** on any Plune-side config. The boundary is
+about product scope and messaging, so neither side grows into the other's responsibility.
+
+## Consequences
+
+- (+) The name scales to the umbrella roadmap (`cairn ui|e2e`, `cairn api`, `cairn unit`, `cairn docs`).
+- (+) Full backward compatibility: old CLI name, old package (kept published, never deleted — see C0-07),
+  and old `LEX_`/`LEXBOT_` env vars all keep working, each with a deprecation nudge.
+- (−) A migration window where two package names and two CLI names coexist; mitigated by `npm deprecate`
+  on the old package and the in-CLI deprecation notice.
+- (−) Docs, demo asset, and social/preview metadata must be refreshed (tracked under epic C0).
+
+## Out of scope for this ADR / PR (manual, maintainer-run)
+
+- Renaming the **GitHub repository** `plune-ai/lex-bot` → `plune-ai/cairn` (C0-01, #11).
+- **npm publish** of `@plune-ai/cairn` + `npm deprecate @plune-ai/lex-bot` (C0-07, #17).
+- Repo **metadata / social-preview** (C0-08, #18).

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -1,6 +1,6 @@
 # Module Map
 
-One layered npm package `@plune-ai/lex-bot` (ADR-0007). Layer boundaries = directories + barrel exports +
+One layered npm package `@plune-ai/cairn` (ADR-0007). Layer boundaries = directories + barrel exports +
 ESLint `no-restricted-imports`. **Browser backends are imported ONLY through `browser/gateway.ts`.**
 
 ## `src/` structure

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,0 +1,39 @@
+# Cairn demo (asciinema)
+
+A scripted, non-interactive walkthrough of the `cairn` CLI — **no secrets, no network calls** (it only
+drives `--version` / `--help`). Safe to record and publish.
+
+## Record
+
+```bash
+npm run build                                       # the demo drives the built CLI
+asciinema rec docs/demo/cairn.cast -c ./scripts/demo.sh
+```
+
+Tune pacing with `DEMO_PAUSE` (seconds) and target a global install with `CAIRN`:
+
+```bash
+DEMO_PAUSE=2 CAIRN=cairn asciinema rec docs/demo/cairn.cast -c ./scripts/demo.sh
+```
+
+## Play back
+
+```bash
+asciinema play docs/demo/cairn.cast
+```
+
+## Publish + embed
+
+Upload to get a cast id, then point the README hero badge at it:
+
+```bash
+asciinema upload docs/demo/cairn.cast
+```
+
+```md
+[![Cairn demo](https://asciinema.org/a/<id>.svg)](https://asciinema.org/a/<id>)
+```
+
+> The cast file (`cairn.cast`) is intentionally **not committed yet** — record it right before launch so it
+> reflects the shipped CLI. Until then the README hero carries a placeholder marker
+> (`<!-- asciinema: docs/demo/cairn.cast (record before launch) -->`) and a `REPLACE_ME` badge.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,9 +1,9 @@
-# Getting started with lex-bot
+# Getting started with cairn
 
-New to lex-bot — or to UI test automation in general? This guide takes you from zero to a generated,
+New to cairn — or to UI test automation in general? This guide takes you from zero to a generated,
 validated `@playwright/test` suite, explaining each step as you go.
 
-## What lex-bot does (in one paragraph)
+## What cairn does (in one paragraph)
 
 You point it at a web page; it logs in (with a saved session), studies the page, and writes **test cases**
 in a human-readable Markdown format. Cases it's confident it can automate become **ATC** files; cases that
@@ -29,7 +29,7 @@ If you review an MTC and decide it really is safe to automate, **promote** it �
 ## Step 1 — Install and configure
 
 ```bash
-npm install -g @plune-ai/lex-bot
+npm install -g @plune-ai/cairn
 ```
 
 Create a `.env` (copy `.env.example`) with at least your LLM key:
@@ -53,7 +53,7 @@ Skip this step for public pages.
 The easiest way to start is the **interactive TUI** — run the bot with no arguments:
 
 ```bash
-lex-bot
+cairn
 ```
 
 Pick **Design** (writes test cases, no code yet), fill in the URL and pick your session, and watch the live
@@ -63,7 +63,7 @@ dashboard as it works. When it finishes you'll see the cases and where they were
 Prefer the command line?
 
 ```bash
-lex-bot design --url https://app.example.com/page --session myapp
+cairn design --url https://app.example.com/page --session myapp
 ```
 
 ## Step 4 — Review the cases
@@ -81,7 +81,7 @@ Decided an `MTC` case is actually automatable? Promote it to `ATC`:
 - **In the TUI:** on the Cases tab, with an MTC case open, press **`a`**.
 - **On the CLI:**
   ```bash
-  lex-bot promote --run runs/<id> --cases MTC-LOGIN-001,MTC-LOGIN-002
+  cairn promote --run runs/<id> --cases MTC-LOGIN-001,MTC-LOGIN-002
   ```
 
 Promote renames the file to the next free `ATC-*` number, flips it to automatable, and refills selectors
@@ -93,7 +93,7 @@ add `--session <name>` so it can verify locators live in a browser.)
 Generate `@playwright/test` code from the approved `ATC` cases, and run them:
 
 ```bash
-lex-bot automate --run runs/<id> --validate --session myapp
+cairn automate --run runs/<id> --validate --session myapp
 ```
 
 You get `.spec.ts` files under `runs/<id>/tests/`, a pass/fail/flaky report, and automatic repair of
@@ -104,7 +104,7 @@ failures (a repair never makes the suite worse).
 If you just want the full pipeline without stopping to review:
 
 ```bash
-lex-bot explore --url https://app.example.com/page --session myapp
+cairn explore --url https://app.example.com/page --session myapp
 ```
 
 This runs design → code → validate → repair → a holistic "Pilot" verdict in one go.

--- a/docs/runbooks/design-and-automate.md
+++ b/docs/runbooks/design-and-automate.md
@@ -9,7 +9,7 @@ First we write test cases (a human-valuable artifact in the ATC/MTC format), and
 
 ## 2. `design` — test cases only (no code)
 ```
-lex-bot design --url https://app.example.com/page --session myapp --checklist plan.md
+cairn design --url https://app.example.com/page --session myapp --checklist plan.md
 ```
 Writes `runs/<id>/testcases/*.md`:
 - **ATC-<SUITE>-NNN.md** — `execution: auto` (read-only, verified locators) → can be automated; `status: ❌ Not implemented`.
@@ -22,13 +22,13 @@ Metrics: grounding, verified_ratio, test_case_quality, methodology_adherence, **
 
 ## 3. `automate` — code from approved cases
 ```
-lex-bot automate --run runs/<id> [--validate --session myapp]
+cairn automate --run runs/<id> [--validate --session myapp]
 ```
 - Reads `testcases/*.md`, **skips MTC/manual**, generates `@playwright/test` from the ATC cases (locators are taken from the Selectors section) → `runs/<id>/tests/`.
 - `--validate` — runs the generated tests (a session is required).
 
 ## 4. Alternative — `explore` (everything at once)
 ```
-lex-bot explore --url ... --session ... [--checklist ...]
+cairn explore --url ... --session ... [--checklist ...]
 ```
 observe→design→code→validation→repair (keep-best)→Pilot verdict — a validated suite + metrics right away.

--- a/docs/runbooks/real-site-smoke.md
+++ b/docs/runbooks/real-site-smoke.md
@@ -14,11 +14,11 @@
 3. **(Opt.) Checklist:** `.md`/text or `## TC-XX` — steers what to test.
 4. **First design (no code — the safest):**
    ```
-   lex-bot design --url https://app.example.com/page --session myapp --checklist plan.md
+   cairn design --url https://app.example.com/page --session myapp --checklist plan.md
    ```
    → review `runs/<id>/testcases/ATC-*.md` (+ MTC-* manual).
-5. **Then — automate the approved ones:** `lex-bot automate --run runs/<id> --validate --session myapp`.
-   Or the full flow at once: `lex-bot explore --url ... --session myapp` (code+validation+repair+Pilot).
+5. **Then — automate the approved ones:** `cairn automate --run runs/<id> --validate --session myapp`.
+   Or the full flow at once: `cairn explore --url ... --session myapp` (code+validation+repair+Pilot).
 
 ## Robustness
 - **Rate limit / 5xx:** `retryInvoke` auto-retries transient errors (backoff).

--- a/docs/runbooks/run-experiment.md
+++ b/docs/runbooks/run-experiment.md
@@ -14,7 +14,7 @@ Prove (or disprove) that a new prompt version is better than production, on the 
 ## Run
 
 ```bash
-lex-bot experiment \
+cairn experiment \
   --dataset bot-regression-v1 \
   --prompt qa-testcase-from-ui \
   --prompt-version candidate \

--- a/docs/runbooks/run-exploration.md
+++ b/docs/runbooks/run-exploration.md
@@ -12,7 +12,7 @@
 ## Basic run
 
 ```bash
-lex-bot explore --url https://app.example.com/login \
+cairn explore --url https://app.example.com/login \
   --session demo \           # storageState name (opt.)
   --backend lib \            # lib | cli (default lib)
   --profile openrouter \     # anthropic | openrouter | mixed (default anthropic; OpenRouter — economical)

--- a/docs/runbooks/save-session.md
+++ b/docs/runbooks/save-session.md
@@ -20,11 +20,11 @@ await page.goto('https://app.example.com/login');
 await ctx.storageState({ path: './.auth/demo.storageState.json' });
 ```
 
-Then: `lex-bot explore --url ... --session demo` (the bot reads `./.auth/demo.storageState.json`).
+Then: `cairn explore --url ... --session demo` (the bot reads `./.auth/demo.storageState.json`).
 
 ## Option B — interactive login by the bot (S6)
 
-`lex-bot session login --url ... --session demo` opens a browser, waits for a manual login, and saves the state.
+`cairn session login --url ... --session demo` opens a browser, waits for a manual login, and saves the state.
 
 ## Security (MANDATORY)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@plune-ai/lex-bot",
+  "name": "@plune-ai/cairn",
   "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@plune-ai/lex-bot",
+      "name": "@plune-ai/cairn",
       "version": "0.2.1",
       "license": "GPL-3.0-only",
       "dependencies": {
@@ -32,7 +32,8 @@
         "zod": "^4.4.3"
       },
       "bin": {
-        "lex-bot": "dist/cli/index.js"
+        "cairn": "dist/cli/index.js",
+        "lex-bot": "dist/cli/lex-bot.js"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "@plune-ai/lex-bot",
+  "name": "@plune-ai/cairn",
   "version": "0.2.1",
-  "description": "Autonomous QA agent that explores web pages and generates UI tests (@playwright/test) on LangGraph + Claude/OpenRouter, with self-improvement via Langfuse.",
+  "description": "Cairn — an AI that walks your system and leaves a trail of tests. Autonomous QA agent (UI today; API/unit/docs planned) on LangGraph + Claude/OpenRouter, with self-improvement via Langfuse.",
   "type": "module",
   "license": "GPL-3.0-only",
   "author": "plune-ai",
   "keywords": [
+    "cairn",
     "qa",
     "testing",
     "test-generation",
@@ -14,21 +15,23 @@
     "langgraph",
     "ai-agent",
     "langfuse",
-    "anthropic"
+    "anthropic",
+    "openrouter"
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/plune-ai/lex-bot.git"
+    "url": "git+https://github.com/plune-ai/cairn.git"
   },
-  "homepage": "https://github.com/plune-ai/lex-bot#readme",
+  "homepage": "https://github.com/plune-ai/cairn#readme",
   "bugs": {
-    "url": "https://github.com/plune-ai/lex-bot/issues"
+    "url": "https://github.com/plune-ai/cairn/issues"
   },
   "engines": {
     "node": ">=20"
   },
   "bin": {
-    "lex-bot": "dist/cli/index.js"
+    "cairn": "dist/cli/index.js",
+    "lex-bot": "dist/cli/lex-bot.js"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Scripted, non-interactive Cairn walkthrough for asciinema — NO secrets, NO network calls.
+# It only exercises --version / --help surfaces, so it is safe to record and publish.
+#
+#   asciinema rec docs/demo/cairn.cast -c ./scripts/demo.sh
+#
+# By default it drives the locally built CLI (run `npm run build` first). Override with:
+#   CAIRN="cairn" ./scripts/demo.sh     # use a globally installed cairn instead of the built dist
+#   DEMO_PAUSE=2  ./scripts/demo.sh     # slower pacing for a nicer recording
+set -euo pipefail
+
+CAIRN="${CAIRN:-node dist/cli/index.js}"
+PAUSE="${DEMO_PAUSE:-1}"
+
+say() { printf '\n\033[36m# %s\033[0m\n' "$1"; sleep "$PAUSE"; }
+run() { printf '\033[2m$ cairn %s\033[0m\n' "$*"; sleep "$PAUSE"; $CAIRN "$@" || true; sleep "$PAUSE"; }
+
+if [ "$CAIRN" = "node dist/cli/index.js" ] && [ ! -f dist/cli/index.js ]; then
+  echo "Build first:  npm run build   (or set CAIRN=cairn to use a global install)"
+  exit 1
+fi
+
+say "Cairn — an AI that walks your system and leaves a trail of tests: UI, API, unit, docs."
+say "Cairn = generation layer · Plune = record / management / eval layer."
+run --version
+run --help
+say "Explore a page -> methodology-based test cases -> @playwright/test code (UI surface, today):"
+run explore --help
+say "Design-only (no code) and automate-from-cases are separate, decoupled subcommands:"
+run design --help
+say "A real run needs a captured session + an API key, e.g.:"
+printf '\033[2m$ cairn explore --url https://app.example.com/page --session myapp\033[0m\n'
+sleep "$PAUSE"
+say "Future surfaces are gated, by demand:  cairn ui|e2e · cairn api · cairn unit · cairn docs"

--- a/scripts/save-session.ts
+++ b/scripts/save-session.ts
@@ -62,4 +62,4 @@ await browser.close();
 
 console.log(`\n✓ Session saved: ${statePath}`);
 console.log(`  Session name: ${name}`);
-console.log(`  Next: qa-bot explore --url ${url} --session ${name}`);
+console.log(`  Next: cairn explore --url ${url} --session ${name}`);

--- a/src/cli/branding.ts
+++ b/src/cli/branding.ts
@@ -1,0 +1,17 @@
+/**
+ * CLI branding + the deprecated-alias notice (C0-03 / C0-04).
+ *
+ * `cairn` is the primary command; `lex-bot` remains a hidden, deprecated alias
+ * (see src/cli/lex-bot.ts) that prints {@link LEXBOT_CLI_NOTICE} before delegating
+ * to the same code path. Nothing is removed yet — full backward compatibility.
+ */
+export const PRIMARY_BIN = "cairn" as const;
+export const DEPRECATED_BIN = "lex-bot" as const;
+
+/** Product tagline (umbrella framing across surfaces). */
+export const TAGLINE =
+  "Cairn — an AI that walks your system and leaves a trail of tests: UI, API, unit, docs." as const;
+
+/** One-line notice printed to stderr when invoked via the legacy `lex-bot` alias. */
+export const LEXBOT_CLI_NOTICE =
+  "⚠ `lex-bot` is deprecated and will be removed in 1–2 releases — use `cairn` instead." as const;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 /**
- * CLI `lex-bot`. Commands: observe · explore · design · automate · dataset-add · experiment.
+ * CLI `cairn`. Commands: observe · explore · design · automate · dataset-add · experiment.
+ * `lex-bot` stays as a hidden, deprecated alias (see ./lex-bot.ts) → same code path.
  */
 import "dotenv/config";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { Command } from "commander";
 import { BOT_NAME, BOT_VERSION } from "../index.js";
 import { makeGateway } from "../browser/index.js";
@@ -23,7 +25,7 @@ import type { PageStudy } from "../observe/index.js";
 
 const program = new Command();
 program
-  .name("lex-bot")
+  .name("cairn")
   .description(`${BOT_NAME} — autonomous UI test generator`)
   .version(BOT_VERSION);
 
@@ -340,22 +342,36 @@ program
         const res = await promoteCase(runDir, id, { collectLive });
         process.stdout.write(`${res.oldId} → ${res.newId}${res.warning ? ` (⚠ ${res.warning})` : ""}\n`);
       }
-      process.stdout.write(`\nDone. Run \`lex-bot automate --run ${opts.run}\` to generate code for the new ATC case(s).\n`);
+      process.stdout.write(`\nDone. Run \`cairn automate --run ${opts.run}\` to generate code for the new ATC case(s).\n`);
     },
   );
 
-const cliArgs = process.argv.slice(2);
-if (cliArgs.length === 0 && process.stdin.isTTY && process.stdout.isTTY) {
-  // No command in an interactive terminal → launch the TUI (lazy: keeps React/Ink
-  // out of every other code path, incl. library embedders).
-  const { mountTui } = await import("../tui/index.js");
-  await mountTui();
-} else if (cliArgs.length === 0) {
-  // No command but non-TTY (pipe/CI) → print usage instead of crashing Ink raw-mode.
-  program.outputHelp();
-} else {
-  await program.parseAsync(process.argv).catch((e: unknown) => {
-    process.stderr.write(`${(e as Error).message}\n`);
-    process.exitCode = 1;
-  });
+/**
+ * Run the CLI. Shared by the primary `cairn` entry (this file) and the deprecated
+ * `lex-bot` alias shim (./lex-bot.ts), so both go through the exact same code path.
+ */
+export async function runCli(): Promise<void> {
+  const cliArgs = process.argv.slice(2);
+  if (cliArgs.length === 0 && process.stdin.isTTY && process.stdout.isTTY) {
+    // No command in an interactive terminal → launch the TUI (lazy: keeps React/Ink
+    // out of every other code path, incl. library embedders).
+    const { mountTui } = await import("../tui/index.js");
+    await mountTui();
+  } else if (cliArgs.length === 0) {
+    // No command but non-TTY (pipe/CI) → print usage instead of crashing Ink raw-mode.
+    program.outputHelp();
+  } else {
+    await program.parseAsync(process.argv).catch((e: unknown) => {
+      process.stderr.write(`${(e as Error).message}\n`);
+      process.exitCode = 1;
+    });
+  }
+}
+
+// Auto-run only when invoked directly as the `cairn` bin — NOT when imported by the
+// `lex-bot` alias shim (which calls runCli() itself after printing the deprecation notice).
+const invokedDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  await runCli();
 }

--- a/src/cli/lex-bot.ts
+++ b/src/cli/lex-bot.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+/**
+ * Deprecated `lex-bot` CLI alias (C0-03). Prints a one-line deprecation notice to
+ * stderr, then runs the exact same code path as `cairn`. Kept for 1–2 releases so
+ * existing scripts/aliases keep working; will be removed once users have migrated.
+ */
+import { LEXBOT_CLI_NOTICE } from "./branding.js";
+import { runCli } from "./index.js";
+
+process.stderr.write(`${LEXBOT_CLI_NOTICE}\n`);
+await runCli();

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,52 @@
+/**
+ * Env-var resolution with the CAIRN_ prefix and backward-compatible fallbacks (C0-06).
+ *
+ * For each logical name, resolution order is:
+ *   CAIRN_<name>  →  LEXBOT_<name>  →  LEX_<name>  →  <name>  (bare/current)
+ *
+ * The new `CAIRN_` prefix and the current bare names are first-class; the legacy
+ * `LEXBOT_`/`LEX_` forms keep working but emit a one-time deprecation warning so
+ * users can migrate. Nothing is removed — this is purely additive back-compat.
+ */
+
+export type EnvRecord = Record<string, string | undefined>;
+
+/** Legacy product prefixes, in precedence order (newer legacy form first). */
+const LEGACY_PREFIXES = ["LEXBOT_", "LEX_"] as const;
+
+const defaultWarn = (msg: string): void => {
+  process.stderr.write(`${msg}\n`);
+};
+
+/**
+ * Build an env reader bound to a raw env record. Returns `read(name)` which applies
+ * the CAIRN_ → legacy → bare resolution above. Legacy hits warn once per variable
+ * (deduped for the lifetime of this reader, i.e. once per process in the CLI).
+ */
+export function createEnvReader(
+  raw: EnvRecord,
+  warn: (msg: string) => void = defaultWarn,
+): (name: string) => string | undefined {
+  const warned = new Set<string>();
+  return (name: string): string | undefined => {
+    const preferred = raw[`CAIRN_${name}`];
+    if (preferred !== undefined) return preferred;
+
+    for (const prefix of LEGACY_PREFIXES) {
+      const key = `${prefix}${name}`;
+      const value = raw[key];
+      if (value !== undefined) {
+        if (!warned.has(key)) {
+          warned.add(key);
+          warn(
+            `[cairn] env ${key} is deprecated — use CAIRN_${name} instead ` +
+              `(old name still works; removal planned in 1–2 releases).`,
+          );
+        }
+        return value;
+      }
+    }
+
+    return raw[name];
+  };
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,6 +5,7 @@ import {
 } from "./schema.js";
 import type { AppConfig, Provider } from "./schema.js";
 import { PROFILES } from "./profiles.js";
+import { createEnvReader } from "./env.js";
 
 export type { AppConfig, ModelsConfig, ModelTier, Provider, LlmProfile, BrowserBackend } from "./schema.js";
 
@@ -14,11 +15,17 @@ type Env = Record<string, string | undefined>;
  * Read and validate configuration from env. Pure function (env is injected for tests).
  * Throws a clear error on an invalid profile/backend or a missing key for a required provider.
  */
-export function loadConfig(env: Env = process.env): AppConfig {
-  const profileResult = LlmProfileSchema.safeParse(env.LLM_PROFILE ?? "anthropic");
+export function loadConfig(
+  env: Env = process.env,
+  opts: { warn?: (msg: string) => void } = {},
+): AppConfig {
+  // Resolve every var via CAIRN_ → LEXBOT_/LEX_ (deprecated) → bare name (C0-06).
+  const read = createEnvReader(env, opts.warn);
+  const llmProfileRaw = read("LLM_PROFILE");
+  const profileResult = LlmProfileSchema.safeParse(llmProfileRaw ?? "anthropic");
   if (!profileResult.success) {
     throw new Error(
-      `Invalid LLM_PROFILE='${env.LLM_PROFILE}'. Allowed: anthropic | openrouter | mixed.`,
+      `Invalid LLM_PROFILE='${llmProfileRaw}'. Allowed: anthropic | openrouter | mixed.`,
     );
   }
   const llmProfile = profileResult.data;
@@ -29,8 +36,8 @@ export function loadConfig(env: Env = process.env): AppConfig {
   if (models.vision) tiers.push(models.vision);
   const providers = new Set<Provider>(tiers.map((t) => t.provider));
 
-  const anthropicApiKey = env.ANTHROPIC_API_KEY;
-  const openrouterApiKey = env.OPENROUTER_API_KEY;
+  const anthropicApiKey = read("ANTHROPIC_API_KEY");
+  const openrouterApiKey = read("OPENROUTER_API_KEY");
   if (providers.has("anthropic") && !anthropicApiKey) {
     throw new Error(
       `Profile '${llmProfile}' uses Anthropic, but ANTHROPIC_API_KEY is not set.`,
@@ -42,22 +49,25 @@ export function loadConfig(env: Env = process.env): AppConfig {
     );
   }
 
-  const backendResult = BrowserBackendSchema.safeParse(env.BROWSER_BACKEND ?? "lib");
+  const browserBackendRaw = read("BROWSER_BACKEND");
+  const backendResult = BrowserBackendSchema.safeParse(browserBackendRaw ?? "lib");
   if (!backendResult.success) {
-    throw new Error(`Invalid BROWSER_BACKEND='${env.BROWSER_BACKEND}'. Allowed: lib | cli.`);
+    throw new Error(`Invalid BROWSER_BACKEND='${browserBackendRaw}'. Allowed: lib | cli.`);
   }
 
-  const langfuseEnabled = Boolean(
-    env.LANGFUSE_BASE_URL && env.LANGFUSE_PUBLIC_KEY && env.LANGFUSE_SECRET_KEY,
-  );
+  const langfuseBaseUrl = read("LANGFUSE_BASE_URL");
+  const langfusePublicKey = read("LANGFUSE_PUBLIC_KEY");
+  const langfuseSecretKey = read("LANGFUSE_SECRET_KEY");
+  const langfuseEnabled = Boolean(langfuseBaseUrl && langfusePublicKey && langfuseSecretKey);
 
-  const maxRepair = env.MAX_REPAIR === undefined ? 2 : Number(env.MAX_REPAIR);
+  const maxRepairRaw = read("MAX_REPAIR");
+  const maxRepair = maxRepairRaw === undefined ? 2 : Number(maxRepairRaw);
   if (!Number.isInteger(maxRepair) || maxRepair < 0) {
-    throw new Error(`Invalid MAX_REPAIR='${env.MAX_REPAIR}'. Must be a non-negative integer.`);
+    throw new Error(`Invalid MAX_REPAIR='${maxRepairRaw}'. Must be a non-negative integer.`);
   }
 
   // Test-case language: default English; env override accepts a name or a code (en/uk/ua).
-  const langRaw = (env.QA_TESTCASE_LANG ?? "English").trim();
+  const langRaw = (read("QA_TESTCASE_LANG") ?? "English").trim();
   const LANG_ALIASES: Record<string, string> = {
     en: "English",
     eng: "English",
@@ -77,11 +87,11 @@ export function loadConfig(env: Env = process.env): AppConfig {
     openrouterApiKey,
     langfuse: {
       enabled: langfuseEnabled,
-      baseUrl: env.LANGFUSE_BASE_URL,
-      publicKey: env.LANGFUSE_PUBLIC_KEY,
-      secretKey: env.LANGFUSE_SECRET_KEY,
+      baseUrl: langfuseBaseUrl,
+      publicKey: langfusePublicKey,
+      secretKey: langfuseSecretKey,
     },
-    browser: { backend: backendResult.data, channel: env.BROWSER_CHANNEL },
+    browser: { backend: backendResult.data, channel: read("BROWSER_CHANNEL") },
     maxRepair,
     testCaseLanguage,
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 /**
  * QA Explorer Bot — public library API (Sprint 6: frozen for embedding).
  *
- * Example: import { runDesign, runAutomate, runExploration } from "@plune-ai/lex-bot";
+ * Example: import { runDesign, runAutomate, runExploration } from "@plune-ai/cairn";
  * Three entry points: explore (everything), design (cases only), automate (code from cases).
  */
 
-export const BOT_NAME = "@plune-ai/lex-bot" as const;
+export const BOT_NAME = "@plune-ai/cairn" as const;
 export const BOT_VERSION = "0.1.0" as const;
 
 // Entry points.

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -1,5 +1,5 @@
 /**
- * TUI entry point. Lazily imported by the CLI dispatch when `lex-bot` runs with
+ * TUI entry point. Lazily imported by the CLI dispatch when `cairn` runs with
  * no arguments in a TTY — this keeps React/Ink out of every non-TUI code path
  * (other CLI commands and library embedders never load them).
  */

--- a/src/tui/screens/launcher-screen.tsx
+++ b/src/tui/screens/launcher-screen.tsx
@@ -35,7 +35,7 @@ export function LauncherScreen() {
   return (
     <Box flexDirection="column">
       <Text color="cyan" bold>
-        lex-bot
+        Cairn
       </Text>
       <Text dimColor>Interactive UI-test generation — pick a command</Text>
       <Box marginTop={1}>

--- a/tests/unit/cli-branding.test.ts
+++ b/tests/unit/cli-branding.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { LEXBOT_CLI_NOTICE } from "../../src/cli/branding.js";
+
+/**
+ * C0-03: `cairn` is the primary command; `lex-bot` stays as a hidden, deprecated
+ * alias that prints a one-line notice before running the same code path.
+ */
+describe("CLI deprecation alias notice (C0-03)", () => {
+  it("names the old command, points at the new one, and flags deprecation + removal", () => {
+    expect(LEXBOT_CLI_NOTICE).toContain("lex-bot");
+    expect(LEXBOT_CLI_NOTICE).toContain("cairn");
+    expect(LEXBOT_CLI_NOTICE.toLowerCase()).toContain("deprecated");
+    expect(LEXBOT_CLI_NOTICE.toLowerCase()).toMatch(/remov|release/);
+  });
+
+  it("is a single line (one-line notice)", () => {
+    expect(LEXBOT_CLI_NOTICE.trimEnd()).not.toContain("\n");
+  });
+});

--- a/tests/unit/config-env.test.ts
+++ b/tests/unit/config-env.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from "vitest";
+import { createEnvReader } from "../../src/config/env.js";
+
+/**
+ * C0-06: env vars move to the CAIRN_ prefix while staying fully backward-compatible.
+ * Resolution order per name: CAIRN_<name> → LEXBOT_<name> → LEX_<name> → <name> (bare/current).
+ * Legacy LEX_/LEXBOT_ forms keep working but emit a one-time deprecation warning.
+ */
+describe("createEnvReader — CAIRN_ prefix with LEX_/LEXBOT_ back-compat (C0-06)", () => {
+  it("prefers CAIRN_<name> over the bare name", () => {
+    const read = createEnvReader({ CAIRN_LLM_PROFILE: "mixed", LLM_PROFILE: "anthropic" });
+    expect(read("LLM_PROFILE")).toBe("mixed");
+  });
+
+  it("falls back to the bare/current name when no prefixed form exists (no warning)", () => {
+    const warn = vi.fn();
+    const read = createEnvReader({ LLM_PROFILE: "openrouter" }, warn);
+    expect(read("LLM_PROFILE")).toBe("openrouter");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to LEXBOT_<name> and warns once, pointing at CAIRN_<name>", () => {
+    const warn = vi.fn();
+    const read = createEnvReader({ LEXBOT_MAX_REPAIR: "3" }, warn);
+    expect(read("MAX_REPAIR")).toBe("3");
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("LEXBOT_MAX_REPAIR");
+    expect(warn.mock.calls[0][0]).toContain("CAIRN_MAX_REPAIR");
+  });
+
+  it("falls back to the older LEX_<name> form and warns", () => {
+    const warn = vi.fn();
+    const read = createEnvReader({ LEX_MAX_REPAIR: "5" }, warn);
+    expect(read("MAX_REPAIR")).toBe("5");
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("LEX_MAX_REPAIR");
+  });
+
+  it("CAIRN_ wins over legacy LEX_/LEXBOT_ and does not warn", () => {
+    const warn = vi.fn();
+    const read = createEnvReader(
+      { CAIRN_LLM_PROFILE: "mixed", LEXBOT_LLM_PROFILE: "anthropic", LEX_LLM_PROFILE: "openrouter" },
+      warn,
+    );
+    expect(read("LLM_PROFILE")).toBe("mixed");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("precedence: LEXBOT_ over LEX_", () => {
+    const read = createEnvReader({ LEXBOT_LLM_PROFILE: "mixed", LEX_LLM_PROFILE: "openrouter" }, vi.fn());
+    expect(read("LLM_PROFILE")).toBe("mixed");
+  });
+
+  it("warns only once per legacy variable (deduped per reader/process)", () => {
+    const warn = vi.fn();
+    const read = createEnvReader({ LEXBOT_MAX_REPAIR: "3" }, warn);
+    read("MAX_REPAIR");
+    read("MAX_REPAIR");
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns undefined when nothing is set for the name", () => {
+    const read = createEnvReader({});
+    expect(read("NOPE")).toBeUndefined();
+  });
+});

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { loadConfig } from "../../src/config/index.js";
 
 /** Base valid env for the anthropic profile. */
@@ -70,6 +70,34 @@ describe("loadConfig — Langfuse (ADR-0006, self-hosted)", () => {
     });
     expect(cfg.langfuse.enabled).toBe(true);
     expect(cfg.langfuse.baseUrl).toBe("https://lf.my-server.example");
+  });
+});
+
+describe("loadConfig — CAIRN_ prefix + legacy env back-compat (C0-06)", () => {
+  it("reads the new CAIRN_LLM_PROFILE", () => {
+    const cfg = loadConfig({ ...baseEnv, CAIRN_LLM_PROFILE: "mixed" });
+    expect(cfg.llmProfile).toBe("mixed");
+  });
+
+  it("CAIRN_-prefixed provider keys satisfy validation", () => {
+    const cfg = loadConfig({ CAIRN_ANTHROPIC_API_KEY: "x", CAIRN_OPENROUTER_API_KEY: "y" });
+    expect(cfg.llmProfile).toBe("anthropic");
+    expect(cfg.anthropicApiKey).toBe("x");
+  });
+
+  it("legacy LEXBOT_LLM_PROFILE still works and warns toward CAIRN_LLM_PROFILE", () => {
+    const warn = vi.fn();
+    const cfg = loadConfig({ ...baseEnv, LEXBOT_LLM_PROFILE: "openrouter" }, { warn });
+    expect(cfg.llmProfile).toBe("openrouter");
+    expect(warn).toHaveBeenCalled();
+    expect(warn.mock.calls[0][0]).toContain("CAIRN_LLM_PROFILE");
+  });
+
+  it("current bare names keep working with no deprecation warning", () => {
+    const warn = vi.fn();
+    const cfg = loadConfig({ ...baseEnv, LLM_PROFILE: "mixed" }, { warn });
+    expect(cfg.llmProfile).toBe("mixed");
+    expect(warn).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/smoke.test.ts
+++ b/tests/unit/smoke.test.ts
@@ -3,7 +3,7 @@ import { BOT_NAME, BOT_VERSION } from "../../src/index.js";
 
 describe("smoke (Sprint 0)", () => {
   it("exports the package name", () => {
-    expect(BOT_NAME).toBe("@plune-ai/lex-bot");
+    expect(BOT_NAME).toBe("@plune-ai/cairn");
   });
 
   it("exports the version in semver format", () => {

--- a/tests/unit/tui/app-smoke.test.tsx
+++ b/tests/unit/tui/app-smoke.test.tsx
@@ -8,9 +8,9 @@ import { App } from "../../../src/tui/App.js";
  * this fails first.
  */
 describe("TUI App skeleton", () => {
-  it("renders the lex-bot banner", () => {
+  it("renders the cairn banner", () => {
     const { lastFrame, unmount } = render(<App />);
-    expect(lastFrame()).toContain("lex-bot");
+    expect(lastFrame()).toContain("Cairn");
     unmount();
   });
 });


### PR DESCRIPTION
Code-side of epic **C0 — Rename Lex-Bot → Cairn** (#9). Pure rename + backward compatibility — **no runtime, pipeline, or agent-logic changes**.

## What changed
- **C0-02 `package.json`** — `name` → `@plune-ai/cairn`; `bin` → `{ "cairn": "dist/cli/index.js", "lex-bot": "dist/cli/lex-bot.js" }`; `repository`/`homepage`/`bugs` → `plune-ai/cairn`; keywords refreshed.
- **C0-03 CLI** — `cairn` is the primary command. `lex-bot` stays a **hidden, deprecated alias** that prints a one-line notice to **stderr**, then runs the same code path (shared exported `runCli()` + an `import.meta.url` "invoked directly" guard; shim = `src/cli/lex-bot.ts`). Help/usage/examples → `cairn`.
- **C0-06 env** — new `CAIRN_` prefix. Resolution per name: `CAIRN_<X>` → `LEXBOT_<X>` → `LEX_<X>` → `<X>` (bare). Legacy `LEX_`/`LEXBOT_` still work, with a **one-time** deprecation warning. `README` + `.env.example` updated.
- **C0-04 README** — hero rewrite (name + tagline), every `@plune-ai/lex-bot` → `@plune-ai/cairn`, every `lex-bot` CLI example → `cairn`, asciinema placeholder marker + badge stub.
- **C0-05 ADR** — `docs/adr/0010-rename-to-cairn.md` (anti `-bot` me-too vs Explorbot/ApiBot/DocBot; umbrella naming; `Nib` ruled out — live npm + Apple `.nib`; `Cairn` = dormant collision + trail-of-markers metaphor; **Cairn = generation layer / Plune = record-management-eval layer**).
- **Demo** — `scripts/demo.sh` (scripted, non-interactive, **no secrets/network**) + `docs/demo/README.md` (asciinema record/playback/embed).

## Backward compatibility
- `lex-bot <cmd>` still works — deprecation notice on **stderr**, payload on **stdout** (pipes unaffected).
- Old `@plune-ai/lex-bot` package stays published, never deleted (C0-07).
- Old env vars work (bare + `LEX_`/`LEXBOT_`); `CAIRN_` preferred.

## Verification
`npm run build` ✓ · `npm test` ✓ **155 passed** · `npm run lint` ✓. Ran both bins: `cairn --version`/`--help` and `lex-bot --version` (prints notice → identical output).

<details><summary><code>npm pack --dry-run</code></summary>

```
npm notice name: @plune-ai/cairn
npm notice version: 0.2.1
npm notice filename: plune-ai-cairn-0.2.1.tgz
npm notice 15.5kB dist/cli/index.js
npm notice 467B  dist/cli/lex-bot.js
npm notice total files: 323

bin: { "cairn": "dist/cli/index.js", "lex-bot": "dist/cli/lex-bot.js" }
```
</details>

## Checklist
- [x] C0-02 `package.json` (name / bin / URLs / keywords)
- [x] C0-03 CLI rename + hidden deprecated `lex-bot` alias (same code path)
- [x] C0-06 env `CAIRN_` prefix + `LEX_`/`LEXBOT_` back-compat warning
- [x] C0-04 README hero + tagline + name replacements + asciinema placeholder
- [x] C0-05 ADR-0010 rename rationale + Cairn/Plune boundary
- [x] Demo asciinema scaffold (script + docs + README marker)
- [x] `build` / `test` / `lint` green; `npm pack --dry-run` → `@plune-ai/cairn` + `cairn` bin

## Out of scope — remain **MANUAL** (maintainer)
- **#11** — rename the GitHub repo `plune-ai/lex-bot` → `plune-ai/cairn`
- **#17** — `npm publish @plune-ai/cairn` + `npm deprecate @plune-ai/lex-bot` (never delete the old)
- **#18** — repo metadata (description, topics, social-preview)

## Notes / deltas (repo is source of truth)
- `bin` keeps a `lex-bot` entry **beyond the literal C0-02 text** — required so the old CLI name keeps working per the back-compat constraint; it points at a thin deprecation shim (`dist/cli/lex-bot.js`).
- `src/browser/backends/playwright-cli.ts` default session name kept as `"lex-bot"` — it's a **runtime arg** to `@playwright/cli`, so renaming it would be a behavior change (excluded by the "no runtime change" constraint).
- `.github/workflows/publish.yml` package-name strings bumped to `@plune-ai/cairn` so the (manual) first publish targets the right package.

Closes #12, #13, #14, #15, #16. Refs #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
