### PR TITLE
docs: README launch badges (CI/npm/node/license) → @plune-ai/cairn

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 > **Cairn — an AI that walks your system and leaves a trail of tests: UI, API, unit, docs.**
 
+[![CI](https://github.com/plune-ai/cairn/actions/workflows/ci.yml/badge.svg)](https://github.com/plune-ai/cairn/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/@plune-ai/cairn)](https://www.npmjs.com/package/@plune-ai/cairn)
+[![node](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](package.json)
+[![license](https://img.shields.io/badge/license-GPL--3.0-blue)](LICENSE)
+
 <!-- asciinema: docs/demo/cairn.cast (record before launch — see docs/demo/README.md) -->
 [![Cairn demo](https://asciinema.org/a/REPLACE_ME.svg)](https://asciinema.org/a/REPLACE_ME)
 


### PR DESCRIPTION
Follow-up to #28. Adds **CI · npm · node · license** badges to the README hero, all pointing at the renamed path/package.

- CI: `plune-ai/cairn/actions/workflows/ci.yml` — live once the repo rename (#11) lands.
- npm version: `@plune-ai/cairn` — live once the first publish (#17) lands.
- node (>=20) + license (GPL-3.0): static, live now.

**Audit done alongside** (your checklist):
- `git grep lex-bot|lexbot` → only **intentional** residue remains: deprecated CLI alias (`src/cli/lex-bot.ts`, bin, branding), env fallback `LEX_`/`LEXBOT_` (`src/config/env.ts`), and historical ADRs/plans.
- `package.json`: name `@plune-ai/cairn`, `bin.cairn`, repository/homepage/bugs → `plune-ai/cairn` ✓.
- `CLAUDE.md` (gitignored, local only): `lex-bot`+`qa-bot` → `cairn`, repo line → `plune-ai/cairn (main)` ✓ (not in this diff — it's ignored).
- No tracked file carries `qa-bot`.
- CI workflows (`ci.yml`/`publish.yml`) use `actions/checkout` with **no hardcoded repo path** → rename-safe; no in-repo deploy hook clones the old path.

Refs #9, #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)