### PR TITLE
fix: cairn --version reads from package.json (was stale 0.1.0)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,15 @@
  * Example: import { runDesign, runAutomate, runExploration } from "@plune-ai/cairn";
  * Three entry points: explore (everything), design (cases only), automate (code from cases).
  */
+import { readFileSync } from "node:fs";
+
+const pkg = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as { version: string };
 
 export const BOT_NAME = "@plune-ai/cairn" as const;
-export const BOT_VERSION = "0.1.0" as const;
+/** Read from package.json at load time — single source of truth, no manual drift. */
+export const BOT_VERSION: string = pkg.version;
 
 // Entry points.
 export { runExploration, runDesign, runAutomate, buildExploreGraph, ExploreState } from "./agent/index.js";

--- a/tests/unit/smoke.test.ts
+++ b/tests/unit/smoke.test.ts
@@ -1,12 +1,18 @@
+import { readFileSync } from "node:fs";
 import { describe, it, expect } from "vitest";
 import { BOT_NAME, BOT_VERSION } from "../../src/index.js";
+
+const pkg = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8")) as {
+  version: string;
+};
 
 describe("smoke (Sprint 0)", () => {
   it("exports the package name", () => {
     expect(BOT_NAME).toBe("@plune-ai/cairn");
   });
 
-  it("exports the version in semver format", () => {
+  it("exports the version from package.json (single source of truth — no manual drift)", () => {
     expect(BOT_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(BOT_VERSION).toBe(pkg.version);
   });
 });


### PR DESCRIPTION
Small launch-readiness fix found during the rename audit.

`BOT_VERSION` in `src/index.ts` was a hardcoded `"0.1.0"` while `package.json` is `0.2.1` — so `cairn --version` printed the wrong version. Now read from package.json at load time (single source of truth; resolves from src/dist/installed-package alike).

**TDD:** smoke test now asserts `BOT_VERSION === package.json.version` (was: format-only). RED (0.1.0≠0.2.1) → GREEN.

**Verified:** `npm run build` ✓ · 155 tests ✓ · lint ✓ · `node dist/cli/index.js --version` → `0.2.1`.

Refs #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)