### PR TITLE
L1-01 — per-role model routing (worker/reasoner) + per-run cost/tokens

### DIFF
--- a/docs/adr/0011-per-role-model-routing.md
+++ b/docs/adr/0011-per-role-model-routing.md
@@ -1,0 +1,59 @@
+# ADR-0011: Per-role model routing (worker/reasoner) + per-run cost/token reporting
+
+- **Status:** Accepted · **Date:** 2026-06-13 · **Issue:** [L1-01 (#6)](https://github.com/plune-ai/cairn/issues/6)
+- **Decision in code:** `src/llm/routing.ts`, `src/llm/cost.ts`, `src/config/{schema,profiles,index}.ts`, wiring in `src/agent/index.ts`
+
+## Context
+
+Model selection was already **per-node**, but keyed by a 4-**tier** map (`ModelsConfig = { reasoning, bulk, judge, vision }`) selected wholesale by `LLM_PROFILE` (ADR-0002). Two gaps:
+
+1. **No named cost intent.** Users want to run Cairn *cheaply at volume* (a cheap/fast model for mechanical LLM steps) OR *at Claude quality* (a strong model for judgment steps) — their choice. Tiers don't express that intent: the mechanical "worker" work spans two tiers (`vision` for page analysis, `bulk` for code generation), and the judgment work spans `reasoning` (case design) plus the Pilot verdict.
+2. **No cost/token visibility.** `CallBudget` counts *calls* as a guardrail; `structuredInvoker` discarded `withStructuredOutput().invoke()` usage; `report.ts` had no cost fields. There was no way to see what a run actually cost, per anything.
+
+The brief's word **"judge"** for the strong role clashes with the existing config tier **`judge`**, which is the *cheap* LLM-as-judge scorer (Haiku/Qwen) — the opposite cost intent.
+
+## Decision
+
+A **thin named-role layer over the existing tier map**, plus per-role cost/token capture. Node logic and the graph are unchanged.
+
+### 1. Roles
+
+Two routable roles, named to avoid the `judge` clash:
+
+| Role | Steps | Default tier (no routing) |
+|---|---|---|
+| `worker` | identifyElements (vision), generateCode (bulk), repair (bulk) | `vision ?? reasoning`, `bulk`, `bulk` |
+| `reasoner` | designTestCases, **Pilot verdict** | `reasoning`, `reasoning` |
+
+A role **does not own a tier** — it resolves to one: `resolveRoleTier(role, fallbackTier, cfg.roles) = cfg.roles[role] ?? fallbackTier`. With no routing config, every role resolves to exactly today's tier ⇒ backward-compatible by construction.
+
+The cheap LLM-as-judge scorer (`judgeTestCases`, `judgeChecklistCoverage`) keeps the `judge` tier and is **NOT routable** — it is metered-only, under a `judge` bucket, so totals stay honest.
+
+### 2. Config / env override (additive over `LLM_PROFILE`)
+
+- `LLM_ROUTING=<preset>` selects a named **routing preset**. Built-in: **`volume`** = `worker`→cheap OpenRouter (`deepseek/deepseek-chat`) + `reasoner`→Anthropic (`claude-opus-4-8`).
+- `CAIRN_ROLE_WORKER` / `CAIRN_ROLE_REASONER` = `provider:model` give explicit per-role overrides (which win over a preset).
+- `LLM_PROFILE` still selects the tier map unchanged; routing layers on top (`cfg.roles?`). Unknown preset / unknown role → **warn + fall back** to the tier default. A routed role with a missing provider key → error naming **role + provider**.
+- CLI: `--routing <preset>` on `explore` / `design` / `automate`.
+
+### 3. Per-role cost + tokens (the new plumbing)
+
+- `meteredInvoker` reads usage off the LangChain response via `withStructuredOutput(schema, { includeRaw: true })` → `usage_metadata` (fallback `response_metadata.usage` / `tokenUsage`); never throws.
+- A `CostLedger` (sibling of `CallBudget`, one per run, owned by `RoleRouter`) attributes usage to the role, prices it, and renders `perRole` + totals into `report.md`, `report.json`, the CLI summary, and the public `ExploreResult/DesignResult/AutomateResult.cost`.
+- Pricing: Anthropic list prices are authoritative; OpenRouter prices are approximate/movable (per ADR-0002) — any model absent from the table yields a **null cost** (tokens still reported), never a crash.
+
+## Consequences
+
+- (+) Users get the Explorbot-style cost play (`LLM_ROUTING=volume`) or all-Claude quality (`anthropic` profile) without touching node logic — routing is one resolution step at graph-build time.
+- (+) Honest per-run cost/token reporting, per role, everywhere a run is summarized.
+- (+) Fully backward-compatible: no routing config ⇒ identical to today; `LLM_PROFILE` untouched.
+- (−) **Behavior change:** the Pilot verdict now runs on `reasoner` (the strong model) instead of the cheap `judge` tier — intended ("smart judge"), but it raises Pilot cost on the default profile. Flagged in the PR.
+- (−) For `volume`, the `worker` model is text-only (`deepseek/deepseek-chat`), so identifyElements falls back to aria-only (ADR-0002 vision-optional) — an accepted cost/vision trade-off for the cheap preset.
+- (−) OpenRouter cost is an estimate until the price table is tuned (ADR-0002); a missing price shows tokens with `n/a` cost.
+
+## Rejected alternatives
+
+- **Reuse the config tier `judge` for the strong role** — opposite cost intent (cheap scorer); guaranteed confusion. Used distinct names `worker`/`reasoner` instead.
+- **Make `volume` a new `LLM_PROFILE`** — a profile is a *tier* map; `volume` is *role* intent, and lives orthogonally to the profile so it composes with any tier map (incl. the cheap `judge` scorer staying on the profile).
+- **Route `observe`/`ground`** — they make no LLM calls; routing there is a no-op.
+- **Track cost in Langfuse only** — Langfuse is self-hosted and optional; the run summary must work offline, so the ledger is SDK-side.

--- a/docs/superpowers/plans/2026-06-13-l1-01-role-routing.md
+++ b/docs/superpowers/plans/2026-06-13-l1-01-role-routing.md
@@ -1,0 +1,646 @@
+# L1-01 — Per-Role Model Routing + Per-Run Cost/Token Reporting — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a thin named-role layer (`worker`/`reasoner`) over the existing 4-tier `makeModel(tier)` map, plus per-role cost+token reporting captured from each LangChain response — backward-compatible with `LLM_PROFILE`.
+
+**Architecture:** Roles resolve to a tier (override `cfg.roles[role]` ?? the profile/tier default). A `RoleRouter` (sibling to `CallBudget`, one per run) builds per-step metered invokers; a `CostLedger` accumulates usage→cost per role. Node logic and the graph are unchanged — nodes still receive a `StructuredInvoke`. Pilot verdict moves from the cheap `judge` tier to `reasoner` (intended behavior change). A `volume` routing preset routes `worker`→cheap OpenRouter + `reasoner`→Anthropic.
+
+**Tech Stack:** Node 20+, TypeScript strict (NodeNext, `noUncheckedIndexedAccess`), LangChain (`@langchain/{anthropic,openai,core}`), zod 4, vitest. NOT the Vercel AI SDK.
+
+---
+
+## Role → tier mapping (the contract)
+
+| Step | Calls LLM? | Role | Default tier (no routing) | `anthropic` model |
+|---|---|---|---|---|
+| observe (capture) | no | — | — | — |
+| identifyElements (analyzePage) | yes | `worker` | `vision ?? reasoning` | Haiku |
+| verifyLocators / exploreStates / probeInteractions | no | — | — | — |
+| designTestCases | yes | `reasoner` | `reasoning` | Opus |
+| generateCode | yes | `worker` | `bulk` | Sonnet |
+| validate | no | — | — | — |
+| repair (regenerate) | yes | `worker` | `bulk` | Sonnet |
+| judgeTestCases / judgeChecklistCoverage | yes | `judge`* | `judge` (unchanged) | Haiku |
+| pilotReview (Pilot verdict) | yes | `reasoner` | `reasoning` **(was `judge`)** | Opus **(was Haiku)** |
+
+\* `judge` is metered-only (cost visibility) — it is the cheap LLM-as-judge scorer and stays on `cfg.models.judge`; it is NOT a routable role. Only `worker` and `reasoner` accept overrides/presets. This avoids the name clash called out in issue #6 delta #2.
+
+**Default pricing (USD / 1M tokens), source = claude-api skill:** Opus 4.8 `5/25`, Sonnet 4.6 `3/15`, Haiku 4.5 `1/5`. OpenRouter models: approximate, movable (ADR-0002); any model absent from the table → cost `null` (tokens still counted).
+
+---
+
+### Task 1: Config schema — Role types + RolesConfig + AppConfig.roles
+
+**Files:**
+- Modify: `src/config/schema.ts`
+
+- [ ] **Step 1: Add role types + routing config to schema.ts** (after `ModelsConfigSchema`)
+
+```ts
+/** Named role over the tier map (L1-01). Only these two are routable. */
+export const RoleSchema = z.enum(["worker", "reasoner"]);
+export type Role = z.infer<typeof RoleSchema>;
+
+/** A role override reuses the tier shape (provider + model + vision + temperature). */
+export type RoleModel = ModelTier;
+
+/** Optional per-role routing overrides, layered over `models` (the tier map). */
+export type RolesConfig = Partial<Record<Role, RoleModel>>;
+```
+
+- [ ] **Step 2: Add `roles?` to `AppConfig`** (optional, additive — backward-compatible)
+
+```ts
+  /** L1-01 per-role routing overrides (optional; layered over `models`). */
+  roles?: RolesConfig;
+```
+
+- [ ] **Step 3: build** — `npm run build` passes (no callers yet).
+
+---
+
+### Task 2: Routing presets (volume)
+
+**Files:**
+- Modify: `src/config/profiles.ts`
+
+- [ ] **Step 1: Add `ROUTING_PRESETS` with `volume`** (cheap OpenRouter worker + Anthropic reasoner)
+
+```ts
+import type { LlmProfile, ModelsConfig, RolesConfig } from "./schema.js";
+
+/** Named role-routing presets (L1-01). `volume` = cheap worker + smart reasoner (Explorbot-style). */
+export const ROUTING_PRESETS: Record<string, RolesConfig> = {
+  volume: {
+    // worker spans identifyElements(vision) + generateCode/repair(bulk) → one cheap text model.
+    // supportsVision:false → identifyElements falls back to aria-only (ADR-0002 vision-optional).
+    worker: { provider: "openrouter", model: "deepseek/deepseek-chat", supportsVision: false },
+    // reasoner = designTestCases + Pilot verdict → quality model.
+    reasoner: { provider: "anthropic", model: "claude-opus-4-8", supportsVision: false },
+  },
+};
+```
+
+---
+
+### Task 3: Cost module — pricing, usage extraction, ledger, report types
+
+**Files:**
+- Create: `src/llm/cost.ts`
+- Test: `tests/unit/cost.test.ts`
+- Modify: `vitest.config.ts` (add `src/llm/cost.ts` to coverage `include`)
+
+- [ ] **Step 1: Write the failing test** `tests/unit/cost.test.ts`
+
+```ts
+import { describe, it, expect } from "vitest";
+import { CostLedger, extractUsage, priceFor, DEFAULT_PRICING } from "../../src/llm/cost.js";
+
+const PRICES = { "m-cheap": { inputPer1M: 1, outputPer1M: 2 }, "m-pricey": { inputPer1M: 10, outputPer1M: 30 } };
+
+describe("priceFor", () => {
+  it("known model → price; unknown → undefined", () => {
+    expect(priceFor("m-cheap", PRICES)).toEqual({ inputPer1M: 1, outputPer1M: 2 });
+    expect(priceFor("nope", PRICES)).toBeUndefined();
+  });
+  it("default table prices the Anthropic profile models", () => {
+    expect(priceFor("claude-opus-4-8", DEFAULT_PRICING)).toEqual({ inputPer1M: 5, outputPer1M: 25 });
+  });
+});
+
+describe("extractUsage", () => {
+  it("reads usage_metadata", () => {
+    expect(extractUsage({ usage_metadata: { input_tokens: 100, output_tokens: 40 } })).toEqual({ inputTokens: 100, outputTokens: 40 });
+  });
+  it("falls back to response_metadata.usage (OpenAI shape)", () => {
+    expect(extractUsage({ response_metadata: { usage: { prompt_tokens: 7, completion_tokens: 3 } } })).toEqual({ inputTokens: 7, outputTokens: 3 });
+  });
+  it("missing usage → zeros (never throws)", () => {
+    expect(extractUsage({})).toEqual({ inputTokens: 0, outputTokens: 0 });
+  });
+});
+
+describe("CostLedger — per-role attribution sums correctly", () => {
+  it("sums tokens + cost per role across calls", () => {
+    const led = new CostLedger(PRICES);
+    led.record("worker", "m-cheap", { inputTokens: 1_000_000, outputTokens: 500_000 }); // 1*1 + 0.5*2 = 2
+    led.record("worker", "m-cheap", { inputTokens: 1_000_000, outputTokens: 0 });        // +1 = 3
+    led.record("reasoner", "m-pricey", { inputTokens: 100_000, outputTokens: 100_000 }); // 0.1*10 + 0.1*30 = 4
+    const rep = led.report();
+    const worker = rep.perRole.find((r) => r.role === "worker")!;
+    expect(worker.calls).toBe(2);
+    expect(worker.inputTokens).toBe(2_000_000);
+    expect(worker.outputTokens).toBe(500_000);
+    expect(worker.costUsd).toBeCloseTo(3, 6);
+    const reasoner = rep.perRole.find((r) => r.role === "reasoner")!;
+    expect(reasoner.costUsd).toBeCloseTo(4, 6);
+    expect(rep.totalTokens).toBe(2_700_000);
+    expect(rep.totalCostUsd).toBeCloseTo(7, 6);
+  });
+  it("unknown model price → role costUsd null + total null, tokens still counted", () => {
+    const led = new CostLedger(PRICES);
+    led.record("worker", "mystery/model", { inputTokens: 1000, outputTokens: 1000 });
+    const rep = led.report();
+    const worker = rep.perRole.find((r) => r.role === "worker")!;
+    expect(worker.costUsd).toBeNull();
+    expect(worker.inputTokens).toBe(1000);
+    expect(rep.totalCostUsd).toBeNull();
+    expect(rep.totalTokens).toBe(2000);
+  });
+});
+```
+
+- [ ] **Step 2: Run it — expect FAIL** (`cost.ts` missing): `npm test -- cost`
+
+- [ ] **Step 3: Implement** `src/llm/cost.ts`
+
+```ts
+/** Per-role cost + token accounting (L1-01). Pure — no SDK, no network. */
+
+export interface TokenUsage { inputTokens: number; outputTokens: number; }
+export interface ModelPrice { inputPer1M: number; outputPer1M: number; }
+
+/**
+ * Default price table (USD per 1M tokens). Anthropic prices are authoritative
+ * (claude-api skill, 2026-06). OpenRouter prices are APPROXIMATE and move
+ * (ADR-0002) — any model absent here yields a null (unknown) cost; tokens are
+ * still counted. Override by passing a table to CostLedger.
+ */
+export const DEFAULT_PRICING: Record<string, ModelPrice> = {
+  "claude-opus-4-8": { inputPer1M: 5, outputPer1M: 25 },
+  "claude-sonnet-4-6": { inputPer1M: 3, outputPer1M: 15 },
+  "claude-haiku-4-5": { inputPer1M: 1, outputPer1M: 5 },
+  // OpenRouter — approximate, movable (ADR-0002).
+  "deepseek/deepseek-chat": { inputPer1M: 0.28, outputPer1M: 0.88 },
+  "deepseek/deepseek-r1": { inputPer1M: 0.55, outputPer1M: 2.19 },
+  "qwen/qwen-2.5-72b-instruct": { inputPer1M: 0.35, outputPer1M: 0.4 },
+  "qwen/qwen-2-vl-72b-instruct": { inputPer1M: 0.4, outputPer1M: 0.4 },
+};
+
+export function priceFor(model: string, table: Record<string, ModelPrice> = DEFAULT_PRICING): ModelPrice | undefined {
+  return table[model];
+}
+
+/** Minimal structural view of a LangChain response carrying usage. */
+interface UsageCarrier {
+  usage_metadata?: { input_tokens?: number; output_tokens?: number };
+  response_metadata?: {
+    usage?: { input_tokens?: number; output_tokens?: number; prompt_tokens?: number; completion_tokens?: number };
+    tokenUsage?: { promptTokens?: number; completionTokens?: number };
+  };
+}
+
+/** Read token usage off a LangChain message; never throws (missing → zeros). */
+export function extractUsage(raw: unknown): TokenUsage {
+  const m = (raw ?? {}) as UsageCarrier;
+  const um = m.usage_metadata;
+  if (um && (um.input_tokens !== undefined || um.output_tokens !== undefined)) {
+    return { inputTokens: um.input_tokens ?? 0, outputTokens: um.output_tokens ?? 0 };
+  }
+  const u = m.response_metadata?.usage;
+  if (u) {
+    return {
+      inputTokens: u.input_tokens ?? u.prompt_tokens ?? 0,
+      outputTokens: u.output_tokens ?? u.completion_tokens ?? 0,
+    };
+  }
+  const t = m.response_metadata?.tokenUsage;
+  if (t) return { inputTokens: t.promptTokens ?? 0, outputTokens: t.completionTokens ?? 0 };
+  return { inputTokens: 0, outputTokens: 0 };
+}
+
+export interface RoleCost {
+  role: string;
+  models: string[];
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  costUsd: number | null; // null if any contributing model has no price
+}
+export interface CostReport {
+  perRole: RoleCost[];
+  totalTokens: number;
+  totalCostUsd: number | null;
+}
+
+interface Row { models: Set<string>; calls: number; in: number; out: number; cost: number; costKnown: boolean; }
+
+/** Accumulates usage per role and prices it. Sibling to CallBudget; one per run. */
+export class CostLedger {
+  private readonly rows = new Map<string, Row>();
+  constructor(private readonly pricing: Record<string, ModelPrice> = DEFAULT_PRICING) {}
+
+  record(role: string, model: string, usage: TokenUsage): void {
+    const row = this.rows.get(role) ?? { models: new Set(), calls: 0, in: 0, out: 0, cost: 0, costKnown: true };
+    row.calls += 1;
+    row.in += usage.inputTokens;
+    row.out += usage.outputTokens;
+    row.models.add(model);
+    const p = this.pricing[model];
+    if (p) row.cost += (usage.inputTokens / 1e6) * p.inputPer1M + (usage.outputTokens / 1e6) * p.outputPer1M;
+    else row.costKnown = false;
+    this.rows.set(role, row);
+  }
+
+  report(): CostReport {
+    const order = ["worker", "reasoner", "judge"];
+    const roles = [...this.rows.keys()].sort((a, b) => {
+      const ia = order.indexOf(a), ib = order.indexOf(b);
+      return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib);
+    });
+    const perRole: RoleCost[] = roles.map((role) => {
+      const r = this.rows.get(role)!;
+      return {
+        role,
+        models: [...r.models],
+        calls: r.calls,
+        inputTokens: r.in,
+        outputTokens: r.out,
+        totalTokens: r.in + r.out,
+        costUsd: r.costKnown ? Number(r.cost.toFixed(6)) : null,
+      };
+    });
+    const totalTokens = perRole.reduce((s, r) => s + r.totalTokens, 0);
+    const anyUnknown = perRole.some((r) => r.costUsd === null);
+    const totalCostUsd = anyUnknown ? null : Number(perRole.reduce((s, r) => s + (r.costUsd ?? 0), 0).toFixed(6));
+    return { perRole, totalTokens, totalCostUsd };
+  }
+}
+```
+
+- [ ] **Step 4: Add to coverage gate** — in `vitest.config.ts` `coverage.include`, add `"src/llm/cost.ts",`.
+
+- [ ] **Step 5: Run — expect PASS**: `npm test -- cost`
+
+---
+
+### Task 4: Metered invoker (captures usage off the LangChain response)
+
+**Files:**
+- Modify: `src/llm/structured.ts` (gated — must stay ≥80%)
+- Test: `tests/unit/routing.test.ts` (shared with Task 5)
+
+- [ ] **Step 1: Write the failing test** (in `tests/unit/routing.test.ts`)
+
+```ts
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { meteredInvoker } from "../../src/llm/structured.js";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+
+function fakeModel(parsed: unknown, raw: unknown): BaseChatModel {
+  return { withStructuredOutput: () => ({ invoke: async () => ({ raw, parsed }) }) } as unknown as BaseChatModel;
+}
+
+describe("meteredInvoker", () => {
+  it("returns parsed result AND reports usage to the callback", async () => {
+    const seen: Array<{ usage: unknown; model: string }> = [];
+    const model = fakeModel({ ok: 1 }, { usage_metadata: { input_tokens: 12, output_tokens: 5 } });
+    const invoke = meteredInvoker(model, (usage, m) => seen.push({ usage, model: m }), "deepseek/deepseek-chat");
+    const out = await invoke(z.object({ ok: z.number() }), []);
+    expect(out).toEqual({ ok: 1 });
+    expect(seen).toEqual([{ usage: { inputTokens: 12, outputTokens: 5 }, model: "deepseek/deepseek-chat" }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**: `npm test -- routing`
+
+- [ ] **Step 3: Implement** in `src/llm/structured.ts` (add import + function; keep existing exports)
+
+```ts
+import { extractUsage, type TokenUsage } from "./cost.js";
+// ...existing imports & code stay...
+
+/**
+ * Like structuredInvoker, but captures usage off the raw LangChain response
+ * (via withStructuredOutput includeRaw) and reports it to `onUsage` (L1-01).
+ * Node logic is unchanged — it still receives the parsed result.
+ */
+export function meteredInvoker(
+  model: BaseChatModel,
+  onUsage: (usage: TokenUsage, model: string) => void,
+  modelId: string,
+): StructuredInvoke {
+  return async <T>(schema: ZodType<T>, messages: BaseMessageLike[]): Promise<T> => {
+    const structured = model.withStructuredOutput(schema, { includeRaw: true });
+    const res = (await structured.invoke(messages)) as { raw: unknown; parsed: T };
+    try {
+      onUsage(extractUsage(res.raw), modelId);
+    } catch {
+      // metering must never break the call
+    }
+    return res.parsed;
+  };
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**: `npm test -- routing`
+
+---
+
+### Task 5: Routing layer — resolveRoleTier + RoleRouter
+
+**Files:**
+- Create: `src/llm/routing.ts`
+- Test: `tests/unit/routing.test.ts` (extend)
+
+- [ ] **Step 1: Add failing tests** (append to `tests/unit/routing.test.ts`)
+
+```ts
+import { resolveRoleTier, RoleRouter, KNOWN_ROLES } from "../../src/llm/routing.js";
+import type { ModelTier } from "../../src/config/index.js";
+
+const vision: ModelTier = { provider: "anthropic", model: "claude-haiku-4-5", supportsVision: true };
+const bulk: ModelTier = { provider: "anthropic", model: "claude-sonnet-4-6", supportsVision: false };
+
+describe("resolveRoleTier — override ?? fallback (backward-compat)", () => {
+  it("no routing → returns the fallback tier unchanged", () => {
+    expect(resolveRoleTier("worker", vision, undefined)).toBe(vision);
+  });
+  it("override present → returns the override tier", () => {
+    const ovr: ModelTier = { provider: "openrouter", model: "deepseek/deepseek-chat", supportsVision: false };
+    expect(resolveRoleTier("worker", vision, { worker: ovr })).toBe(ovr);
+  });
+  it("KNOWN_ROLES is worker + reasoner only", () => {
+    expect([...KNOWN_ROLES]).toEqual(["worker", "reasoner"]);
+  });
+});
+
+describe("RoleRouter — meters per role, falls back per tier", () => {
+  it("invoke meters usage under the role; tierFor resolves override", async () => {
+    const keys = { anthropicApiKey: "k" };
+    const fakeModel = () => ({ withStructuredOutput: () => ({ invoke: async () => ({ raw: { usage_metadata: { input_tokens: 4, output_tokens: 2 } }, parsed: { ok: 1 } }) }) });
+    const cfg = { models: { reasoning: bulk, bulk, judge: bulk, vision }, roles: { worker: { provider: "openrouter", model: "x", supportsVision: false } } } as never;
+    const router = new RoleRouter(cfg, keys, { charge() {} } as never, undefined, fakeModel as never);
+    expect(router.tierFor("worker", vision).model).toBe("x");
+    const inv = router.invoke("reasoner", bulk);
+    await inv((await import("zod")).z.object({ ok: (await import("zod")).z.number() }), []);
+    const rep = router.ledger.report();
+    expect(rep.perRole.find((r) => r.role === "reasoner")?.inputTokens).toBe(4);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**: `npm test -- routing`
+
+- [ ] **Step 3: Implement** `src/llm/routing.ts`
+
+```ts
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import type { AppConfig, ModelTier, RolesConfig } from "../config/index.js";
+import { makeModel, type ProviderKeys } from "./factory.js";
+import { meteredInvoker, cappedInvoke, retryInvoke, type CallBudget, type StructuredInvoke } from "./structured.js";
+import { CostLedger, type ModelPrice } from "./cost.js";
+
+/** Routable roles (L1-01). `judge` is metered-only, NOT routable (cheap scorer stays put). */
+export const KNOWN_ROLES = ["worker", "reasoner"] as const;
+
+/** Pure: which tier does this role use? override (roles[role]) ?? fallback. */
+export function resolveRoleTier(role: string, fallback: ModelTier, roles: RolesConfig | undefined): ModelTier {
+  return (roles?.[role as (typeof KNOWN_ROLES)[number]] as ModelTier | undefined) ?? fallback;
+}
+
+type ModelFactory = (tier: ModelTier, keys: ProviderKeys) => BaseChatModel;
+
+/** Builds per-step metered invokers and owns the per-role CostLedger. One per run. */
+export class RoleRouter {
+  readonly ledger: CostLedger;
+  constructor(
+    private readonly cfg: AppConfig,
+    private readonly keys: ProviderKeys,
+    private readonly budget: CallBudget,
+    pricing?: Record<string, ModelPrice>,
+    private readonly makeModelFn: ModelFactory = makeModel,
+  ) {
+    this.ledger = new CostLedger(pricing);
+  }
+
+  /** Resolved tier for a role (override ?? fallback). */
+  tierFor(role: string, fallback: ModelTier): ModelTier {
+    return resolveRoleTier(role, fallback, this.cfg.roles);
+  }
+
+  /** StructuredInvoke for an already-resolved tier, metered under `role`, capped + retried. */
+  invoke(role: string, tier: ModelTier): StructuredInvoke {
+    const model = this.makeModelFn(tier, this.keys);
+    const metered = meteredInvoker(model, (u, m) => this.ledger.record(role, m, u), tier.model);
+    return cappedInvoke(retryInvoke(metered), this.budget);
+  }
+}
+```
+
+- [ ] **Step 4: Export from barrel** `src/llm/index.ts`:
+
+```ts
+export { meteredInvoker, structuredInvoker, retryInvoke, CallBudget, cappedInvoke } from "./structured.js";
+export { RoleRouter, resolveRoleTier, KNOWN_ROLES } from "./routing.js";
+export { CostLedger, DEFAULT_PRICING, priceFor, extractUsage } from "./cost.js";
+export type { CostReport, RoleCost, TokenUsage, ModelPrice } from "./cost.js";
+```
+
+- [ ] **Step 5: Run — expect PASS**: `npm test -- routing`
+
+---
+
+### Task 6: loadConfig — parse LLM_ROUTING preset + CAIRN_ROLE_* overrides; validate keys; warn unknown
+
+**Files:**
+- Modify: `src/config/index.ts`
+- Test: `tests/unit/config.test.ts` (new)
+
+- [ ] **Step 1: Write failing tests** `tests/unit/config.test.ts`
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { loadConfig } from "../../src/config/index.js";
+
+const base = { ANTHROPIC_API_KEY: "a", OPENROUTER_API_KEY: "o" };
+
+describe("loadConfig — routing is additive + backward-compatible", () => {
+  it("no routing config → roles undefined, profile unchanged", () => {
+    const cfg = loadConfig({ ...base, LLM_PROFILE: "anthropic" });
+    expect(cfg.roles).toBeUndefined();
+    expect(cfg.models.reasoning.model).toBe("claude-opus-4-8");
+  });
+  it("LLM_ROUTING=volume → worker=OpenRouter, reasoner=Anthropic", () => {
+    const cfg = loadConfig({ ...base, LLM_ROUTING: "volume" });
+    expect(cfg.roles?.worker?.provider).toBe("openrouter");
+    expect(cfg.roles?.reasoner?.provider).toBe("anthropic");
+  });
+  it("missing provider key for a routed role → error names ROLE + PROVIDER", () => {
+    expect(() => loadConfig({ ANTHROPIC_API_KEY: "a", LLM_ROUTING: "volume" }))
+      .toThrow(/Role 'worker'.*OpenRouter/i);
+  });
+  it("CAIRN_ROLE_WORKER=provider:model overrides the role", () => {
+    const cfg = loadConfig({ ...base, CAIRN_ROLE_WORKER: "openrouter:deepseek/deepseek-chat" });
+    expect(cfg.roles?.worker).toEqual({ provider: "openrouter", model: "deepseek/deepseek-chat", supportsVision: false });
+  });
+  it("unknown role in CAIRN_ROLE_* → warning + ignored (falls back to default)", () => {
+    const warn = vi.fn();
+    const cfg = loadConfig({ ...base, CAIRN_ROLE_TYPO: "anthropic:claude-opus-4-8" }, { warn });
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/unknown role/i));
+    expect(cfg.roles?.["typo" as never]).toBeUndefined();
+  });
+  it("unknown preset name → warning + no routing (graceful)", () => {
+    const warn = vi.fn();
+    const cfg = loadConfig({ ...base, LLM_ROUTING: "bogus" }, { warn });
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/unknown.*routing preset/i));
+    expect(cfg.roles).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**: `npm test -- config`
+
+- [ ] **Step 3: Implement** in `src/config/index.ts`:
+  - import `ROUTING_PRESETS` from `./profiles.js`, `ProviderSchema`, `RoleSchema` from `./schema.js`, re-export `RolesConfig`/`Role`/`ROUTING_PRESETS`.
+  - after computing `models`, build `roles` via a new `resolveRoles(read, env, warn)` helper:
+    - start from `ROUTING_PRESETS[LLM_ROUTING]` if `LLM_ROUTING` set (unknown name → `warn(...unknown ... routing preset...)`, skip).
+    - scan `Object.keys(env)` for `CAIRN_ROLE_<NAME>`: `name=NAME.toLowerCase()`; if `RoleSchema.safeParse(name).success` → parse value `provider:model` (split on first `:`; provider via `ProviderSchema` or throw a clear invalid-provider error; `supportsVision:false`), merge into roles; else `warn(...unknown role '<name>' in CAIRN_ROLE_<NAME> — ignored)`.
+    - if no roles collected → return `undefined`.
+  - after `roles` resolved, validate provider keys per routed role:
+
+```ts
+for (const [role, tier] of Object.entries(roles ?? {})) {
+  if (tier.provider === "anthropic" && !anthropicApiKey)
+    throw new Error(`Role '${role}' uses Anthropic, but ANTHROPIC_API_KEY is not set.`);
+  if (tier.provider === "openrouter" && !openrouterApiKey)
+    throw new Error(`Role '${role}' uses OpenRouter, but OPENROUTER_API_KEY is not set.`);
+}
+```
+  - add `roles` to the returned `AppConfig`.
+
+- [ ] **Step 4: Run — expect PASS**: `npm test -- config`
+
+---
+
+### Task 7: Render cost in report.ts (md) + report.json shape
+
+**Files:**
+- Modify: `src/artifacts/report.ts`
+- Test: `tests/unit/report.test.ts` (extend)
+
+- [ ] **Step 1: Add failing assertion** to the existing `renderReportMd` test — pass a `cost` and assert the section:
+
+```ts
+cost: {
+  perRole: [
+    { role: "worker", models: ["deepseek/deepseek-chat"], calls: 2, inputTokens: 1000, outputTokens: 500, totalTokens: 1500, costUsd: 0.001 },
+    { role: "reasoner", models: ["claude-opus-4-8"], calls: 1, inputTokens: 800, outputTokens: 400, totalTokens: 1200, costUsd: 0.014 },
+  ],
+  totalTokens: 2700, totalCostUsd: 0.015,
+},
+// asserts:
+expect(md).toContain("Cost (per role)");
+expect(md).toContain("worker");
+expect(md).toContain("reasoner");
+expect(md).toContain("$0.015");
+```
+
+- [ ] **Step 2: Implement** — import `CostReport` type, add `cost?: CostReport` to `ReportInput`, render after Metrics:
+
+```ts
+if (r.cost && r.cost.perRole.length > 0) {
+  lines.push("## Cost (per role)", "", "| role | model(s) | calls | input tok | output tok | cost (USD) |", "|---|---|---|---|---|---|");
+  for (const c of r.cost.perRole) {
+    lines.push(`| ${c.role} | ${c.models.join(", ")} | ${c.calls} | ${c.inputTokens} | ${c.outputTokens} | ${c.costUsd === null ? "—" : `$${c.costUsd.toFixed(4)}`} |`);
+  }
+  const total = r.cost.totalCostUsd === null ? "— (some prices unknown)" : `$${r.cost.totalCostUsd.toFixed(4)}`;
+  lines.push(`| **total** |  |  |  | ${r.cost.totalTokens} | ${total} |`, "");
+}
+```
+
+- [ ] **Step 3: Run — expect PASS**: `npm test -- report`
+
+---
+
+### Task 8: Wire RoleRouter into the agent (runExploration / runDesign / runAutomate)
+
+**Files:**
+- Modify: `src/agent/index.ts`
+
+No graph change — nodes still get `StructuredInvoke`. Replace each `cappedInvoke(retryInvoke(structuredInvoker(makeModel(<tier>, keys))), budget)` with router-built invokers, compute `useVision` from the resolved worker tier, route Pilot to `reasoner`, and thread cost into results + reports.
+
+- [ ] **Step 1:** In `runExploration`, after `const budget = new CallBudget(80);` add:
+
+```ts
+const router = new RoleRouter(cfg, keys, budget);
+const visionTier = cfg.models.vision ?? cfg.models.reasoning;
+const analyzeTier = router.tierFor("worker", visionTier);
+const designTier = router.tierFor("reasoner", cfg.models.reasoning);
+const codegenTier = router.tierFor("worker", cfg.models.bulk);
+```
+
+- [ ] **Step 2:** Replace the `buildExploreGraph` invoker deps:
+
+```ts
+analyzeInvoke: router.invoke("worker", analyzeTier),
+designInvoke: router.invoke("reasoner", designTier),
+codegenInvoke: router.invoke("worker", codegenTier),
+useVision: analyzeTier.supportsVision,
+```
+(remove the now-duplicate local `visionTier` declaration further down — keep one.)
+
+- [ ] **Step 3:** Replace the judge scorer + checklist coverage invokers with `router.invoke("judge", cfg.models.judge)` (metered under `judge`, tier unchanged). Route **Pilot** to reasoner:
+
+```ts
+const pilotTier = router.tierFor("reasoner", cfg.models.reasoning);
+pilot = await pilotReview(..., router.invoke("reasoner", pilotTier), prompts);
+```
+
+- [ ] **Step 4:** Build `const cost = router.ledger.report();` before writing artifacts. Add `cost` to `writeReport({...})`, to `renderReportMd({...})`, and to the returned `ExploreResult`. Add `cost: CostReport` to the `ExploreResult` interface (import the type).
+
+- [ ] **Step 5:** Apply the same pattern in `runDesign` (analyze/design/codegen + judge; no Pilot) — add `cost` to its `writeReport` + `DesignResult`. In `runAutomate`, route the bulk codegen via `router.invoke("worker", router.tierFor("worker", cfg.models.bulk))` and add `cost?: CostReport` to `AutomateResult`.
+
+- [ ] **Step 6:** `npm run build` — fix type errors. Then `npm test` — existing graph/agent tests still green (deps shape unchanged).
+
+---
+
+### Task 9: Public types + CLI flag + CLI cost print
+
+**Files:**
+- Modify: `src/index.ts`, `src/cli/index.ts`
+
+- [ ] **Step 1:** `src/index.ts` — export the cost types:
+
+```ts
+export type { CostReport, RoleCost } from "./llm/cost.js";
+```
+
+- [ ] **Step 2:** `src/cli/index.ts` — add `--routing <preset>` to `explore`, `design`, `automate`; set `env.LLM_ROUTING = opts.routing` before `loadConfig(env)` (mirror `--backend`). For `explore`/`design` build the env object like `explore` already does.
+
+- [ ] **Step 3:** Print per-role cost in the `explore` summary (after Metrics):
+
+```ts
+if (result.cost && result.cost.perRole.length > 0) {
+  process.stdout.write("\n=== Cost (per role) ===\n");
+  for (const c of result.cost.perRole) {
+    const usd = c.costUsd === null ? "n/a" : `$${c.costUsd.toFixed(4)}`;
+    process.stdout.write(`  ${c.role.padEnd(9)} ${c.calls} calls  ${c.inputTokens}→${c.outputTokens} tok  ${usd}\n`);
+  }
+  const total = result.cost.totalCostUsd === null ? "n/a (some prices unknown)" : `$${result.cost.totalCostUsd.toFixed(4)}`;
+  process.stdout.write(`  total     ${result.cost.totalTokens} tok  ${total}\n`);
+}
+```
+
+- [ ] **Step 4:** `npm run build && npm run lint` clean.
+
+---
+
+### Task 10: ADR-0010 + verify + PR
+
+- [ ] **Step 1:** Write `docs/adr/0010-per-role-model-routing.md` (Accepted): role layer over tiers, `worker`/`reasoner` naming (vs the cheap `judge` tier), the Pilot→reasoner behavior change, cost-ledger plumbing, `volume` preset, graceful price handling.
+- [ ] **Step 2:** Full gate: `npm run build` · `npm test` · `npm run lint` · `npm run test:coverage` — all green.
+- [ ] **Step 3:** Live verification (no Anthropic key in `.env`; OpenRouter present): run `cairn explore` against a public no-auth page with `LLM_PROFILE=openrouter` + a `CAIRN_ROLE_WORKER` OpenRouter override → confirm the summary shows per-role cost + tokens (real tokens). Document that `volume`/`anthropic` live runs need an Anthropic key (config-resolution + key-error covered by unit tests); leave the login-gated DoD line unchecked (ref #27).
+- [ ] **Step 4:** Commit on `feat/l1-01-role-routing`; open PR closing #6 with the mapping table, Pilot behavior-change note, backward-compat test result, and the checklist.
+
+---
+
+## Self-review
+
+- **Spec coverage:** roles (T1,T5) · config/env override + fallback (T1,T6) · per-role cost+tokens (T3,T4,T7,T8) · volume preset (T2,T6) · Pilot→reasoner (T8) · all 4 edge-case tests (T6 backward-compat/missing-key/unknown-role + T3 cost-sum). ✓
+- **No placeholders:** every step has concrete code or an exact insertion point. ✓
+- **Type consistency:** `RoleRouter.tierFor/invoke`, `CostLedger.record/report`, `CostReport`/`RoleCost`, `meteredInvoker(model,onUsage,modelId)`, `extractUsage` used identically across tasks. ✓

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -2,8 +2,8 @@ import { randomUUID } from "node:crypto";
 import { resolve, dirname, basename, join } from "node:path";
 import { readFile, readdir } from "node:fs/promises";
 import { makeGateway } from "../browser/index.js";
-import { makeModel } from "../llm/index.js";
-import { structuredInvoker, retryInvoke, CallBudget, cappedInvoke } from "../llm/structured.js";
+import { RoleRouter, type CostReport } from "../llm/index.js";
+import { CallBudget } from "../llm/structured.js";
 import { PromptRegistry } from "../prompts/index.js";
 import { initTelemetry } from "../telemetry/index.js";
 import { ArtifactStore } from "../artifacts/index.js";
@@ -63,6 +63,8 @@ export interface ExploreResult {
   validation?: ValidationReport;
   scores: Score[];
   pilot?: PilotVerdict;
+  /** Per-role cost + tokens for the run (L1-01, ADR-0011). */
+  cost: CostReport;
 }
 
 /**
@@ -73,6 +75,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
   const cfg = input.config;
   const keys = { anthropicApiKey: cfg.anthropicApiKey, openrouterApiKey: cfg.openrouterApiKey };
   const budget = new CallBudget(80); // cost-guardrail: safeguard (normally ~6-10 calls/run)
+  const router = new RoleRouter(cfg, keys, budget); // L1-01: per-role routing + cost ledger
 
   // Progress → live (CLI) + buffered into run.log.
   const logLines: string[] = [];
@@ -119,14 +122,18 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
   const styleText = styleDirective(input.style ?? "all");
   const languageText = input.language ?? cfg.testCaseLanguage;
 
+  // L1-01: resolve per-role tiers (override ?? profile tier), then build metered invokers.
   const visionTier = cfg.models.vision ?? cfg.models.reasoning;
+  const analyzeTier = router.tierFor("worker", visionTier);
+  const designTier = router.tierFor("reasoner", cfg.models.reasoning);
+  const codegenTier = router.tierFor("worker", cfg.models.bulk);
   const graph = buildExploreGraph({
     gateway,
     prompts,
-    analyzeInvoke: cappedInvoke(retryInvoke(structuredInvoker(makeModel(visionTier, keys))), budget),
-    designInvoke: cappedInvoke(retryInvoke(structuredInvoker(makeModel(cfg.models.reasoning, keys))), budget),
-    codegenInvoke: cappedInvoke(retryInvoke(structuredInvoker(makeModel(cfg.models.bulk, keys))), budget),
-    useVision: visionTier.supportsVision,
+    analyzeInvoke: router.invoke("worker", analyzeTier),
+    designInvoke: router.invoke("reasoner", designTier),
+    codegenInvoke: router.invoke("worker", codegenTier),
+    useVision: analyzeTier.supportsVision,
     checklistText: checklistFormatted,
     knowledgeText,
     experienceText,
@@ -198,7 +205,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
         ...(await judgeTestCases(
           out.testCases,
           out.analysis.pageSemantics,
-          cappedInvoke(retryInvoke(structuredInvoker(makeModel(cfg.models.judge, keys))), budget),
+          router.invoke("judge", cfg.models.judge),
           prompts,
         )),
       );
@@ -210,7 +217,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
         const cov = await judgeChecklistCoverage(
           checklistItems,
           out.testCases,
-          cappedInvoke(retryInvoke(structuredInvoker(makeModel(cfg.models.judge, keys))), budget),
+          router.invoke("judge", cfg.models.judge),
           prompts,
         );
         scores.push({ name: "checklist_coverage", value: cov.value, comment: cov.comment });
@@ -246,7 +253,9 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
         out.analysis.pageSemantics,
         validation,
         out.testCases,
-        cappedInvoke(retryInvoke(structuredInvoker(makeModel(cfg.models.judge, keys))), budget),
+        // L1-01: Pilot verdict now runs on the strong `reasoner` role (was the cheap `judge` tier) —
+        // intended behavior change toward a "smart judge". See ADR-0011.
+        router.invoke("reasoner", router.tierFor("reasoner", cfg.models.reasoning)),
         prompts,
       );
       onProgress(`pilot — verdict: ${pilot.verdict} — ${pilot.reason}`);
@@ -254,6 +263,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
       // pilot is not critical
     }
 
+    const cost = router.ledger.report(); // L1-01: per-role cost + tokens for this run
     await runWriter.writeStudy(out.study);
     if (out.study.screenshotB64) await runWriter.writeScreenshot(out.study.screenshotB64);
     await runWriter.writeAria(out.study.ariaYaml);
@@ -265,6 +275,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
       validation,
       scores,
       pilot,
+      cost,
       history: {
         priorRuns: priorRuns.length,
         bestPriorGreen: bestPriorGreen ?? null,
@@ -283,6 +294,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
         validation,
         scores,
         consoleErrors: out.study.consoleErrors,
+        cost,
       }),
     );
     const green = validation ? `${Math.round(validation.greenRatio * 100)}%` : "—";
@@ -300,6 +312,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
       validation,
       scores,
       pilot,
+      cost,
     };
   } finally {
     await gateway.close();
@@ -315,6 +328,8 @@ export interface DesignResult {
   testCases: TestCase[];
   testCaseFiles: string[];
   scores: Score[];
+  /** Per-role cost + tokens for the run (L1-01). */
+  cost: CostReport;
 }
 
 function suiteFromUrl(url: string): string {
@@ -335,6 +350,7 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
   const cfg = input.config;
   const keys = { anthropicApiKey: cfg.anthropicApiKey, openrouterApiKey: cfg.openrouterApiKey };
   const budget = new CallBudget(80); // cost-guardrail: safeguard (normally ~6-10 calls/run)
+  const router = new RoleRouter(cfg, keys, budget); // L1-01: per-role routing + cost ledger
   const logLines: string[] = [];
   const onProgress = (event: string): void => {
     logLines.push(`${new Date().toISOString()}  ${event}`);
@@ -369,15 +385,19 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
   );
   const styleText = styleDirective(input.style ?? "all");
   const languageText = input.language ?? cfg.testCaseLanguage;
+  // L1-01: resolve per-role tiers (override ?? profile tier), then build metered invokers.
   const visionTier = cfg.models.vision ?? cfg.models.reasoning;
+  const analyzeTier = router.tierFor("worker", visionTier);
+  const designTier = router.tierFor("reasoner", cfg.models.reasoning);
+  const codegenTier = router.tierFor("worker", cfg.models.bulk);
 
   const graph = buildExploreGraph({
     gateway,
     prompts,
-    analyzeInvoke: cappedInvoke(retryInvoke(structuredInvoker(makeModel(visionTier, keys))), budget),
-    designInvoke: cappedInvoke(retryInvoke(structuredInvoker(makeModel(cfg.models.reasoning, keys))), budget),
-    codegenInvoke: cappedInvoke(retryInvoke(structuredInvoker(makeModel(cfg.models.bulk, keys))), budget),
-    useVision: visionTier.supportsVision,
+    analyzeInvoke: router.invoke("worker", analyzeTier),
+    designInvoke: router.invoke("reasoner", designTier),
+    codegenInvoke: router.invoke("worker", codegenTier),
+    useVision: analyzeTier.supportsVision,
     checklistText: formatChecklist(checklistItems),
     knowledgeText,
     experienceText,
@@ -446,7 +466,7 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
         ...(await judgeTestCases(
           out.testCases,
           out.analysis.pageSemantics,
-          cappedInvoke(retryInvoke(structuredInvoker(makeModel(cfg.models.judge, keys))), budget),
+          router.invoke("judge", cfg.models.judge),
           prompts,
         )),
       );
@@ -458,7 +478,7 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
         const cov = await judgeChecklistCoverage(
           checklistItems,
           out.testCases,
-          cappedInvoke(retryInvoke(structuredInvoker(makeModel(cfg.models.judge, keys))), budget),
+          router.invoke("judge", cfg.models.judge),
           prompts,
         );
         scores.push({ name: "checklist_coverage", value: cov.value, comment: cov.comment });
@@ -470,6 +490,7 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
     await runWriter.writeStudy(out.study);
     if (out.study.screenshotB64) await runWriter.writeScreenshot(out.study.screenshotB64);
     await runWriter.writeAria(out.study.ariaYaml);
+    const cost = router.ledger.report(); // L1-01: per-role cost + tokens for this run
     await runWriter.writeReport({
       runId,
       url: out.study.url,
@@ -479,6 +500,7 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
       testCases: out.testCases,
       testCaseFiles,
       scores,
+      cost,
     });
     await runWriter.writeLog(
       [...logLines, "", `summary: mode=design testCases=${out.testCases.length} suite=${suite} runId=${runId}`].join("\n"),
@@ -492,6 +514,7 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
       testCases: out.testCases,
       testCaseFiles,
       scores,
+      cost,
     };
   } finally {
     await gateway.close();
@@ -503,6 +526,8 @@ export interface AutomateResult {
   runDir: string;
   specFiles: string[];
   validation?: ValidationReport;
+  /** Per-role cost + tokens for the codegen step (L1-01). */
+  cost: CostReport;
 }
 
 /**
@@ -521,6 +546,7 @@ export async function runAutomate(input: {
   const cfg = input.config;
   const keys = { anthropicApiKey: cfg.anthropicApiKey, openrouterApiKey: cfg.openrouterApiKey };
   const budget = new CallBudget(80); // cost-guardrail: safeguard (normally ~6-10 calls/run)
+  const router = new RoleRouter(cfg, keys, budget); // L1-01: per-role routing + cost ledger
   const onProgress = input.onProgress ?? ((): void => undefined);
   const runDir = resolve(input.runDir);
 
@@ -543,7 +569,7 @@ export async function runAutomate(input: {
   const suite = await automateCases(
     cases,
     { baseUrl, pageSemantics },
-    { invoke: cappedInvoke(retryInvoke(structuredInvoker(makeModel(cfg.models.bulk, keys))), budget), prompts: new PromptRegistry() },
+    { invoke: router.invoke("worker", router.tierFor("worker", cfg.models.bulk)), prompts: new PromptRegistry() },
   );
 
   const artifacts = new ArtifactStore(dirname(runDir));
@@ -562,5 +588,6 @@ export async function runAutomate(input: {
     onProgress(`automate — validation: ${Math.round(validation.greenRatio * 100)}% green`);
   }
 
-  return { runDir: runWriter.dir, specFiles, validation };
+  const cost = router.ledger.report(); // L1-01: per-role cost + tokens for the codegen step
+  return { runDir: runWriter.dir, specFiles, validation, cost };
 }

--- a/src/artifacts/report.ts
+++ b/src/artifacts/report.ts
@@ -2,6 +2,7 @@ import type { ElementRef } from "../browser/types.js";
 import type { TestCase } from "../design/index.js";
 import type { ValidationReport } from "../validate/index.js";
 import type { Score } from "../eval/scorers.js";
+import type { CostReport } from "../llm/cost.js";
 
 /** Generate a Playwright locator for an element (ref → getByRole). */
 export function locatorFor(el: ElementRef): string {
@@ -20,6 +21,8 @@ export interface ReportInput {
   validation?: ValidationReport;
   scores?: Score[];
   consoleErrors?: string[];
+  /** Per-role cost + tokens (L1-01); rendered as a table when present. */
+  cost?: CostReport;
 }
 
 function mark(status: string): string {
@@ -46,6 +49,21 @@ export function renderReportMd(r: ReportInput): string {
       lines.push(`| ${s.name} | ${s.value.toFixed(2)}${s.comment ? ` — ${s.comment}` : ""} |`);
     }
     lines.push("");
+  }
+
+  if (r.cost && r.cost.perRole.length > 0) {
+    lines.push(
+      "## Cost (per role)",
+      "",
+      "| role | model(s) | calls | input tok | output tok | cost (USD) |",
+      "|---|---|---|---|---|---|",
+    );
+    for (const c of r.cost.perRole) {
+      const usd = c.costUsd === null ? "—" : `$${c.costUsd.toFixed(4)}`;
+      lines.push(`| ${c.role} | ${c.models.join(", ")} | ${c.calls} | ${c.inputTokens} | ${c.outputTokens} | ${usd} |`);
+    }
+    const total = r.cost.totalCostUsd === null ? "— (some prices unknown)" : `$${r.cost.totalCostUsd.toFixed(4)}`;
+    lines.push(`| **total** |  |  |  | ${r.cost.totalTokens} | ${total} |`, "");
   }
 
   if (r.consoleErrors && r.consoleErrors.length > 0) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,6 +22,19 @@ import { structuredInvoker } from "../llm/structured.js";
 import { PromptRegistry, LOCAL_PROMPTS } from "../prompts/index.js";
 import { runExperiment, type DatasetItem, type Variant } from "../eval/experiment.js";
 import type { PageStudy } from "../observe/index.js";
+import type { CostReport } from "../llm/cost.js";
+
+/** Print the per-role cost + token summary (L1-01). */
+function printCost(cost: CostReport): void {
+  if (cost.perRole.length === 0) return;
+  process.stdout.write("\n=== Cost (per role) ===\n");
+  for (const c of cost.perRole) {
+    const usd = c.costUsd === null ? "n/a" : `$${c.costUsd.toFixed(4)}`;
+    process.stdout.write(`  ${c.role.padEnd(9)} ${c.calls} call(s)  ${c.inputTokens}→${c.outputTokens} tok  ${usd}\n`);
+  }
+  const total = cost.totalCostUsd === null ? "n/a (some prices unknown)" : `$${cost.totalCostUsd.toFixed(4)}`;
+  process.stdout.write(`  ${"total".padEnd(9)} ${cost.totalTokens} tok  ${total}\n`);
+}
 
 const program = new Command();
 program
@@ -73,6 +86,7 @@ program
   .option("--headed", "visible browser (debug)")
   .option("--checklist <file>", "checklist file (md/text) — guides what to test")
   .option("--style <s>", "planning style: happy | negative | coverage | all")
+  .option("--routing <preset>", "role-routing preset, e.g. volume (sets LLM_ROUTING)")
   .action(
     async (opts: {
       url: string;
@@ -82,9 +96,11 @@ program
       headed?: boolean;
       checklist?: string;
       style?: string;
+      routing?: string;
     }) => {
       const env: Record<string, string | undefined> = { ...process.env };
       if (opts.backend) env.BROWSER_BACKEND = opts.backend;
+      if (opts.routing) env.LLM_ROUTING = opts.routing;
       const config = loadConfig(env);
       const checklistText = opts.checklist ? await readFile(opts.checklist, "utf8") : undefined;
       process.stderr.write(
@@ -135,6 +151,7 @@ program
         `\n=== Pilot: ${result.pilot.verdict.toUpperCase()} ===\n  ${result.pilot.reason}\n  → ${result.pilot.guidance}\n`,
       );
     }
+    printCost(result.cost);
     process.stdout.write(`\nArtifacts: ${result.runDir}\n`);
   });
 
@@ -232,6 +249,7 @@ program
   .option("--session-file <path>", "path to a storageState file")
   .option("--checklist <file>", "checklist file — guides what to test")
   .option("--style <s>", "planning style: happy | negative | coverage | all")
+  .option("--routing <preset>", "role-routing preset, e.g. volume (sets LLM_ROUTING)")
   .option("--headed", "visible browser (debug)")
   .action(
     async (opts: {
@@ -241,8 +259,11 @@ program
       checklist?: string;
       style?: string;
       headed?: boolean;
+      routing?: string;
     }) => {
-      const config = loadConfig(process.env);
+      const env: Record<string, string | undefined> = { ...process.env };
+      if (opts.routing) env.LLM_ROUTING = opts.routing;
+      const config = loadConfig(env);
       const checklistText = opts.checklist ? await readFile(opts.checklist, "utf8") : undefined;
       process.stderr.write(`▸ Designing test cases for ${opts.url}${opts.session ? ` (session: ${opts.session})` : ""}…\n`);
       const result = await runDesign({
@@ -270,6 +291,7 @@ program
           process.stdout.write(`  ${s.name}: ${s.value.toFixed(2)}${s.comment ? ` — ${s.comment}` : ""}\n`);
         }
       }
+      printCost(result.cost);
     },
   );
 
@@ -280,9 +302,12 @@ program
   .option("--validate", "run the generated tests (a session is required)")
   .option("--session <name>", "session name for validation")
   .option("--session-file <path>", "path to storageState for validation")
+  .option("--routing <preset>", "role-routing preset, e.g. volume (sets LLM_ROUTING)")
   .action(
-    async (opts: { run: string; validate?: boolean; session?: string; sessionFile?: string }) => {
-      const config = loadConfig(process.env);
+    async (opts: { run: string; validate?: boolean; session?: string; sessionFile?: string; routing?: string }) => {
+      const env: Record<string, string | undefined> = { ...process.env };
+      if (opts.routing) env.LLM_ROUTING = opts.routing;
+      const config = loadConfig(env);
       process.stderr.write(`▸ Automating cases from ${opts.run}…\n`);
       const result = await runAutomate({
         runDir: opts.run,
@@ -301,6 +326,7 @@ program
           `\nValidation: ${Math.round(result.validation.greenRatio * 100)}% green out of ${result.validation.results.length} tests\n`,
         );
       }
+      printCost(result.cost);
     },
   );
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,12 +2,14 @@ import {
   BrowserBackendSchema,
   LlmProfileSchema,
   ModelsConfigSchema,
+  ProviderSchema,
+  RoleSchema,
 } from "./schema.js";
-import type { AppConfig, Provider } from "./schema.js";
-import { PROFILES } from "./profiles.js";
+import type { AppConfig, Provider, ModelTier, RolesConfig } from "./schema.js";
+import { PROFILES, ROUTING_PRESETS } from "./profiles.js";
 import { createEnvReader } from "./env.js";
 
-export type { AppConfig, ModelsConfig, ModelTier, Provider, LlmProfile, BrowserBackend } from "./schema.js";
+export type { AppConfig, ModelsConfig, ModelTier, Provider, LlmProfile, BrowserBackend, Role, RoleModel, RolesConfig } from "./schema.js";
 
 type Env = Record<string, string | undefined>;
 
@@ -49,6 +51,23 @@ export function loadConfig(
     );
   }
 
+  // L1-01 (ADR-0011): optional per-role routing, additive over the tier map. Preset via
+  // LLM_ROUTING + explicit CAIRN_ROLE_<NAME> overrides. Unknown roles/presets warn and fall
+  // back to the tier default; a routed role with a missing provider key errors by role+provider.
+  const warn = opts.warn ?? ((msg: string): void => { process.stderr.write(`${msg}\n`); });
+  const roles = parseRoles(env, read, warn);
+  if (roles) {
+    for (const [role, tier] of Object.entries(roles)) {
+      if (!tier) continue;
+      if (tier.provider === "anthropic" && !anthropicApiKey) {
+        throw new Error(`Role '${role}' uses Anthropic, but ANTHROPIC_API_KEY is not set.`);
+      }
+      if (tier.provider === "openrouter" && !openrouterApiKey) {
+        throw new Error(`Role '${role}' uses OpenRouter, but OPENROUTER_API_KEY is not set.`);
+      }
+    }
+  }
+
   const browserBackendRaw = read("BROWSER_BACKEND");
   const backendResult = BrowserBackendSchema.safeParse(browserBackendRaw ?? "lib");
   if (!backendResult.success) {
@@ -83,6 +102,7 @@ export function loadConfig(
   return {
     llmProfile,
     models,
+    roles,
     anthropicApiKey,
     openrouterApiKey,
     langfuse: {
@@ -95,4 +115,70 @@ export function loadConfig(
     maxRepair,
     testCaseLanguage,
   };
+}
+
+/**
+ * L1-01: build the optional per-role routing map (worker/reasoner) from a named preset
+ * (`LLM_ROUTING`) plus explicit `CAIRN_ROLE_<NAME>=provider:model` overrides (which win over
+ * the preset). Unknown presets and unknown role names warn and are ignored (graceful fallback
+ * to the tier default). Returns undefined when no routing is configured.
+ */
+function parseRoles(
+  env: Env,
+  read: (name: string) => string | undefined,
+  warn: (msg: string) => void,
+): RolesConfig | undefined {
+  const roles: Record<string, ModelTier> = {};
+
+  // 1) Named preset via LLM_ROUTING (e.g. "volume").
+  const presetName = read("LLM_ROUTING");
+  if (presetName) {
+    const preset = ROUTING_PRESETS[presetName];
+    if (preset) {
+      for (const [role, tier] of Object.entries(preset)) {
+        if (tier) roles[role] = { ...tier };
+      }
+    } else {
+      warn(
+        `[cairn] unknown LLM_ROUTING routing preset '${presetName}' — ignored ` +
+          `(known: ${Object.keys(ROUTING_PRESETS).join(", ")}).`,
+      );
+    }
+  }
+
+  // 2) Explicit per-role overrides via CAIRN_ROLE_<NAME>=provider:model (override the preset).
+  const known = RoleSchema.options as readonly string[];
+  for (const key of Object.keys(env)) {
+    if (!key.startsWith("CAIRN_ROLE_")) continue;
+    const value = env[key];
+    if (value === undefined || value.trim() === "") continue;
+    const role = key.slice("CAIRN_ROLE_".length).toLowerCase();
+    if (!known.includes(role)) {
+      warn(`[cairn] unknown role '${role}' in ${key} — ignored (known roles: ${known.join(", ")}).`);
+      continue;
+    }
+    roles[role] = parseRoleSpec(role, value);
+  }
+
+  return Object.keys(roles).length > 0 ? (roles as RolesConfig) : undefined;
+}
+
+/** Parse a `provider:model` role spec; throws a clear error on a bad provider or empty model. */
+function parseRoleSpec(role: string, value: string): ModelTier {
+  const i = value.indexOf(":");
+  const providerRaw = (i === -1 ? value : value.slice(0, i)).trim();
+  const model = (i === -1 ? "" : value.slice(i + 1)).trim();
+  const provider = ProviderSchema.safeParse(providerRaw);
+  if (!provider.success) {
+    throw new Error(
+      `Invalid provider '${providerRaw}' for role '${role}' (allowed: anthropic | openrouter). ` +
+        `Use CAIRN_ROLE_${role.toUpperCase()}=provider:model.`,
+    );
+  }
+  if (!model) {
+    throw new Error(
+      `Missing model for role '${role}' — use CAIRN_ROLE_${role.toUpperCase()}=${providerRaw}:<model>.`,
+    );
+  }
+  return { provider: provider.data, model, supportsVision: false };
 }

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -1,4 +1,4 @@
-import type { LlmProfile, ModelsConfig } from "./schema.js";
+import type { LlmProfile, ModelsConfig, RolesConfig } from "./schema.js";
 
 /**
  * Default model profiles (ADR-0002). Exact OpenRouter model-ids are confirmed by Spike S6;
@@ -25,5 +25,23 @@ export const PROFILES: Record<LlmProfile, ModelsConfig> = {
     bulk: { provider: "openrouter", model: "deepseek/deepseek-chat", supportsVision: false },
     judge: { provider: "openrouter", model: "qwen/qwen-2.5-72b-instruct", supportsVision: false },
     vision: { provider: "anthropic", model: "claude-haiku-4-5", supportsVision: true },
+  },
+};
+
+/**
+ * Named role-routing presets (L1-01, ADR-0011). Layered OVER a profile's tier map:
+ * a preset only sets the routable roles (`worker`/`reasoner`); the cheap `judge`
+ * scorer tier still comes from `LLM_PROFILE`. Selected via `LLM_ROUTING=<name>`.
+ *
+ * `volume` = run cheaply at scale (Explorbot-style): the mechanical worker steps on a
+ * cheap OpenRouter model, the judgment steps (designTestCases + Pilot verdict) on Claude.
+ */
+export const ROUTING_PRESETS: Record<string, RolesConfig> = {
+  volume: {
+    // worker spans identifyElements(vision) + generateCode/repair(bulk) → one cheap text model.
+    // supportsVision:false → identifyElements falls back to aria-only (ADR-0002, vision-optional).
+    worker: { provider: "openrouter", model: "deepseek/deepseek-chat", supportsVision: false },
+    // reasoner = designTestCases + Pilot verdict → quality model.
+    reasoner: { provider: "anthropic", model: "claude-opus-4-8", supportsVision: false },
   },
 };

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -22,6 +22,19 @@ export const ModelsConfigSchema = z.object({
 });
 export type ModelsConfig = z.infer<typeof ModelsConfigSchema>;
 
+/**
+ * Named role over the tier map (L1-01). Only these two are routable; the cheap
+ * LLM-as-judge scorer keeps the `judge` tier and is NOT a role (see ADR-0011).
+ */
+export const RoleSchema = z.enum(["worker", "reasoner"]);
+export type Role = z.infer<typeof RoleSchema>;
+
+/** A role override reuses the tier shape (provider + model + vision + temperature). */
+export type RoleModel = ModelTier;
+
+/** Optional per-role routing overrides, layered over `models` (the tier map). */
+export type RolesConfig = Partial<Record<Role, RoleModel>>;
+
 export const LlmProfileSchema = z.enum(["anthropic", "openrouter", "mixed"]);
 export type LlmProfile = z.infer<typeof LlmProfileSchema>;
 
@@ -39,6 +52,8 @@ export interface LangfuseConfig {
 export interface AppConfig {
   llmProfile: LlmProfile;
   models: ModelsConfig;
+  /** L1-01 per-role routing overrides (optional; layered over `models`). */
+  roles?: RolesConfig;
   anthropicApiKey?: string;
   openrouterApiKey?: string;
   langfuse: LangfuseConfig;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,10 @@ export type {
 
 // Config.
 export { loadConfig } from "./config/index.js";
-export type { AppConfig } from "./config/index.js";
+export type { AppConfig, Role, RolesConfig } from "./config/index.js";
+
+// Cost/token reporting (L1-01, ADR-0011).
+export type { CostReport, RoleCost } from "./llm/cost.js";
 
 // Domain types (output contracts).
 export type { TestCase, DesignedCase } from "./design/index.js";

--- a/src/llm/cost.ts
+++ b/src/llm/cost.ts
@@ -1,0 +1,146 @@
+/**
+ * Per-role cost + token accounting (L1-01, ADR-0011). Pure — no SDK, no network.
+ *
+ * `CallBudget` (structured.ts) counts CALLS as a guardrail; this is its sibling that
+ * counts tokens and prices them per role. Capture happens in `meteredInvoker`.
+ */
+
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface ModelPrice {
+  inputPer1M: number;
+  outputPer1M: number;
+}
+
+/**
+ * Default price table (USD per 1M tokens). Anthropic prices are authoritative
+ * (claude-api skill, 2026-06). OpenRouter prices are APPROXIMATE and move
+ * (ADR-0002) — any model absent here yields a null (unknown) cost; tokens are
+ * still counted. Override by passing a table to `CostLedger`.
+ */
+export const DEFAULT_PRICING: Record<string, ModelPrice> = {
+  "claude-opus-4-8": { inputPer1M: 5, outputPer1M: 25 },
+  "claude-sonnet-4-6": { inputPer1M: 3, outputPer1M: 15 },
+  "claude-haiku-4-5": { inputPer1M: 1, outputPer1M: 5 },
+  // OpenRouter — approximate, movable (ADR-0002, self-hosted Langfuse needs custom pricing).
+  "deepseek/deepseek-chat": { inputPer1M: 0.28, outputPer1M: 0.88 },
+  "deepseek/deepseek-r1": { inputPer1M: 0.55, outputPer1M: 2.19 },
+  "qwen/qwen-2.5-72b-instruct": { inputPer1M: 0.35, outputPer1M: 0.4 },
+  "qwen/qwen-2-vl-72b-instruct": { inputPer1M: 0.4, outputPer1M: 0.4 },
+};
+
+export function priceFor(
+  model: string,
+  table: Record<string, ModelPrice> = DEFAULT_PRICING,
+): ModelPrice | undefined {
+  return table[model];
+}
+
+/** Minimal structural view of a LangChain response carrying token usage. */
+interface UsageCarrier {
+  usage_metadata?: { input_tokens?: number; output_tokens?: number };
+  response_metadata?: {
+    usage?: { input_tokens?: number; output_tokens?: number; prompt_tokens?: number; completion_tokens?: number };
+    tokenUsage?: { promptTokens?: number; completionTokens?: number };
+  };
+}
+
+/**
+ * Read token usage off a LangChain message. Prefers `usage_metadata` (normalized by
+ * LangChain across providers), then `response_metadata.usage` (OpenAI/OpenRouter), then
+ * `tokenUsage`. Never throws — missing usage yields zeros (graceful per ADR-0002).
+ */
+export function extractUsage(raw: unknown): TokenUsage {
+  const m = (raw ?? {}) as UsageCarrier;
+  const um = m.usage_metadata;
+  if (um && (um.input_tokens !== undefined || um.output_tokens !== undefined)) {
+    return { inputTokens: um.input_tokens ?? 0, outputTokens: um.output_tokens ?? 0 };
+  }
+  const u = m.response_metadata?.usage;
+  if (u) {
+    return {
+      inputTokens: u.input_tokens ?? u.prompt_tokens ?? 0,
+      outputTokens: u.output_tokens ?? u.completion_tokens ?? 0,
+    };
+  }
+  const t = m.response_metadata?.tokenUsage;
+  if (t) return { inputTokens: t.promptTokens ?? 0, outputTokens: t.completionTokens ?? 0 };
+  return { inputTokens: 0, outputTokens: 0 };
+}
+
+export interface RoleCost {
+  role: string;
+  models: string[];
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  /** null when any contributing model has no configured price (tokens still reported). */
+  costUsd: number | null;
+}
+
+export interface CostReport {
+  perRole: RoleCost[];
+  totalTokens: number;
+  /** null when any role's cost is unknown. */
+  totalCostUsd: number | null;
+}
+
+interface Row {
+  models: Set<string>;
+  calls: number;
+  in: number;
+  out: number;
+  cost: number;
+  costKnown: boolean;
+}
+
+const ROLE_ORDER = ["worker", "reasoner", "judge"];
+
+/** Accumulates usage per role and prices it. Sibling to CallBudget; one per run. */
+export class CostLedger {
+  private readonly rows = new Map<string, Row>();
+
+  constructor(private readonly pricing: Record<string, ModelPrice> = DEFAULT_PRICING) {}
+
+  record(role: string, model: string, usage: TokenUsage): void {
+    const row = this.rows.get(role) ?? { models: new Set<string>(), calls: 0, in: 0, out: 0, cost: 0, costKnown: true };
+    row.calls += 1;
+    row.in += usage.inputTokens;
+    row.out += usage.outputTokens;
+    row.models.add(model);
+    const p = this.pricing[model];
+    if (p) row.cost += (usage.inputTokens / 1e6) * p.inputPer1M + (usage.outputTokens / 1e6) * p.outputPer1M;
+    else row.costKnown = false;
+    this.rows.set(role, row);
+  }
+
+  report(): CostReport {
+    const rank = (r: string): number => {
+      const i = ROLE_ORDER.indexOf(r);
+      return i === -1 ? ROLE_ORDER.length : i;
+    };
+    const roles = [...this.rows.keys()].sort((a, b) => rank(a) - rank(b));
+    const perRole: RoleCost[] = roles.map((role) => {
+      const r = this.rows.get(role) as Row;
+      return {
+        role,
+        models: [...r.models],
+        calls: r.calls,
+        inputTokens: r.in,
+        outputTokens: r.out,
+        totalTokens: r.in + r.out,
+        costUsd: r.costKnown ? Number(r.cost.toFixed(6)) : null,
+      };
+    });
+    const totalTokens = perRole.reduce((s, r) => s + r.totalTokens, 0);
+    const anyUnknown = perRole.some((r) => r.costUsd === null);
+    const totalCostUsd = anyUnknown
+      ? null
+      : Number(perRole.reduce((s, r) => s + (r.costUsd ?? 0), 0).toFixed(6));
+    return { perRole, totalTokens, totalCostUsd };
+  }
+}

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -2,3 +2,9 @@ export { OPENROUTER_BASE_URL, resolveModelSpec, makeModel } from "./factory.js";
 export type { ModelSpec, ProviderKeys } from "./factory.js";
 export { imageBlock } from "./vision.js";
 export type { ImageBlock } from "./vision.js";
+// L1-01 — per-role routing + cost/token accounting (ADR-0011).
+export { structuredInvoker, meteredInvoker, retryInvoke, CallBudget, cappedInvoke } from "./structured.js";
+export type { StructuredInvoke } from "./structured.js";
+export { RoleRouter, resolveRoleTier, KNOWN_ROLES } from "./routing.js";
+export { CostLedger, DEFAULT_PRICING, priceFor, extractUsage } from "./cost.js";
+export type { CostReport, RoleCost, TokenUsage, ModelPrice } from "./cost.js";

--- a/src/llm/routing.ts
+++ b/src/llm/routing.ts
@@ -1,0 +1,58 @@
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import type { AppConfig, ModelTier, RolesConfig } from "../config/index.js";
+import { makeModel, type ProviderKeys } from "./factory.js";
+import { meteredInvoker, cappedInvoke, retryInvoke } from "./structured.js";
+import type { CallBudget, StructuredInvoke } from "./structured.js";
+import { CostLedger, type ModelPrice } from "./cost.js";
+
+/**
+ * Routable roles (L1-01, ADR-0011). The cheap LLM-as-judge scorer keeps the `judge`
+ * tier and is metered-only — NOT routable (it has the opposite cost intent).
+ */
+export const KNOWN_ROLES = ["worker", "reasoner"] as const;
+
+/** Pure: which tier does this role use? An explicit override (`roles[role]`) wins, else the fallback. */
+export function resolveRoleTier(
+  role: string,
+  fallback: ModelTier,
+  roles: RolesConfig | undefined,
+): ModelTier {
+  return (roles?.[role as (typeof KNOWN_ROLES)[number]] as ModelTier | undefined) ?? fallback;
+}
+
+type ModelFactory = (tier: ModelTier, keys: ProviderKeys) => BaseChatModel;
+
+/**
+ * Builds per-step metered invokers over `makeModel(tier)` and owns the per-role
+ * {@link CostLedger}. One per run, a sibling of `CallBudget`. The model factory is
+ * injectable so the router is unit-testable without the SDK.
+ */
+export class RoleRouter {
+  readonly ledger: CostLedger;
+
+  constructor(
+    private readonly cfg: AppConfig,
+    private readonly keys: ProviderKeys,
+    private readonly budget: CallBudget,
+    pricing?: Record<string, ModelPrice>,
+    private readonly makeModelFn: ModelFactory = makeModel,
+  ) {
+    this.ledger = new CostLedger(pricing);
+  }
+
+  /** Resolved tier for a role: the routing override if present, else the given fallback tier. */
+  tierFor(role: string, fallback: ModelTier): ModelTier {
+    return resolveRoleTier(role, fallback, this.cfg.roles);
+  }
+
+  /**
+   * A `StructuredInvoke` for an already-resolved tier, metered under `role` and wrapped
+   * with the existing retry + call-budget guardrails. Drop-in for the old
+   * `cappedInvoke(retryInvoke(structuredInvoker(makeModel(tier, keys))), budget)`.
+   */
+  invoke(role: string, tier: ModelTier): StructuredInvoke {
+    const model = this.makeModelFn(tier, this.keys);
+    const metered = meteredInvoker(model, (u, m) => this.ledger.record(role, m, u), tier.model);
+    return cappedInvoke(retryInvoke(metered), this.budget);
+  }
+}

--- a/src/llm/structured.ts
+++ b/src/llm/structured.ts
@@ -1,6 +1,7 @@
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import type { BaseMessageLike } from "@langchain/core/messages";
 import type { ZodType } from "zod";
+import { extractUsage, type TokenUsage } from "./cost.js";
 
 /**
  * Structured-call seam: (schema, messages) → typed result.
@@ -13,6 +14,28 @@ export function structuredInvoker(model: BaseChatModel): StructuredInvoke {
   return async <T>(schema: ZodType<T>, messages: BaseMessageLike[]): Promise<T> => {
     const structured = model.withStructuredOutput(schema);
     return (await structured.invoke(messages)) as T;
+  };
+}
+
+/**
+ * Like {@link structuredInvoker}, but captures token usage off the raw LangChain response
+ * (via `withStructuredOutput(..., { includeRaw: true })`) and reports it to `onUsage` (L1-01).
+ * Node logic is unchanged — callers still receive the parsed result. Metering never throws.
+ */
+export function meteredInvoker(
+  model: BaseChatModel,
+  onUsage: (usage: TokenUsage, model: string) => void,
+  modelId: string,
+): StructuredInvoke {
+  return async <T>(schema: ZodType<T>, messages: BaseMessageLike[]): Promise<T> => {
+    const structured = model.withStructuredOutput(schema, { includeRaw: true });
+    const res = (await structured.invoke(messages)) as { raw: unknown; parsed: T };
+    try {
+      onUsage(extractUsage(res.raw), modelId);
+    } catch {
+      // metering must never break the underlying call
+    }
+    return res.parsed;
   };
 }
 

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -126,3 +126,75 @@ describe("loadConfig — browser and maxRepair", () => {
     expect(loadConfig({ ...baseEnv, QA_TESTCASE_LANG: "Deutsch" }).testCaseLanguage).toBe("Deutsch");
   });
 });
+
+describe("loadConfig — per-role routing is additive + backward-compatible (L1-01)", () => {
+  it("no routing config → roles undefined, profile/tier map unchanged (behaves as today)", () => {
+    const cfg = loadConfig({ ...baseEnv, LLM_PROFILE: "anthropic" });
+    expect(cfg.roles).toBeUndefined();
+    expect(cfg.models.reasoning.model).toBe("claude-opus-4-8");
+    expect(cfg.models.bulk.model).toBe("claude-sonnet-4-6");
+    expect(cfg.models.judge.model).toBe("claude-haiku-4-5");
+  });
+
+  it("every LLM_PROFILE still resolves its tier map unchanged (no roles)", () => {
+    expect(loadConfig({ ...baseEnv, LLM_PROFILE: "openrouter" }).roles).toBeUndefined();
+    expect(loadConfig({ ...baseEnv, LLM_PROFILE: "mixed" }).roles).toBeUndefined();
+  });
+
+  it("LLM_ROUTING=volume → worker=OpenRouter (cheap), reasoner=Anthropic (smart)", () => {
+    const cfg = loadConfig({ ...baseEnv, LLM_ROUTING: "volume" });
+    expect(cfg.roles?.worker?.provider).toBe("openrouter");
+    expect(cfg.roles?.worker?.model).toBe("deepseek/deepseek-chat");
+    expect(cfg.roles?.reasoner?.provider).toBe("anthropic");
+    expect(cfg.roles?.reasoner?.model).toBe("claude-opus-4-8");
+    // routing does NOT touch the profile tiers (incl. the cheap judge scorer)
+    expect(cfg.models.judge.model).toBe("claude-haiku-4-5");
+  });
+
+  it("missing provider key for a routed role → error names ROLE + PROVIDER", () => {
+    // volume routes worker→OpenRouter, but only ANTHROPIC_API_KEY is set
+    expect(() => loadConfig({ ANTHROPIC_API_KEY: "a", LLM_ROUTING: "volume" })).toThrow(
+      /Role 'worker'.*OpenRouter/i,
+    );
+  });
+
+  it("CAIRN_ROLE_WORKER=provider:model remaps the role", () => {
+    const cfg = loadConfig({ ...baseEnv, CAIRN_ROLE_WORKER: "openrouter:deepseek/deepseek-chat" });
+    expect(cfg.roles?.worker).toEqual({
+      provider: "openrouter",
+      model: "deepseek/deepseek-chat",
+      supportsVision: false,
+    });
+    expect(cfg.roles?.reasoner).toBeUndefined(); // unset role falls back to the tier default
+  });
+
+  it("explicit override composes over a preset (override wins)", () => {
+    const cfg = loadConfig({
+      ...baseEnv,
+      LLM_ROUTING: "volume",
+      CAIRN_ROLE_REASONER: "openrouter:deepseek/deepseek-r1",
+    });
+    expect(cfg.roles?.worker?.provider).toBe("openrouter"); // from preset
+    expect(cfg.roles?.reasoner?.model).toBe("deepseek/deepseek-r1"); // overridden
+  });
+
+  it("unknown role in CAIRN_ROLE_* → warning + ignored (falls back to default)", () => {
+    const warn = vi.fn();
+    const cfg = loadConfig({ ...baseEnv, CAIRN_ROLE_TYPO: "anthropic:claude-opus-4-8" }, { warn });
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/unknown role/i));
+    expect(cfg.roles).toBeUndefined();
+  });
+
+  it("unknown LLM_ROUTING preset → warning + no routing (graceful)", () => {
+    const warn = vi.fn();
+    const cfg = loadConfig({ ...baseEnv, LLM_ROUTING: "bogus" }, { warn });
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/unknown.*routing preset/i));
+    expect(cfg.roles).toBeUndefined();
+  });
+
+  it("invalid provider in CAIRN_ROLE_* → clear error", () => {
+    expect(() => loadConfig({ ...baseEnv, CAIRN_ROLE_WORKER: "groq:llama" })).toThrow(
+      /Invalid provider 'groq'/i,
+    );
+  });
+});

--- a/tests/unit/cost.test.ts
+++ b/tests/unit/cost.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { CostLedger, extractUsage, priceFor, DEFAULT_PRICING } from "../../src/llm/cost.js";
+
+const PRICES = {
+  "m-cheap": { inputPer1M: 1, outputPer1M: 2 },
+  "m-pricey": { inputPer1M: 10, outputPer1M: 30 },
+};
+
+describe("priceFor", () => {
+  it("known model → price; unknown → undefined", () => {
+    expect(priceFor("m-cheap", PRICES)).toEqual({ inputPer1M: 1, outputPer1M: 2 });
+    expect(priceFor("nope", PRICES)).toBeUndefined();
+  });
+  it("default table prices the Anthropic profile models (claude-api skill)", () => {
+    expect(priceFor("claude-opus-4-8", DEFAULT_PRICING)).toEqual({ inputPer1M: 5, outputPer1M: 25 });
+    expect(priceFor("claude-sonnet-4-6", DEFAULT_PRICING)).toEqual({ inputPer1M: 3, outputPer1M: 15 });
+    expect(priceFor("claude-haiku-4-5", DEFAULT_PRICING)).toEqual({ inputPer1M: 1, outputPer1M: 5 });
+  });
+});
+
+describe("extractUsage — reads usage off a LangChain message, never throws", () => {
+  it("reads usage_metadata (LangChain-normalized)", () => {
+    expect(extractUsage({ usage_metadata: { input_tokens: 100, output_tokens: 40 } })).toEqual({
+      inputTokens: 100,
+      outputTokens: 40,
+    });
+  });
+  it("falls back to response_metadata.usage (OpenAI/OpenRouter shape)", () => {
+    expect(extractUsage({ response_metadata: { usage: { prompt_tokens: 7, completion_tokens: 3 } } })).toEqual({
+      inputTokens: 7,
+      outputTokens: 3,
+    });
+  });
+  it("response_metadata.usage with input_tokens/output_tokens (Anthropic-via-LC shape)", () => {
+    expect(extractUsage({ response_metadata: { usage: { input_tokens: 9, output_tokens: 4 } } })).toEqual({
+      inputTokens: 9,
+      outputTokens: 4,
+    });
+  });
+  it("response_metadata.tokenUsage (camelCase fallback)", () => {
+    expect(extractUsage({ response_metadata: { tokenUsage: { promptTokens: 11, completionTokens: 6 } } })).toEqual({
+      inputTokens: 11,
+      outputTokens: 6,
+    });
+  });
+  it("partial usage_metadata (only input) → output zero", () => {
+    expect(extractUsage({ usage_metadata: { input_tokens: 8 } })).toEqual({ inputTokens: 8, outputTokens: 0 });
+  });
+  it("missing usage → zeros", () => {
+    expect(extractUsage({})).toEqual({ inputTokens: 0, outputTokens: 0 });
+    expect(extractUsage(undefined)).toEqual({ inputTokens: 0, outputTokens: 0 });
+  });
+});
+
+describe("CostLedger — per-role attribution sums correctly", () => {
+  it("sums tokens + cost per role across calls", () => {
+    const led = new CostLedger(PRICES);
+    led.record("worker", "m-cheap", { inputTokens: 1_000_000, outputTokens: 500_000 }); // 1*1 + 0.5*2 = 2
+    led.record("worker", "m-cheap", { inputTokens: 1_000_000, outputTokens: 0 }); // +1 = 3
+    led.record("reasoner", "m-pricey", { inputTokens: 100_000, outputTokens: 100_000 }); // 0.1*10 + 0.1*30 = 4
+    const rep = led.report();
+
+    const worker = rep.perRole.find((r) => r.role === "worker");
+    expect(worker?.calls).toBe(2);
+    expect(worker?.inputTokens).toBe(2_000_000);
+    expect(worker?.outputTokens).toBe(500_000);
+    expect(worker?.totalTokens).toBe(2_500_000);
+    expect(worker?.costUsd).toBeCloseTo(3, 6);
+
+    const reasoner = rep.perRole.find((r) => r.role === "reasoner");
+    expect(reasoner?.costUsd).toBeCloseTo(4, 6);
+
+    expect(rep.totalTokens).toBe(2_700_000);
+    expect(rep.totalCostUsd).toBeCloseTo(7, 6);
+  });
+
+  it("orders roles worker, reasoner, judge", () => {
+    const led = new CostLedger(PRICES);
+    led.record("judge", "m-cheap", { inputTokens: 1, outputTokens: 1 });
+    led.record("reasoner", "m-cheap", { inputTokens: 1, outputTokens: 1 });
+    led.record("worker", "m-cheap", { inputTokens: 1, outputTokens: 1 });
+    expect(led.report().perRole.map((r) => r.role)).toEqual(["worker", "reasoner", "judge"]);
+  });
+
+  it("unknown model price → role costUsd null + total null; tokens still counted (graceful, ADR-0002)", () => {
+    const led = new CostLedger(PRICES);
+    led.record("worker", "mystery/model", { inputTokens: 1000, outputTokens: 1000 });
+    led.record("reasoner", "m-pricey", { inputTokens: 1_000_000, outputTokens: 0 }); // 10
+    const rep = led.report();
+
+    const worker = rep.perRole.find((r) => r.role === "worker");
+    expect(worker?.costUsd).toBeNull();
+    expect(worker?.inputTokens).toBe(1000);
+    expect(worker?.models).toEqual(["mystery/model"]);
+
+    const reasoner = rep.perRole.find((r) => r.role === "reasoner");
+    expect(reasoner?.costUsd).toBeCloseTo(10, 6); // known prices still computed per-role
+
+    expect(rep.totalCostUsd).toBeNull(); // any unknown → total unknown
+    expect(rep.totalTokens).toBe(1_002_000);
+  });
+});

--- a/tests/unit/report.test.ts
+++ b/tests/unit/report.test.ts
@@ -52,4 +52,49 @@ describe("renderReportMd", () => {
     expect(md).toContain("Metrics");
     expect(md).toContain("grounding");
   });
+
+  it("renders a per-role Cost section when cost is provided (L1-01)", () => {
+    const md = renderReportMd({
+      runId: "r2",
+      url: "http://x/app",
+      backend: "lib",
+      profile: "anthropic",
+      pageSemantics: "App",
+      elements: [btn],
+      testCases: [],
+      cost: {
+        perRole: [
+          { role: "worker", models: ["deepseek/deepseek-chat"], calls: 2, inputTokens: 1000, outputTokens: 500, totalTokens: 1500, costUsd: 0.001 },
+          { role: "reasoner", models: ["claude-opus-4-8"], calls: 1, inputTokens: 800, outputTokens: 400, totalTokens: 1200, costUsd: 0.014 },
+        ],
+        totalTokens: 2700,
+        totalCostUsd: 0.015,
+      },
+    });
+    expect(md).toContain("Cost (per role)");
+    expect(md).toContain("worker");
+    expect(md).toContain("reasoner");
+    expect(md).toContain("deepseek/deepseek-chat");
+    expect(md).toContain("$0.0140");
+    expect(md).toContain("$0.0150"); // total
+  });
+
+  it("renders '—' for an unknown (null) cost without crashing", () => {
+    const md = renderReportMd({
+      runId: "r3",
+      url: "http://x/app",
+      backend: "lib",
+      profile: "openrouter",
+      pageSemantics: "App",
+      elements: [],
+      testCases: [],
+      cost: {
+        perRole: [{ role: "worker", models: ["mystery"], calls: 1, inputTokens: 10, outputTokens: 5, totalTokens: 15, costUsd: null }],
+        totalTokens: 15,
+        totalCostUsd: null,
+      },
+    });
+    expect(md).toContain("Cost (per role)");
+    expect(md).toMatch(/\bworker\b.*—/);
+  });
 });

--- a/tests/unit/routing.test.ts
+++ b/tests/unit/routing.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { meteredInvoker, CallBudget } from "../../src/llm/structured.js";
+import { resolveRoleTier, RoleRouter, KNOWN_ROLES } from "../../src/llm/routing.js";
+import type { AppConfig, ModelTier } from "../../src/config/index.js";
+
+const vision: ModelTier = { provider: "anthropic", model: "claude-haiku-4-5", supportsVision: true };
+const bulk: ModelTier = { provider: "anthropic", model: "claude-sonnet-4-6", supportsVision: false };
+const okSchema = z.object({ ok: z.number() });
+
+/** Minimal fake BaseChatModel whose structured call returns {raw, parsed}. */
+function fakeModel(parsed: unknown, raw: unknown): BaseChatModel {
+  return {
+    withStructuredOutput: () => ({ invoke: async () => ({ raw, parsed }) }),
+  } as unknown as BaseChatModel;
+}
+
+describe("meteredInvoker", () => {
+  it("returns the parsed result AND reports usage to the callback", async () => {
+    const seen: Array<{ usage: unknown; model: string }> = [];
+    const model = fakeModel({ ok: 1 }, { usage_metadata: { input_tokens: 12, output_tokens: 5 } });
+    const invoke = meteredInvoker(model, (usage, m) => seen.push({ usage, model: m }), "deepseek/deepseek-chat");
+    const out = await invoke(okSchema, []);
+    expect(out).toEqual({ ok: 1 });
+    expect(seen).toEqual([{ usage: { inputTokens: 12, outputTokens: 5 }, model: "deepseek/deepseek-chat" }]);
+  });
+
+  it("a throwing usage callback never breaks the call", async () => {
+    const model = fakeModel({ ok: 2 }, {});
+    const invoke = meteredInvoker(
+      model,
+      () => {
+        throw new Error("boom");
+      },
+      "m",
+    );
+    await expect(invoke(okSchema, [])).resolves.toEqual({ ok: 2 });
+  });
+});
+
+describe("resolveRoleTier — override ?? fallback (backward-compat)", () => {
+  it("no routing → returns the fallback tier unchanged", () => {
+    expect(resolveRoleTier("worker", vision, undefined)).toBe(vision);
+  });
+  it("override present → returns the override tier", () => {
+    const ovr: ModelTier = { provider: "openrouter", model: "deepseek/deepseek-chat", supportsVision: false };
+    expect(resolveRoleTier("worker", vision, { worker: ovr })).toBe(ovr);
+  });
+  it("KNOWN_ROLES is worker + reasoner only (judge is not routable)", () => {
+    expect([...KNOWN_ROLES]).toEqual(["worker", "reasoner"]);
+  });
+});
+
+describe("RoleRouter — meters per role, falls back per tier", () => {
+  const baseCfg = {
+    llmProfile: "anthropic",
+    models: { reasoning: bulk, bulk, judge: bulk, vision },
+    langfuse: { enabled: false },
+    browser: { backend: "lib" },
+    maxRepair: 0,
+    testCaseLanguage: "English",
+  } as unknown as AppConfig;
+
+  it("tierFor resolves the override for a routed role", () => {
+    const cfg = { ...baseCfg, roles: { worker: { provider: "openrouter", model: "x", supportsVision: false } } } as AppConfig;
+    const router = new RoleRouter(cfg, { anthropicApiKey: "k", openrouterApiKey: "k" }, new CallBudget(80));
+    expect(router.tierFor("worker", vision).model).toBe("x");
+    expect(router.tierFor("reasoner", bulk).model).toBe(bulk.model); // no override → fallback
+  });
+
+  it("invoke meters usage under the named role via the injected model factory", async () => {
+    const fake = () => fakeModel({ ok: 1 }, { usage_metadata: { input_tokens: 4, output_tokens: 2 } });
+    const router = new RoleRouter(
+      baseCfg,
+      { anthropicApiKey: "k" },
+      new CallBudget(80),
+      undefined,
+      fake,
+    );
+    const inv = router.invoke("reasoner", bulk);
+    await inv(okSchema, []);
+    const reasoner = router.ledger.report().perRole.find((r) => r.role === "reasoner");
+    expect(reasoner?.calls).toBe(1);
+    expect(reasoner?.inputTokens).toBe(4);
+    expect(reasoner?.outputTokens).toBe(2);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
         "src/validate/index.ts",
         "src/prompts/index.ts",
         "src/llm/structured.ts",
+        "src/llm/cost.ts",
       ],
       thresholds: { lines: 80, functions: 80, branches: 75, statements: 80 },
     },


### PR DESCRIPTION
Closes #6.

A **thin named-role layer over the existing tier map** (`makeModel(tier)`) + **per-run, per-role cost & token reporting** captured from each LangChain response. Pure routing + reporting — the pipeline, agent logic, and node behavior are unchanged. `LLM_PROFILE` keeps working exactly as before; routing is additive over `cfg.models` and absent by default. Decision recorded in **[ADR-0011](docs/adr/0011-per-role-model-routing.md)**.

## Role → tier mapping

| Step | LLM? | Role | Default tier (no routing) | `anthropic` model |
|---|---|---|---|---|
| observe (capture) | no | — | — | — |
| identifyElements (analyzePage) | yes | `worker` | `vision ?? reasoning` | Haiku |
| verifyLocators / exploreStates / probeInteractions | no | — | — | — |
| designTestCases | yes | `reasoner` | `reasoning` | Opus |
| generateCode | yes | `worker` | `bulk` | Sonnet |
| validate | no | — | — | — |
| repair (regenerate) | yes | `worker` | `bulk` | Sonnet |
| judgeTestCases / judgeChecklistCoverage | yes | `judge`¹ | `judge` (unchanged) | Haiku |
| pilotReview (Pilot verdict) | yes | `reasoner` | `reasoning` **(was `judge`)** | Opus **(was Haiku)** |

¹ `judge` is **metered-only**, not routable: it is the cheap LLM-as-judge scorer and stays on `cfg.models.judge`. Only `worker` and `reasoner` accept overrides/presets — the distinct names avoid the clash with the existing config tier `judge` (opposite cost intent, called out in the issue).

`resolveRoleTier(role, fallback, cfg.roles) = cfg.roles[role] ?? fallback` — with no routing config every role resolves to today's tier, so backward-compat holds by construction.

## ⚠️ Pilot behavior change (intended)

The **Pilot verdict now runs on the strong `reasoner` role** instead of the cheap `judge` tier — the "smart judge" the issue asks for. This raises Pilot cost on the default profile. **Verified live:** the `reasoner` bucket shows **2 calls** = `designTestCases` + Pilot (before L1-01, Pilot would have landed in the `judge` bucket).

## Config / env (backward-compatible)

- `LLM_ROUTING=<preset>` — built-in **`volume`** = `worker`→cheap OpenRouter (`deepseek/deepseek-chat`) + `reasoner`→Anthropic (`claude-opus-4-8`). Composes with any `LLM_PROFILE` (the judge tier still comes from the profile).
- `CAIRN_ROLE_WORKER` / `CAIRN_ROLE_REASONER` = `provider:model` — explicit overrides (win over a preset).
- Graceful: unknown preset / unknown role → **warn + fall back** to the tier default; a routed role with a missing provider key → error **naming role + provider**.
- CLI: `--routing <preset>` on `explore` / `design` / `automate`.

## Cost / token plumbing (new — the largest item)

`CallBudget` counted calls only and `structuredInvoker` dropped usage. Added:
- `meteredInvoker` — reads usage off the response via `withStructuredOutput(schema, { includeRaw: true })` (`usage_metadata` → `response_metadata.usage`/`tokenUsage` → 0); never throws.
- `CostLedger` — sibling of `CallBudget` (one per run, owned by `RoleRouter`); attributes usage to the role, prices it, renders `perRole` + totals into **`report.md`**, **`report.json`**, the **CLI summary**, and the public `ExploreResult/DesignResult/AutomateResult.cost`.
- Pricing: Anthropic list prices authoritative; OpenRouter approximate/movable (ADR-0002) — a model with no price shows tokens with `null`/`n/a` cost, never a crash.

## Backward-compat test result

`tests/unit/config.test.ts` → *"no routing config → roles undefined, profile/tier map unchanged (behaves as today)"* and *"every LLM_PROFILE still resolves its tier map unchanged (no roles)"* both **green**. All existing profile/key/Langfuse/CAIRN-prefix tests untouched and passing. **184 tests pass** (44 files); `npm run build` / `npm run lint` / `npm run test:coverage` all clean (coverage gate green; `src/llm/cost.ts` added to the gated set).

## Live verification

`ANTHROPIC_API_KEY` is not configured locally (only `OPENROUTER_API_KEY`), so the exact `volume`/`anthropic` presets — both of which need Anthropic — can't run live here. Strongest available live proof: an **all-OpenRouter `cairn explore`** against a public no-auth target (`https://example.com`) with both roles overridden, real LLM calls:

```
=== Cost (per role) ===
  worker    2 call(s)  1094→103 tok  $0.0004
  reasoner  2 call(s)  1017→643 tok  $0.0009   ← designTestCases + Pilot
  judge     1 call(s)  325→120 tok  $0.0002    ← cheap scorer, profile tier (qwen)
  total     3302 tok  $0.0014
```

`report.json` carries the same structure. The `volume`/`anthropic` resolution and the missing-key error path are covered by unit tests.

## Checklist

- [x] Role → model map with sensible defaults; `worker` + `reasoner` over the tier map
- [x] `LLM_PROFILE` unchanged; routing additive + backward-compatible
- [x] Graceful fallback: role with no explicit model → profile/tier default
- [x] Per-run summary: cost + tokens **per role** in `report.ts` + `report.json` (+ CLI)
- [x] `volume` preset (cheap OpenRouter worker + Anthropic reasoner)
- [x] Edge-case tests: no-routing backward-compat · missing key → role+provider error · unknown role → warn+fallback · cost attribution sums correctly
- [x] `npm run build` / `npm test` (184) / `npm run lint` / `npm run test:coverage` green
- [x] Live: per-role cost + tokens shown on a real (all-OpenRouter) run
- [ ] `cairn explore` on the **login-gated demo target** with `volume` AND `anthropic` — blocked on a captured session (#27) and a local Anthropic key

## Out of scope (boundary)

Cairn = generation layer; Plune = record/eval layer. The volume/Groq one-flag preset (#7) and the cost/hour README benchmark (#8) are **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
