### PR TITLE
L1-02 — Groq provider + one-flag `fast` routing preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,9 @@ no arguments prints help instead of starting the UI.
 
 | Var | Purpose |
 |---|---|
-| `LLM_PROFILE` | `anthropic` \| `openrouter` \| `mixed` |
-| `ANTHROPIC_API_KEY` / `OPENROUTER_API_KEY` | provider keys (per profile) |
+| `LLM_PROFILE` | `anthropic` \| `openrouter` \| `mixed` (per-tier default models) |
+| `LLM_ROUTING` | per-role preset: `fast` (Groq worker) \| `volume` (OpenRouter worker) — see [Role routing](#role-routing) |
+| `ANTHROPIC_API_KEY` / `OPENROUTER_API_KEY` / `GROQ_API_KEY` | provider keys (per profile / routing) |
 | `QA_TESTCASE_LANG` | test-case language (default `English`; e.g. `Ukrainian`, `uk`) |
 | `LANGFUSE_BASE_URL` / `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` | Langfuse — **cloud or self-hosted** (optional; see [below](#optional-langfuse)) |
 | `BROWSER_BACKEND` | `lib` (in-process Playwright) \| `cli` |
@@ -153,6 +154,12 @@ no arguments prints help instead of starting the UI.
 | `MAX_REPAIR` | repair attempts (default 2) |
 
 - **Env var prefix:** every variable above is read as-is **or** with a `CAIRN_` prefix (e.g. `CAIRN_LLM_PROFILE`, `CAIRN_MAX_REPAIR`). Legacy `LEX_`/`LEXBOT_` prefixes still work but print a one-time deprecation warning — prefer `CAIRN_`.
+- <a id="role-routing"></a>**Role routing (`LLM_ROUTING`, optional):** layer a cheap **worker** over any profile while keeping the strong **reasoner**. One flag picks where the mechanical steps (identify-elements, generate-code/repair) run:
+  - `fast` → worker on **Groq** `llama-3.3-70b-versatile` — lowest latency/cost, OpenAI-compatible tool-calling.
+  - `volume` → worker on **OpenRouter** `deepseek/deepseek-chat` — model breadth.
+  - default (unset) → the profile's own per-tier models.
+
+  In **every** preset the reasoner (design test cases + Pilot verdict) stays on **Anthropic** `claude-opus-4-8` for judgment quality, and the cheap `judge` scorer keeps the profile tier (routing never touches it). Override any role with `CAIRN_ROLE_WORKER` / `CAIRN_ROLE_REASONER=provider:model`; pass `--routing <preset>` on `explore`/`design`/`automate` to set it per run. Per-run **per-role cost** (tokens + $) is printed in the run summary.
 - **Domain knowledge:** put `*.md` files in `./knowledge/` with a `url:` front-matter to inject credentials/validation rules into design.
 - **Prompt overrides:** drop `./prompts/<name>.md` to override any built-in prompt without rebuilding.
 

--- a/docs/adr/0002-llm-anthropic-tiering.md
+++ b/docs/adr/0002-llm-anthropic-tiering.md
@@ -1,6 +1,6 @@
 # ADR-0002: Multi-provider LLM layer (Anthropic + OpenRouter) with tier×provider mapping
 
-- **Status:** Accepted · **Revised:** 2026-06-08 (expanded from "Anthropic only" to multi-provider)
+- **Status:** Accepted · **Revised:** 2026-06-13 (L1-02: Groq added as a third OpenAI-compatible provider) · 2026-06-08 (expanded from "Anthropic only" to multi-provider)
 - **Decision in code:** `src/llm/` (provider-agnostic model factory)
 
 ## Context
@@ -17,6 +17,9 @@ A provider-agnostic factory `makeModel(tier)` that returns a LangChain `BaseChat
 - **Anthropic:** `ChatAnthropic` (`@langchain/anthropic`).
 - **OpenRouter:** `ChatOpenAI` (`@langchain/openai`) with `configuration.baseURL = "https://openrouter.ai/api/v1"`
   and `apiKey = OPENROUTER_API_KEY` (OpenRouter is an OpenAI-compatible API). Optional headers `HTTP-Referer`/`X-Title`.
+- **Groq (L1-02):** also `ChatOpenAI` with `configuration.baseURL = "https://api.groq.com/openai/v1"` and
+  `apiKey = GROQ_API_KEY` — Groq is OpenAI-compatible too, so it **reuses the same adapter, no new dependency**.
+  Surfaced as the `fast` routing preset's worker (lowest latency/cost); see the ADR-0011 addendum.
 
 The config maps **each tier → `{ provider, model, supportsVision }`**. Profiles (examples, configurable):
 

--- a/docs/adr/0011-per-role-model-routing.md
+++ b/docs/adr/0011-per-role-model-routing.md
@@ -31,7 +31,7 @@ The cheap LLM-as-judge scorer (`judgeTestCases`, `judgeChecklistCoverage`) keeps
 
 ### 2. Config / env override (additive over `LLM_PROFILE`)
 
-- `LLM_ROUTING=<preset>` selects a named **routing preset**. Built-in: **`volume`** = `worker`→cheap OpenRouter (`deepseek/deepseek-chat`) + `reasoner`→Anthropic (`claude-opus-4-8`).
+- `LLM_ROUTING=<preset>` selects a named **routing preset**. Built-in: **`volume`** = `worker`→cheap OpenRouter (`deepseek/deepseek-chat`) + `reasoner`→Anthropic (`claude-opus-4-8`); **`fast`** = `worker`→Groq (`llama-3.3-70b-versatile`) + `reasoner`→Anthropic (`claude-opus-4-8`) — see the L1-02 addendum.
 - `CAIRN_ROLE_WORKER` / `CAIRN_ROLE_REASONER` = `provider:model` give explicit per-role overrides (which win over a preset).
 - `LLM_PROFILE` still selects the tier map unchanged; routing layers on top (`cfg.roles?`). Unknown preset / unknown role → **warn + fall back** to the tier default. A routed role with a missing provider key → error naming **role + provider**.
 - CLI: `--routing <preset>` on `explore` / `design` / `automate`.
@@ -57,3 +57,9 @@ The cheap LLM-as-judge scorer (`judgeTestCases`, `judgeChecklistCoverage`) keeps
 - **Make `volume` a new `LLM_PROFILE`** — a profile is a *tier* map; `volume` is *role* intent, and lives orthogonally to the profile so it composes with any tier map (incl. the cheap `judge` scorer staying on the profile).
 - **Route `observe`/`ground`** — they make no LLM calls; routing there is a no-op.
 - **Track cost in Langfuse only** — Langfuse is self-hosted and optional; the run summary must work offline, so the ledger is SDK-side.
+
+## Addendum — L1-02: Groq provider + `fast` preset (2026-06-13)
+
+- **Issue:** [L1-02 (#7)](https://github.com/plune-ai/cairn/issues/7) · **In code:** `src/llm/factory.ts` (`GROQ_BASE_URL`, groq `ModelSpec`/`resolveModelSpec`), `src/config/{schema,profiles,index}.ts`, `src/llm/cost.ts`
+
+Groq joins Anthropic and OpenRouter as a **third provider**. Like OpenRouter it is **OpenAI-compatible**, so it reuses `ChatOpenAI` with `configuration.baseURL = https://api.groq.com/openai/v1` — **no new dependency** (the `makeModel` ChatOpenAI branch already covers it once the spec carries a `baseURL`; only `resolveModelSpec` gains a groq branch for the key + URL). A new built-in preset **`fast`** sets `worker`→Groq `llama-3.3-70b-versatile` and keeps `reasoner`→Anthropic `claude-opus-4-8`. The worker model is a **current Groq production model with tool/function-calling support** — non-negotiable, because the worker steps `identifyElements`/`generateCode` call `withStructuredOutput(…, { includeRaw: true })`, which compiles to function calling on OpenAI-compatible endpoints; a model without it would break structured output. As with `volume`, the Groq worker is text-only ⇒ `identifyElements` falls back to aria-only (vision-optional, ADR-0002). `volume` (OpenRouter worker) is **unchanged**, and both presets still compose with `LLM_PROFILE` and stay overridable via `CAIRN_ROLE_*`. `GROQ_API_KEY` (also `CAIRN_GROQ_API_KEY`) is read through the same `createEnvReader`; a `fast` run without it errors naming **role `worker` + `GROQ_API_KEY`**. Groq pricing in `DEFAULT_PRICING` is **approximate/movable** like OpenRouter's — an unknown Groq model degrades to a **null cost** (tokens still counted), never a crash. The worker model id stays overridable, so when Groq rotates its production line-up the preset can follow without code changes.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -73,7 +73,7 @@ export interface ExploreResult {
  */
 export async function runExploration(input: ExploreInput): Promise<ExploreResult> {
   const cfg = input.config;
-  const keys = { anthropicApiKey: cfg.anthropicApiKey, openrouterApiKey: cfg.openrouterApiKey };
+  const keys = { anthropicApiKey: cfg.anthropicApiKey, openrouterApiKey: cfg.openrouterApiKey, groqApiKey: cfg.groqApiKey };
   const budget = new CallBudget(80); // cost-guardrail: safeguard (normally ~6-10 calls/run)
   const router = new RoleRouter(cfg, keys, budget); // L1-01: per-role routing + cost ledger
 
@@ -341,7 +341,7 @@ function suiteFromUrl(url: string): string {
  */
 export async function runDesign(input: ExploreInput): Promise<DesignResult> {
   const cfg = input.config;
-  const keys = { anthropicApiKey: cfg.anthropicApiKey, openrouterApiKey: cfg.openrouterApiKey };
+  const keys = { anthropicApiKey: cfg.anthropicApiKey, openrouterApiKey: cfg.openrouterApiKey, groqApiKey: cfg.groqApiKey };
   const budget = new CallBudget(80); // cost-guardrail: safeguard (normally ~6-10 calls/run)
   const router = new RoleRouter(cfg, keys, budget); // L1-01: per-role routing + cost ledger
   const logLines: string[] = [];
@@ -533,7 +533,7 @@ export async function runAutomate(input: {
   onProgress?: (event: string) => void;
 }): Promise<AutomateResult> {
   const cfg = input.config;
-  const keys = { anthropicApiKey: cfg.anthropicApiKey, openrouterApiKey: cfg.openrouterApiKey };
+  const keys = { anthropicApiKey: cfg.anthropicApiKey, openrouterApiKey: cfg.openrouterApiKey, groqApiKey: cfg.groqApiKey };
   const budget = new CallBudget(80); // cost-guardrail: safeguard (normally ~6-10 calls/run)
   const router = new RoleRouter(cfg, keys, budget); // L1-01: per-role routing + cost ledger
   const onProgress = input.onProgress ?? ((): void => undefined);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -86,7 +86,7 @@ program
   .option("--headed", "visible browser (debug)")
   .option("--checklist <file>", "checklist file (md/text) — guides what to test")
   .option("--style <s>", "planning style: happy | negative | coverage | all")
-  .option("--routing <preset>", "role-routing preset, e.g. volume (sets LLM_ROUTING)")
+  .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
   .action(
     async (opts: {
       url: string;
@@ -195,6 +195,7 @@ program
     const keys = {
       anthropicApiKey: config.anthropicApiKey,
       openrouterApiKey: config.openrouterApiKey,
+      groqApiKey: config.groqApiKey,
     };
     const ds = JSON.parse(await readFile(opts.dataset, "utf8")) as { items: DatasetItem[] };
 
@@ -249,7 +250,7 @@ program
   .option("--session-file <path>", "path to a storageState file")
   .option("--checklist <file>", "checklist file — guides what to test")
   .option("--style <s>", "planning style: happy | negative | coverage | all")
-  .option("--routing <preset>", "role-routing preset, e.g. volume (sets LLM_ROUTING)")
+  .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
   .option("--headed", "visible browser (debug)")
   .action(
     async (opts: {
@@ -302,7 +303,7 @@ program
   .option("--validate", "run the generated tests (a session is required)")
   .option("--session <name>", "session name for validation")
   .option("--session-file <path>", "path to storageState for validation")
-  .option("--routing <preset>", "role-routing preset, e.g. volume (sets LLM_ROUTING)")
+  .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
   .action(
     async (opts: { run: string; validate?: boolean; session?: string; sessionFile?: string; routing?: string }) => {
       const env: Record<string, string | undefined> = { ...process.env };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -40,6 +40,7 @@ export function loadConfig(
 
   const anthropicApiKey = read("ANTHROPIC_API_KEY");
   const openrouterApiKey = read("OPENROUTER_API_KEY");
+  const groqApiKey = read("GROQ_API_KEY"); // L1-02 — Groq key (also via CAIRN_GROQ_API_KEY).
   if (providers.has("anthropic") && !anthropicApiKey) {
     throw new Error(
       `Profile '${llmProfile}' uses Anthropic, but ANTHROPIC_API_KEY is not set.`,
@@ -64,6 +65,9 @@ export function loadConfig(
       }
       if (tier.provider === "openrouter" && !openrouterApiKey) {
         throw new Error(`Role '${role}' uses OpenRouter, but OPENROUTER_API_KEY is not set.`);
+      }
+      if (tier.provider === "groq" && !groqApiKey) {
+        throw new Error(`Role '${role}' uses Groq, but GROQ_API_KEY is not set.`);
       }
     }
   }
@@ -105,6 +109,7 @@ export function loadConfig(
     roles,
     anthropicApiKey,
     openrouterApiKey,
+    groqApiKey,
     langfuse: {
       enabled: langfuseEnabled,
       baseUrl: langfuseBaseUrl,
@@ -171,7 +176,7 @@ function parseRoleSpec(role: string, value: string): ModelTier {
   const provider = ProviderSchema.safeParse(providerRaw);
   if (!provider.success) {
     throw new Error(
-      `Invalid provider '${providerRaw}' for role '${role}' (allowed: anthropic | openrouter). ` +
+      `Invalid provider '${providerRaw}' for role '${role}' (allowed: anthropic | openrouter | groq). ` +
         `Use CAIRN_ROLE_${role.toUpperCase()}=provider:model.`,
     );
   }

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -35,6 +35,10 @@ export const PROFILES: Record<LlmProfile, ModelsConfig> = {
  *
  * `volume` = run cheaply at scale (Explorbot-style): the mechanical worker steps on a
  * cheap OpenRouter model, the judgment steps (designTestCases + Pilot verdict) on Claude.
+ *
+ * `fast` (L1-02) = the one-flag low-latency preset: the worker on Groq (lowest latency/cost,
+ * OpenAI-compatible tool-calling), the reasoner still on Claude Opus (keep judgment strong).
+ * Both presets compose with `LLM_PROFILE` and stay overridable via `CAIRN_ROLE_<NAME>`.
  */
 export const ROUTING_PRESETS: Record<string, RolesConfig> = {
   volume: {
@@ -42,6 +46,14 @@ export const ROUTING_PRESETS: Record<string, RolesConfig> = {
     // supportsVision:false → identifyElements falls back to aria-only (ADR-0002, vision-optional).
     worker: { provider: "openrouter", model: "deepseek/deepseek-chat", supportsVision: false },
     // reasoner = designTestCases + Pilot verdict → quality model.
+    reasoner: { provider: "anthropic", model: "claude-opus-4-8", supportsVision: false },
+  },
+  fast: {
+    // worker → Groq llama-3.3-70b-versatile: a current production model with tool/function-calling
+    // support (required by withStructuredOutput includeRaw). supportsVision:false → identifyElements
+    // falls back to aria-only (ADR-0002, vision-optional). Model id overridable via CAIRN_ROLE_WORKER.
+    worker: { provider: "groq", model: "llama-3.3-70b-versatile", supportsVision: false },
+    // reasoner = designTestCases + Pilot verdict → keep the quality model (Anthropic Opus).
     reasoner: { provider: "anthropic", model: "claude-opus-4-8", supportsVision: false },
   },
 };

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
-/** LLM provider (ADR-0002). */
-export const ProviderSchema = z.enum(["anthropic", "openrouter"]);
+/** LLM provider (ADR-0002; Groq added in L1-02). */
+export const ProviderSchema = z.enum(["anthropic", "openrouter", "groq"]);
 export type Provider = z.infer<typeof ProviderSchema>;
 
 /** Model settings for a single tier. */
@@ -56,6 +56,7 @@ export interface AppConfig {
   roles?: RolesConfig;
   anthropicApiKey?: string;
   openrouterApiKey?: string;
+  groqApiKey?: string;
   langfuse: LangfuseConfig;
   browser: { backend: BrowserBackend; channel?: string };
   maxRepair: number;

--- a/src/llm/cost.ts
+++ b/src/llm/cost.ts
@@ -30,6 +30,9 @@ export const DEFAULT_PRICING: Record<string, ModelPrice> = {
   "deepseek/deepseek-r1": { inputPer1M: 0.55, outputPer1M: 2.19 },
   "qwen/qwen-2.5-72b-instruct": { inputPer1M: 0.35, outputPer1M: 0.4 },
   "qwen/qwen-2-vl-72b-instruct": { inputPer1M: 0.4, outputPer1M: 0.4 },
+  // Groq — approximate, movable (L1-02; the lowest-latency `fast`-preset worker).
+  // Any Groq model absent here still yields a null cost (graceful), tokens are still counted.
+  "llama-3.3-70b-versatile": { inputPer1M: 0.59, outputPer1M: 0.79 },
 };
 
 export function priceFor(

--- a/src/llm/factory.ts
+++ b/src/llm/factory.ts
@@ -6,9 +6,13 @@ import type { ModelTier } from "../config/index.js";
 /** OpenRouter — OpenAI-compatible API; we connect via the ChatOpenAI baseURL (ADR-0002). */
 export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 
+/** Groq — also OpenAI-compatible; same ChatOpenAI + baseURL path, no new dependency (L1-02). */
+export const GROQ_BASE_URL = "https://api.groq.com/openai/v1";
+
 export interface ProviderKeys {
   anthropicApiKey?: string;
   openrouterApiKey?: string;
+  groqApiKey?: string;
 }
 
 /** Resolved model specification (pure result, no side effects). */
@@ -22,6 +26,14 @@ export type ModelSpec =
     }
   | {
       provider: "openrouter";
+      model: string;
+      apiKey: string;
+      baseURL: string;
+      temperature?: number;
+      supportsVision: boolean;
+    }
+  | {
+      provider: "groq";
       model: string;
       apiKey: string;
       baseURL: string;
@@ -42,6 +54,19 @@ export function resolveModelSpec(tier: ModelTier, keys: ProviderKeys): ModelSpec
       provider: "anthropic",
       model: tier.model,
       apiKey: keys.anthropicApiKey,
+      temperature: tier.temperature,
+      supportsVision: tier.supportsVision,
+    };
+  }
+  if (tier.provider === "groq") {
+    if (!keys.groqApiKey) {
+      throw new Error(`Tier '${tier.model}' requires Groq, but GROQ_API_KEY is not set.`);
+    }
+    return {
+      provider: "groq",
+      model: tier.model,
+      apiKey: keys.groqApiKey,
+      baseURL: GROQ_BASE_URL,
       temperature: tier.temperature,
       supportsVision: tier.supportsVision,
     };

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -1,4 +1,4 @@
-export { OPENROUTER_BASE_URL, resolveModelSpec, makeModel } from "./factory.js";
+export { OPENROUTER_BASE_URL, GROQ_BASE_URL, resolveModelSpec, makeModel } from "./factory.js";
 export type { ModelSpec, ProviderKeys } from "./factory.js";
 export { imageBlock } from "./vision.js";
 export type { ImageBlock } from "./vision.js";

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -151,6 +151,34 @@ describe("loadConfig — per-role routing is additive + backward-compatible (L1-
     expect(cfg.models.judge.model).toBe("claude-haiku-4-5");
   });
 
+  it("LLM_ROUTING=fast → worker=Groq (lowest latency/cost), reasoner=Anthropic (smart) (L1-02)", () => {
+    const cfg = loadConfig({ ...baseEnv, GROQ_API_KEY: "gsk-test", LLM_ROUTING: "fast" });
+    expect(cfg.roles?.worker?.provider).toBe("groq");
+    expect(cfg.roles?.worker?.model).toBe("llama-3.3-70b-versatile");
+    expect(cfg.roles?.reasoner?.provider).toBe("anthropic");
+    expect(cfg.roles?.reasoner?.model).toBe("claude-opus-4-8");
+    // routing does NOT touch the profile tiers (incl. the cheap judge scorer)
+    expect(cfg.models.judge.model).toBe("claude-haiku-4-5");
+  });
+
+  it("LLM_ROUTING=volume stays on OpenRouter, unchanged by L1-02 (no Groq leakage)", () => {
+    const cfg = loadConfig({ ...baseEnv, LLM_ROUTING: "volume" });
+    expect(cfg.roles?.worker?.provider).toBe("openrouter");
+    expect(cfg.roles?.worker?.model).toBe("deepseek/deepseek-chat");
+  });
+
+  it("fast preset without GROQ_API_KEY → error names ROLE 'worker' + GROQ_API_KEY (L1-02)", () => {
+    expect(() => loadConfig({ ANTHROPIC_API_KEY: "a", LLM_ROUTING: "fast" })).toThrow(
+      /Role 'worker'.*Groq/i,
+    );
+  });
+
+  it("CAIRN_GROQ_API_KEY satisfies the Groq worker key (env back-compat via createEnvReader)", () => {
+    const cfg = loadConfig({ ANTHROPIC_API_KEY: "a", CAIRN_GROQ_API_KEY: "g", LLM_ROUTING: "fast" });
+    expect(cfg.groqApiKey).toBe("g");
+    expect(cfg.roles?.worker?.provider).toBe("groq");
+  });
+
   it("missing provider key for a routed role → error names ROLE + PROVIDER", () => {
     // volume routes worker→OpenRouter, but only ANTHROPIC_API_KEY is set
     expect(() => loadConfig({ ANTHROPIC_API_KEY: "a", LLM_ROUTING: "volume" })).toThrow(
@@ -192,9 +220,22 @@ describe("loadConfig — per-role routing is additive + backward-compatible (L1-
     expect(cfg.roles).toBeUndefined();
   });
 
-  it("invalid provider in CAIRN_ROLE_* → clear error", () => {
-    expect(() => loadConfig({ ...baseEnv, CAIRN_ROLE_WORKER: "groq:llama" })).toThrow(
-      /Invalid provider 'groq'/i,
+  it("CAIRN_ROLE_WORKER=groq:model is now accepted (groq is a first-class provider, L1-02)", () => {
+    const cfg = loadConfig({
+      ANTHROPIC_API_KEY: "a",
+      GROQ_API_KEY: "g",
+      CAIRN_ROLE_WORKER: "groq:llama-3.3-70b-versatile",
+    });
+    expect(cfg.roles?.worker).toEqual({
+      provider: "groq",
+      model: "llama-3.3-70b-versatile",
+      supportsVision: false,
+    });
+  });
+
+  it("invalid provider in CAIRN_ROLE_* → clear error (still rejects non-providers)", () => {
+    expect(() => loadConfig({ ...baseEnv, CAIRN_ROLE_WORKER: "mistral:large" })).toThrow(
+      /Invalid provider 'mistral'/i,
     );
   });
 });

--- a/tests/unit/cost.test.ts
+++ b/tests/unit/cost.test.ts
@@ -16,6 +16,12 @@ describe("priceFor", () => {
     expect(priceFor("claude-sonnet-4-6", DEFAULT_PRICING)).toEqual({ inputPer1M: 3, outputPer1M: 15 });
     expect(priceFor("claude-haiku-4-5", DEFAULT_PRICING)).toEqual({ inputPer1M: 1, outputPer1M: 5 });
   });
+  it("default table prices the Groq fast-preset worker (L1-02, approximate/movable)", () => {
+    expect(priceFor("llama-3.3-70b-versatile", DEFAULT_PRICING)).toEqual({ inputPer1M: 0.59, outputPer1M: 0.79 });
+  });
+  it("unknown Groq model → undefined price (graceful; tokens still counted, ADR-0002)", () => {
+    expect(priceFor("groq/does-not-exist", DEFAULT_PRICING)).toBeUndefined();
+  });
 });
 
 describe("extractUsage — reads usage off a LangChain message, never throws", () => {

--- a/tests/unit/llm.test.ts
+++ b/tests/unit/llm.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { ChatOpenAI } from "@langchain/openai";
-import { resolveModelSpec, makeModel, imageBlock, OPENROUTER_BASE_URL } from "../../src/llm/index.js";
+import { resolveModelSpec, makeModel, imageBlock, OPENROUTER_BASE_URL, GROQ_BASE_URL } from "../../src/llm/index.js";
 import type { ModelTier } from "../../src/config/index.js";
 
 const anthropicTier: ModelTier = {
@@ -15,7 +15,12 @@ const openrouterTier: ModelTier = {
   model: "deepseek/deepseek-r1",
   supportsVision: false,
 };
-const keys = { anthropicApiKey: "sk-ant-test", openrouterApiKey: "sk-or-test" };
+const groqTier: ModelTier = {
+  provider: "groq",
+  model: "llama-3.3-70b-versatile",
+  supportsVision: false,
+};
+const keys = { anthropicApiKey: "sk-ant-test", openrouterApiKey: "sk-or-test", groqApiKey: "gsk-test" };
 
 describe("resolveModelSpec — pure provider resolution", () => {
   it("anthropic tier → spec without baseURL, with the Anthropic key", () => {
@@ -34,9 +39,18 @@ describe("resolveModelSpec — pure provider resolution", () => {
     expect(spec.provider === "openrouter" && spec.baseURL).toBe(OPENROUTER_BASE_URL);
   });
 
+  it("groq tier → spec with the Groq baseURL and Groq key (L1-02)", () => {
+    const spec = resolveModelSpec(groqTier, keys);
+    expect(spec.provider).toBe("groq");
+    expect(spec.model).toBe("llama-3.3-70b-versatile");
+    expect(spec.apiKey).toBe("gsk-test");
+    expect(spec.provider === "groq" && spec.baseURL).toBe(GROQ_BASE_URL);
+  });
+
   it("throws if the required provider key is missing", () => {
     expect(() => resolveModelSpec(anthropicTier, { openrouterApiKey: "x" })).toThrow(/ANTHROPIC_API_KEY/);
     expect(() => resolveModelSpec(openrouterTier, { anthropicApiKey: "x" })).toThrow(/OPENROUTER_API_KEY/);
+    expect(() => resolveModelSpec(groqTier, { anthropicApiKey: "x" })).toThrow(/GROQ_API_KEY/);
   });
 });
 
@@ -47,6 +61,10 @@ describe("makeModel — LangChain model instantiation", () => {
 
   it("openrouter tier → ChatOpenAI instance (via baseURL)", () => {
     expect(makeModel(openrouterTier, keys)).toBeInstanceOf(ChatOpenAI);
+  });
+
+  it("groq tier → ChatOpenAI instance (OpenAI-compatible, via baseURL) (L1-02)", () => {
+    expect(makeModel(groqTier, keys)).toBeInstanceOf(ChatOpenAI);
   });
 });
 


### PR DESCRIPTION
Closes #7. Child of the L1 cost epic — sibling of #6 / ADR-0011, which shipped the routing/preset/cost machinery this PR **extends** (no rebuild).

## What
Add **Groq** as a third LLM provider and a built-in **`fast`** routing preset: the mechanical *worker* runs on Groqs lowest-latency model, the *reasoner* stays on Anthropic for judgment quality. One flag (`LLM_ROUTING=fast` or `--routing fast`).

## Provider / preset diff
| Layer | Change |
|---|---|
| `config/schema.ts` | `ProviderSchema += groq`; `AppConfig.groqApiKey?` |
| `llm/factory.ts` | `GROQ_BASE_URL`, `ProviderKeys.groqApiKey?`, `groq` `ModelSpec` variant, `resolveModelSpec` groq branch (**`makeModel` unchanged** — the `ChatOpenAI`+baseURL branch already covers groq once the spec carries a `baseURL`) |
| `config/profiles.ts` | new `fast` preset (worker→groq, reasoner→anthropic) |
| `config/index.ts` | read `GROQ_API_KEY`; routed-role missing-key error names **role + `GROQ_API_KEY`**; `parseRoleSpec` allow-list |
| `llm/cost.ts` | `llama-3.3-70b-versatile` price in `DEFAULT_PRICING` |
| wiring | `groqApiKey` threaded into `ProviderKeys` at all 4 sites (3x `agent/index.ts`, 1x `cli` experiment); `--routing` help text |

**No new dependency** — Groq is OpenAI-compatible, so it reuses `ChatOpenAI` + `configuration.baseURL = https://api.groq.com/openai/v1`, mirroring OpenRouter (ADR-0002 / ADR-0011 addenda in this PR).

## Chosen Groq worker model — `llama-3.3-70b-versatile`
The worker steps `identifyElements` / `generateCode` call `withStructuredOutput(schema, { includeRaw: true })`, which compiles to **function calling** on OpenAI-compatible endpoints — so the worker model **must** support tool/function-calling. `llama-3.3-70b-versatile` is a **current Groq production model** (verified against Groqs live model list, 2026-06) with tool-use support — Groqs own recommended replacement for the deprecated `deepseek-r1-distill-llama-70b`. Kept overridable via `CAIRN_ROLE_WORKER`, so the preset follows Groqs line-up without code changes.

## Per-role cost run on `fast`
No provider keys exist in this environment, so the **live** paid `cairn explore … --routing fast` could not run here (the issue anticipates this). Instead — an **offline end-to-end run of the same public-API path** the CLI uses (`loadConfig(fast)` → `makeModel(worker)` → `CostLedger`), simulated token usage, real ledger + real pricing:

```
roles.worker  : {provider:groq,model:llama-3.3-70b-versatile,supportsVision:false}
roles.reasoner: {provider:anthropic,model:claude-opus-4-8,supportsVision:false}
models.judge  : claude-haiku-4-5 (anthropic) — untouched by routing

worker makeModel instanceof ChatOpenAI: true
worker spec.baseURL  : https://api.groq.com/openai/v1 === GROQ_BASE_URL -> true

=== Per-role Cost summary (simulated usage; real ledger + pricing) ===
  worker    llama-3.3-70b-versatile      6600 tok  $0.004174
  reasoner  claude-opus-4-8              4000 tok  $0.038
  total              : 10600 tok  $0.042174
```

The **`worker` bucket resolves to Groq with tokens + $**, priced from the new `DEFAULT_PRICING` entry. A reviewer with a real `GROQ_API_KEY` can confirm live: `cairn explore --url https://example.com --routing fast` (reasoner needs an Anthropic key, or override it to OpenRouter to isolate the groq worker path).

## `volume` + backward-compat — unchanged
- `volume` still routes worker→OpenRouter `deepseek/deepseek-chat` (explicit regression test added).
- No routing config ⇒ `roles` undefined, tier map identical to today (existing tests stay green).
- The one existing test that asserted `groq` was an *invalid* provider was updated — groq is now valid — to a still-invalid provider (`mistral`), preserving its intent.

## Tests / gate (TDD, RED→GREEN)
Added: factory groq spec + missing-key; `fast` preset resolution + missing-key + `CAIRN_GROQ_API_KEY`; groq pricing; `groq:model` now accepted.
`npm run build` clean · `npm run lint` clean · **213 tests pass** · coverage **96.4% stmts / 79.3% br** (gate 80/75) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)