### PR TITLE
fix(llm): Groq `fast` preset — structured output via tool-calling (was 400 json_schema)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,7 +17,7 @@ import { loadConfig } from "../config/index.js";
 import { runExploration, runDesign, runAutomate } from "../agent/index.js";
 import { promoteCase, locatorFor } from "../promote/index.js";
 import type { PromoteDeps } from "../promote/index.js";
-import { makeModel } from "../llm/index.js";
+import { makeModel, structuredMethodFor } from "../llm/index.js";
 import { structuredInvoker } from "../llm/structured.js";
 import { PromptRegistry, LOCAL_PROMPTS } from "../prompts/index.js";
 import { runExperiment, type DatasetItem, type Variant } from "../eval/experiment.js";
@@ -215,8 +215,14 @@ program
       ds.items,
       variants,
       {
-        designInvoke: structuredInvoker(makeModel(config.models.reasoning, keys)),
-        judgeInvoke: structuredInvoker(makeModel(config.models.judge, keys)),
+        designInvoke: structuredInvoker(
+          makeModel(config.models.reasoning, keys),
+          structuredMethodFor(config.models.reasoning.provider),
+        ),
+        judgeInvoke: structuredInvoker(
+          makeModel(config.models.judge, keys),
+          structuredMethodFor(config.models.judge.provider),
+        ),
       },
       { target: opts.target },
     );

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -49,9 +49,10 @@ export const ROUTING_PRESETS: Record<string, RolesConfig> = {
     reasoner: { provider: "anthropic", model: "claude-opus-4-8", supportsVision: false },
   },
   fast: {
-    // worker → Groq llama-3.3-70b-versatile: a current production model with tool/function-calling
-    // support (required by withStructuredOutput includeRaw). supportsVision:false → identifyElements
-    // falls back to aria-only (ADR-0002, vision-optional). Model id overridable via CAIRN_ROLE_WORKER.
+    // worker → Groq llama-3.3-70b-versatile: lowest latency/cost. This model does NOT support
+    // response_format=json_schema, so structured output goes via tool/function-calling
+    // (structuredMethodFor("groq") → "functionCalling", L1-02 fix). supportsVision:false →
+    // identifyElements falls back to aria-only (ADR-0002). Model id overridable via CAIRN_ROLE_WORKER.
     worker: { provider: "groq", model: "llama-3.3-70b-versatile", supportsVision: false },
     // reasoner = designTestCases + Pilot verdict → keep the quality model (Anthropic Opus).
     reasoner: { provider: "anthropic", model: "claude-opus-4-8", supportsVision: false },

--- a/src/llm/factory.ts
+++ b/src/llm/factory.ts
@@ -2,6 +2,17 @@ import { ChatAnthropic } from "@langchain/anthropic";
 import { ChatOpenAI } from "@langchain/openai";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import type { ModelTier } from "../config/index.js";
+import type { StructuredMethod } from "./structured.js";
+
+/**
+ * Which `withStructuredOutput` method to use for a provider. Groq's OpenAI-compatible endpoint
+ * rejects `response_format: json_schema` for most models (e.g. llama-3.3-70b-versatile → HTTP 400),
+ * so force `functionCalling` (tool-calling), which those models support (L1-02 fix). Anthropic and
+ * OpenRouter keep the LangChain default (`undefined`).
+ */
+export function structuredMethodFor(provider: ModelTier["provider"]): StructuredMethod | undefined {
+  return provider === "groq" ? "functionCalling" : undefined;
+}
 
 /** OpenRouter — OpenAI-compatible API; we connect via the ChatOpenAI baseURL (ADR-0002). */
 export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -1,10 +1,10 @@
-export { OPENROUTER_BASE_URL, GROQ_BASE_URL, resolveModelSpec, makeModel } from "./factory.js";
+export { OPENROUTER_BASE_URL, GROQ_BASE_URL, resolveModelSpec, makeModel, structuredMethodFor } from "./factory.js";
 export type { ModelSpec, ProviderKeys } from "./factory.js";
 export { imageBlock } from "./vision.js";
 export type { ImageBlock } from "./vision.js";
 // L1-01 — per-role routing + cost/token accounting (ADR-0011).
 export { structuredInvoker, meteredInvoker, retryInvoke, CallBudget, cappedInvoke } from "./structured.js";
-export type { StructuredInvoke } from "./structured.js";
+export type { StructuredInvoke, StructuredMethod } from "./structured.js";
 export { RoleRouter, resolveRoleTier, KNOWN_ROLES } from "./routing.js";
 export { CostLedger, DEFAULT_PRICING, priceFor, extractUsage } from "./cost.js";
 export type { CostReport, RoleCost, TokenUsage, ModelPrice } from "./cost.js";

--- a/src/llm/routing.ts
+++ b/src/llm/routing.ts
@@ -1,6 +1,6 @@
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import type { AppConfig, ModelTier, RolesConfig } from "../config/index.js";
-import { makeModel, type ProviderKeys } from "./factory.js";
+import { makeModel, structuredMethodFor, type ProviderKeys } from "./factory.js";
 import { meteredInvoker, cappedInvoke, retryInvoke } from "./structured.js";
 import type { CallBudget, StructuredInvoke } from "./structured.js";
 import { CostLedger, type ModelPrice } from "./cost.js";
@@ -52,7 +52,9 @@ export class RoleRouter {
    */
   invoke(role: string, tier: ModelTier): StructuredInvoke {
     const model = this.makeModelFn(tier, this.keys);
-    const metered = meteredInvoker(model, (u, m) => this.ledger.record(role, m, u), tier.model);
+    // Groq needs functionCalling (its OpenAI-compat endpoint rejects json_schema) — L1-02 fix.
+    const method = structuredMethodFor(tier.provider);
+    const metered = meteredInvoker(model, (u, m) => this.ledger.record(role, m, u), tier.model, method);
     return cappedInvoke(retryInvoke(metered), this.budget);
   }
 }

--- a/src/llm/structured.ts
+++ b/src/llm/structured.ts
@@ -9,10 +9,18 @@ import { extractUsage, type TokenUsage } from "./cost.js";
  */
 export type StructuredInvoke = <T>(schema: ZodType<T>, messages: BaseMessageLike[]) => Promise<T>;
 
+/**
+ * How LangChain should obtain structured output. `jsonSchema` (the ChatOpenAI default) sends
+ * `response_format: json_schema`, which Groq rejects for most models (e.g. llama-3.3-70b-versatile);
+ * `functionCalling` uses tool-calling instead, which those models DO support (L1-02 fix). Pick it per
+ * provider via {@link structuredMethodFor}; `undefined` leaves the LangChain default untouched.
+ */
+export type StructuredMethod = "functionCalling" | "jsonMode" | "jsonSchema";
+
 /** Real implementation on top of LangChain `withStructuredOutput`. */
-export function structuredInvoker(model: BaseChatModel): StructuredInvoke {
+export function structuredInvoker(model: BaseChatModel, method?: StructuredMethod): StructuredInvoke {
   return async <T>(schema: ZodType<T>, messages: BaseMessageLike[]): Promise<T> => {
-    const structured = model.withStructuredOutput(schema);
+    const structured = model.withStructuredOutput(schema, method ? { method } : undefined);
     return (await structured.invoke(messages)) as T;
   };
 }
@@ -26,9 +34,10 @@ export function meteredInvoker(
   model: BaseChatModel,
   onUsage: (usage: TokenUsage, model: string) => void,
   modelId: string,
+  method?: StructuredMethod,
 ): StructuredInvoke {
   return async <T>(schema: ZodType<T>, messages: BaseMessageLike[]): Promise<T> => {
-    const structured = model.withStructuredOutput(schema, { includeRaw: true });
+    const structured = model.withStructuredOutput(schema, { includeRaw: true, ...(method ? { method } : {}) });
     const res = (await structured.invoke(messages)) as { raw: unknown; parsed: T };
     try {
       onUsage(extractUsage(res.raw), modelId);

--- a/tests/unit/llm.test.ts
+++ b/tests/unit/llm.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { ChatOpenAI } from "@langchain/openai";
-import { resolveModelSpec, makeModel, imageBlock, OPENROUTER_BASE_URL, GROQ_BASE_URL } from "../../src/llm/index.js";
+import { resolveModelSpec, makeModel, imageBlock, structuredMethodFor, OPENROUTER_BASE_URL, GROQ_BASE_URL } from "../../src/llm/index.js";
 import type { ModelTier } from "../../src/config/index.js";
 
 const anthropicTier: ModelTier = {
@@ -65,6 +65,16 @@ describe("makeModel — LangChain model instantiation", () => {
 
   it("groq tier → ChatOpenAI instance (OpenAI-compatible, via baseURL) (L1-02)", () => {
     expect(makeModel(groqTier, keys)).toBeInstanceOf(ChatOpenAI);
+  });
+});
+
+describe("structuredMethodFor — provider → withStructuredOutput method (L1-02 Groq fix)", () => {
+  it("forces functionCalling for Groq (llama-3.3-70b lacks json_schema response_format)", () => {
+    expect(structuredMethodFor("groq")).toBe("functionCalling");
+  });
+  it("leaves Anthropic and OpenRouter on the LangChain default (undefined)", () => {
+    expect(structuredMethodFor("anthropic")).toBeUndefined();
+    expect(structuredMethodFor("openrouter")).toBeUndefined();
   });
 });
 

--- a/tests/unit/routing.test.ts
+++ b/tests/unit/routing.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
-import { meteredInvoker, CallBudget } from "../../src/llm/structured.js";
+import { meteredInvoker, structuredInvoker, CallBudget } from "../../src/llm/structured.js";
 import { resolveRoleTier, RoleRouter, KNOWN_ROLES } from "../../src/llm/routing.js";
 import type { AppConfig, ModelTier } from "../../src/config/index.js";
 
@@ -13,6 +13,17 @@ const okSchema = z.object({ ok: z.number() });
 function fakeModel(parsed: unknown, raw: unknown): BaseChatModel {
   return {
     withStructuredOutput: () => ({ invoke: async () => ({ raw, parsed }) }),
+  } as unknown as BaseChatModel;
+}
+
+/** Fake that records the options passed to withStructuredOutput (to assert the structured method). */
+function recordingModel(parsed: unknown, raw: unknown, sink: { opts?: unknown }): BaseChatModel {
+  return {
+    withStructuredOutput: (_schema: unknown, opts?: { includeRaw?: boolean; method?: string }) => {
+      sink.opts = opts;
+      // Mirror LangChain: includeRaw → {raw, parsed}; otherwise the parsed value directly.
+      return { invoke: async () => (opts?.includeRaw ? { raw, parsed } : parsed) };
+    },
   } as unknown as BaseChatModel;
 }
 
@@ -84,5 +95,51 @@ describe("RoleRouter — meters per role, falls back per tier", () => {
     expect(reasoner?.calls).toBe(1);
     expect(reasoner?.inputTokens).toBe(4);
     expect(reasoner?.outputTokens).toBe(2);
+  });
+
+  it("invoke routes a Groq tier through functionCalling (structured-output fix, L1-02)", async () => {
+    const sink: { opts?: unknown } = {};
+    const groqTier: ModelTier = { provider: "groq", model: "llama-3.3-70b-versatile", supportsVision: false };
+    const router = new RoleRouter(
+      baseCfg,
+      { groqApiKey: "k", anthropicApiKey: "k" },
+      new CallBudget(80),
+      undefined,
+      () => recordingModel({ ok: 1 }, { usage_metadata: { input_tokens: 1, output_tokens: 1 } }, sink),
+    );
+    await router.invoke("worker", groqTier)(okSchema, []);
+    expect(sink.opts).toMatchObject({ method: "functionCalling" });
+  });
+});
+
+describe("structured-output method forwarding (L1-02 Groq fix)", () => {
+  it("meteredInvoker forwards the method into withStructuredOutput alongside includeRaw", async () => {
+    const sink: { opts?: unknown } = {};
+    const model = recordingModel({ ok: 1 }, { usage_metadata: { input_tokens: 1, output_tokens: 1 } }, sink);
+    await meteredInvoker(model, () => undefined, "llama-3.3-70b-versatile", "functionCalling")(okSchema, []);
+    expect(sink.opts).toMatchObject({ includeRaw: true, method: "functionCalling" });
+  });
+
+  it("meteredInvoker omits method when none is given (default behavior unchanged)", async () => {
+    const sink: { opts?: unknown } = {};
+    const model = recordingModel({ ok: 1 }, {}, sink);
+    await meteredInvoker(model, () => undefined, "m")(okSchema, []);
+    expect(sink.opts).toEqual({ includeRaw: true });
+  });
+
+  it("structuredInvoker forwards the method and returns the parsed result", async () => {
+    const sink: { opts?: unknown } = {};
+    const model = recordingModel({ ok: 7 }, {}, sink);
+    const out = await structuredInvoker(model, "functionCalling")(okSchema, []);
+    expect(out).toEqual({ ok: 7 });
+    expect(sink.opts).toEqual({ method: "functionCalling" });
+  });
+
+  it("structuredInvoker without a method keeps the LangChain default call", async () => {
+    const sink: { opts?: unknown } = {};
+    const model = recordingModel({ ok: 9 }, {}, sink);
+    const out = await structuredInvoker(model)(okSchema, []);
+    expect(out).toEqual({ ok: 9 });
+    expect(sink.opts).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Problem

The `fast` routing preset (#7 / L1-02) — Groq worker `llama-3.3-70b-versatile` — **failed on every structured-output step**:

```
400 This model does not support response format `json_schema`.
```

LangChain's `ChatOpenAI` (Groq is wired as an OpenAI-compatible endpoint) defaults `withStructuredOutput` to the **strict `json_schema`** `response_format`. Per [Groq's docs](https://console.groq.com/docs/structured-outputs), `json_schema` is supported only by a few models (`openai/gpt-oss-*`, `meta-llama/llama-4-scout`) — **not** `llama-3.3-70b-versatile`. So `identifyElements` (the first worker call) 400'd and the whole `fast` run aborted. This is why the L1-03 benchmark showed `fast` as `n/a`.

## Fix

Make the structured-output **method provider-aware** instead of model-swapping (keeps the fast/cheap `llama-3.3-70b-versatile`, faithful to the preset's intent):

- **`structuredMethodFor(provider)`** (`src/llm/factory.ts`) → `"functionCalling"` for Groq, `undefined` (LangChain default) for Anthropic/OpenRouter. `llama-3.3-70b-versatile` fully supports tool/function calling, so structured output goes through a tool call instead of `json_schema`.
- Both structured invokers thread the method (`src/llm/structured.ts`): `meteredInvoker` (→ `RoleRouter`, the explore/design worker path) and `structuredInvoker` (→ CLI experiment). Anthropic/OpenRouter paths are unchanged (`undefined`).

## Verified on a real Groq call

```
✗ default (json_schema):      400 ... does not support response format json_schema
✓ functionCalling (the fix):  OK → { answer: 42 }
```

Same model, same prompt — only the structured-output mechanism changed.

## Tests (TDD)

- `structuredMethodFor` mapping (groq → functionCalling; anthropic/openrouter → undefined)
- method forwarding into `withStructuredOutput` for `meteredInvoker` (with + without method), `structuredInvoker`, and `RoleRouter.invoke` (Groq tier → functionCalling)
- `src/llm/structured.ts` coverage now **100% lines** (the new `structuredInvoker` tests cover previously-untested paths)

`npm run build` · `npm run lint` · `npm test` (220) · `npm run test:coverage` — all green.

## Notes

- Regression from #7 / L1-02. No model or pricing change — `DEFAULT_PRICING` for `llama-3.3-70b-versatile` still applies.
- **Unblocks the `fast` row in the L1-03 cost benchmark (#8)** — once merged, `npm run bench` will produce real numbers for `fast` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
