### PR TITLE
automate: validate⇄repair⇄keep-best so design→automate matches explore quality (#40)

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -20,6 +20,7 @@ import { validateSuite, type ValidationReport } from "../validate/index.js";
 import { SessionStore } from "../session/index.js";
 import { buildExploreGraph } from "./graph.js";
 import { finalizeFailure } from "./finalize.js";
+import { runRepairLoop } from "./repair-loop.js";
 import type { BudgetReport } from "./summary.js";
 import type { AppConfig } from "../config/index.js";
 import type { StorageState } from "../browser/index.js";
@@ -566,8 +567,12 @@ export interface AutomateResult {
   runDir: string;
   specFiles: string[];
   validation?: ValidationReport;
-  /** Per-role cost + tokens for the codegen step (L1-01). */
+  /** Per-role cost + tokens for the codegen step(s) (L1-01). */
   cost: CostReport;
+  /** Per-run LLM-call budget usage (L1-04, Box 3). */
+  budget: BudgetReport;
+  /** The repair loop bailed early because it stopped making progress (L1-04 #40). */
+  stoppedEarly: boolean;
 }
 
 /**
@@ -586,8 +591,16 @@ export async function runAutomate(input: {
   const cfg = input.config;
   const keys = { anthropicApiKey: cfg.anthropicApiKey, openrouterApiKey: cfg.openrouterApiKey, groqApiKey: cfg.groqApiKey };
   const budget = new CallBudget(80); // cost-guardrail: safeguard (normally ~6-10 calls/run)
-  const router = new RoleRouter(cfg, keys, budget); // L1-01: per-role routing + cost ledger
   const onProgress = input.onProgress ?? ((): void => undefined);
+  // #40: automate now repairs (multiple codegen calls) → warn as it nears the budget, like explore.
+  let warnedBudget = false;
+  const onCharge = (used: number, max: number): void => {
+    if (!warnedBudget && max > 0 && used / max >= 0.8) {
+      warnedBudget = true;
+      onProgress(`⚠ approaching the LLM-call budget (${used}/${max} calls — cost guardrail)`);
+    }
+  };
+  const router = new RoleRouter(cfg, keys, budget, undefined, undefined, onCharge); // L1-01 routing + ledger
   const runDir = resolve(input.runDir);
 
   const rep = JSON.parse(await readFile(join(runDir, "report.json"), "utf8")) as {
@@ -606,28 +619,50 @@ export async function runAutomate(input: {
   const skipped = allCases.length - cases.length;
   onProgress(`automate — ${cases.length} auto cases (skipped manual/MTC: ${skipped}) from ${tcDir}`);
 
-  const suite = await automateCases(
-    cases,
-    { baseUrl, pageSemantics },
-    { invoke: router.invoke("worker", router.tierFor("worker", cfg.models.bulk)), prompts: new PromptRegistry() },
-  );
+  const invoke = router.invoke("worker", router.tierFor("worker", cfg.models.bulk));
+  const prompts = new PromptRegistry();
+  const buildSuite = (repairHint?: string): Promise<GeneratedSuite> =>
+    automateCases(cases, { baseUrl, pageSemantics }, { invoke, prompts }, repairHint);
 
   const artifacts = new ArtifactStore(dirname(runDir));
   const runWriter = await artifacts.openRun(basename(runDir));
-  const specFiles = await runWriter.writeSuite(suite);
-  onProgress(`automate — generated ${specFiles.length} spec files → tests/`);
 
-  let validation: ValidationReport | undefined;
-  if (input.validate) {
-    let sessionPath: string | undefined;
-    if (input.sessionFile) sessionPath = resolve(input.sessionFile);
-    else if (input.sessionName) {
-      sessionPath = new SessionStore(resolve(input.sessionsDir ?? ".auth")).pathFor(input.sessionName);
-    }
-    validation = await validateSuite(runWriter.dir, { storageStatePath: sessionPath });
-    onProgress(`automate — validation: ${Math.round(validation.greenRatio * 100)}% green`);
+  let sessionPath: string | undefined;
+  if (input.sessionFile) sessionPath = resolve(input.sessionFile);
+  else if (input.sessionName) {
+    sessionPath = new SessionStore(resolve(input.sessionsDir ?? ".auth")).pathFor(input.sessionName);
   }
 
-  const cost = router.ledger.report(); // L1-01: per-role cost + tokens for the codegen step
-  return { runDir: runWriter.dir, specFiles, validation, cost };
+  let suite: GeneratedSuite;
+  let validation: ValidationReport | undefined;
+  let stoppedEarly = false;
+  if (input.validate) {
+    // #40: validate ⇄ repair ⇄ keep-best (+ no-progress early-stop) — the SAME convergence the explore
+    // graph uses, instead of a single one-shot generation. Lifts the decoupled flow to explore-grade green.
+    const result = await runRepairLoop({
+      generate: async (hint) => {
+        const s = await buildSuite(hint);
+        await runWriter.writeSuite(s);
+        return s;
+      },
+      validate: () => validateSuite(runWriter.dir, { storageStatePath: sessionPath }),
+      maxRepair: cfg.maxRepair,
+      onProgress,
+    });
+    suite = result.bestSuite;
+    validation = result.bestValidation;
+    stoppedEarly = result.stoppedEarly;
+    onProgress(
+      `automate — validation: ${Math.round(validation.greenRatio * 100)}% green${stoppedEarly ? " · stopped early (no progress)" : ""}`,
+    );
+  } else {
+    suite = await buildSuite(); // single pass — repair needs validation to measure progress
+  }
+
+  const specFiles = await runWriter.writeSuite(suite); // final/best suite on disk
+  onProgress(`automate — ${specFiles.length} spec file(s) → tests/`);
+
+  const cost = router.ledger.report(); // L1-01: per-role cost + tokens for the codegen step(s)
+  const budgetReport: BudgetReport = { used: budget.spent, max: budget.max };
+  return { runDir: runWriter.dir, specFiles, validation, stoppedEarly, cost, budget: budgetReport };
 }

--- a/src/agent/repair-loop.ts
+++ b/src/agent/repair-loop.ts
@@ -1,0 +1,68 @@
+import type { GeneratedSuite } from "../codegen/index.js";
+import type { ValidationReport } from "../validate/index.js";
+import { progressSnapshot, madeProgress } from "./progress.js";
+
+export interface RepairLoopDeps {
+  /** Produce AND write a suite (so `validate` can run it). `repairHint` = failing test names on a repair pass. */
+  generate: (repairHint?: string) => Promise<GeneratedSuite>;
+  /** Run the written suite and classify it. */
+  validate: () => Promise<ValidationReport>;
+  /** Max repair attempts after the initial generation. */
+  maxRepair: number;
+  onProgress?: (event: string) => void;
+}
+
+export interface RepairLoopResult {
+  bestSuite: GeneratedSuite;
+  bestValidation: ValidationReport;
+  /** Repair attempts actually run (0 = green on the first try, or maxRepair=0). */
+  attempts: number;
+  /** Stopped before maxRepair because an attempt made no progress (Box 2). */
+  stoppedEarly: boolean;
+}
+
+/**
+ * Shared validate ⇄ repair ⇄ keep-best loop with no-progress early-stop (L1-04, #40). The same
+ * convergence logic the explore graph uses, factored so the decoupled `automate` flow repairs too.
+ * Pure orchestration over injected `generate`/`validate` — unit-testable without a browser or LLM.
+ */
+export async function runRepairLoop(deps: RepairLoopDeps): Promise<RepairLoopResult> {
+  let suite = await deps.generate();
+  let validation = await deps.validate();
+
+  // keep-best: only accept a regeneration that is BETTER and not broken (≥1 test).
+  let bestSuite = suite;
+  let bestValidation = validation;
+  let bestGreen = validation.results.length > 0 ? validation.greenRatio : -1;
+  let prevSnapshot = progressSnapshot(validation);
+  let attempts = 0;
+  let stoppedEarly = false;
+
+  while (bestGreen < 1 && attempts < deps.maxRepair) {
+    attempts += 1;
+    const failed = validation.results
+      .filter((r) => r.status !== "passed")
+      .map((r) => r.test)
+      .join(", ");
+    deps.onProgress?.(`repair — attempt ${attempts}`);
+    suite = await deps.generate(failed);
+    validation = await deps.validate();
+
+    if (validation.results.length > 0 && validation.greenRatio > bestGreen) {
+      bestSuite = suite;
+      bestValidation = validation;
+      bestGreen = validation.greenRatio;
+    }
+
+    // No-progress detection (Box 2): same green ratio AND the same failing tests → bail early.
+    const snap = progressSnapshot(validation);
+    if (!madeProgress(prevSnapshot, snap)) {
+      stoppedEarly = true;
+      deps.onProgress?.("repair — stopped early: no progress vs the previous attempt (same failing tests).");
+      break;
+    }
+    prevSnapshot = snap;
+  }
+
+  return { bestSuite, bestValidation, attempts, stoppedEarly };
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -346,6 +346,17 @@ program
         );
       }
       printCost(result.cost);
+      // L1-04 (Box 4): same consolidated footer as `explore` — pass/fail · cost · budget · path.
+      process.stdout.write("\n");
+      for (const line of renderRunSummary({
+        runDir: result.runDir,
+        validation: result.validation,
+        cost: result.cost,
+        budget: result.budget,
+        stoppedEarly: result.stoppedEarly,
+      })) {
+        process.stdout.write(`${line}\n`);
+      }
     },
   );
 

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -80,6 +80,8 @@ export async function automateCases(
   cases: ParsedTestCase[],
   ctx: { baseUrl: string; pageSemantics: string },
   deps: CodegenDeps,
+  /** Repair context: failing test names from the previous attempt (#40 — automate now repairs). */
+  repairHint?: string,
 ): Promise<GeneratedSuite> {
   const seen = new Map<string, string>();
   for (const c of cases) for (const s of c.selectors) if (!seen.has(s.locator)) seen.set(s.locator, s.label);
@@ -99,6 +101,9 @@ export async function automateCases(
     transitions: "(from the case steps)",
     language: detectLanguage(testCases),
   });
-  const suite = await deps.invoke(GeneratedSuiteSchema, [new HumanMessage(prompt.text)]);
+  const text = repairHint
+    ? `${prompt.text}\n\nREPAIR: the previous generation failed the tests: ${repairHint}\nFix the locators/navigation/assertions so the tests pass.`
+    : prompt.text;
+  const suite = await deps.invoke(GeneratedSuiteSchema, [new HumanMessage(text)]);
   return { files: suite.files.map((f) => ({ path: sanitizePath(f.path), content: f.content })) };
 }

--- a/tests/unit/codegen.test.ts
+++ b/tests/unit/codegen.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { generateSuite } from "../../src/codegen/index.js";
+import { generateSuite, automateCases } from "../../src/codegen/index.js";
 import { PromptRegistry } from "../../src/prompts/index.js";
 import type { StructuredInvoke } from "../../src/llm/structured.js";
 import type { PageStudy } from "../../src/observe/index.js";
 import type { TestCase } from "../../src/design/index.js";
+import type { ParsedTestCase } from "../../src/artifacts/testcase-md.js";
 
 const study: PageStudy = {
   url: "http://x/login",
@@ -65,5 +66,48 @@ describe("generateSuite", () => {
     );
     expect(suite.files[0]?.path).not.toContain("..");
     expect(suite.files[1]?.path.startsWith("/")).toBe(false);
+  });
+});
+
+describe("automateCases (decoupled automate — repair support, #40)", () => {
+  const cases: ParsedTestCase[] = [
+    {
+      id: "ATC-1",
+      execution: "auto",
+      title: "Login works",
+      steps: ["Click Sign In"],
+      expected: ["Logged in"],
+      selectors: [{ label: "Sign In", locator: "page.getByRole('button', { name: 'Sign In' })" }],
+    },
+  ];
+
+  it("adds a REPAIR instruction carrying the failing tests when a repairHint is given", async () => {
+    let captured = "";
+    const fakeInvoke: StructuredInvoke = async (schema, messages) => {
+      captured = JSON.stringify(messages);
+      return schema.parse({ files: [{ path: "a.spec.ts", content: "import { test } from '@playwright/test';" }] });
+    };
+    await automateCases(
+      cases,
+      { baseUrl: "http://x", pageSemantics: "p" },
+      { invoke: fakeInvoke, prompts: new PromptRegistry() },
+      "Login works",
+    );
+    expect(captured).toContain("REPAIR");
+    expect(captured).toContain("Login works");
+  });
+
+  it("omits the REPAIR instruction on the initial pass (no hint)", async () => {
+    let captured = "";
+    const fakeInvoke: StructuredInvoke = async (schema, messages) => {
+      captured = JSON.stringify(messages);
+      return schema.parse({ files: [{ path: "a.spec.ts", content: "x" }] });
+    };
+    await automateCases(
+      cases,
+      { baseUrl: "http://x", pageSemantics: "p" },
+      { invoke: fakeInvoke, prompts: new PromptRegistry() },
+    );
+    expect(captured).not.toContain("REPAIR");
   });
 });

--- a/tests/unit/repair-loop.test.ts
+++ b/tests/unit/repair-loop.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { runRepairLoop } from "../../src/agent/repair-loop.js";
+import type { GeneratedSuite } from "../../src/codegen/index.js";
+import type { ValidationReport } from "../../src/validate/index.js";
+
+const report = (
+  results: { test: string; status: "passed" | "failed" | "flaky" }[],
+  greenRatio: number,
+): ValidationReport => ({ results, greenRatio, flakyCount: 0 });
+
+/** Scripted generate/validate harness — no browser, no LLM. */
+function harness(validations: ValidationReport[]) {
+  const hints: (string | undefined)[] = [];
+  let gen = 0;
+  let val = 0;
+  return {
+    hints,
+    genCount: (): number => gen,
+    generate: async (hint?: string): Promise<GeneratedSuite> => {
+      hints.push(hint);
+      return { files: [{ path: `s${gen++}.spec.ts`, content: "// gen" }] };
+    },
+    validate: async (): Promise<ValidationReport> => validations[Math.min(val++, validations.length - 1)]!,
+  };
+}
+
+describe("runRepairLoop (L1-04 #40 — shared validate⇄repair⇄keep-best)", () => {
+  it("green on the first try → no repair (attempts 0, only the initial generate)", async () => {
+    const h = harness([report([{ test: "t", status: "passed" }], 1)]);
+    const r = await runRepairLoop({ generate: h.generate, validate: h.validate, maxRepair: 3 });
+    expect(r.attempts).toBe(0);
+    expect(r.bestValidation.greenRatio).toBe(1);
+    expect(h.genCount()).toBe(1);
+  });
+
+  it("red → repair → green (attempts 1; the repair pass gets the failing test as a hint)", async () => {
+    const h = harness([
+      report([{ test: "t", status: "failed" }], 0),
+      report([{ test: "t", status: "passed" }], 1),
+    ]);
+    const r = await runRepairLoop({ generate: h.generate, validate: h.validate, maxRepair: 3 });
+    expect(r.attempts).toBe(1);
+    expect(r.bestValidation.greenRatio).toBe(1);
+    expect(h.hints[0]).toBeUndefined(); // initial generate — no hint
+    expect(h.hints[1]).toContain("t"); // repair generate — failing test names
+  });
+
+  it("persistent identical failures → stop early, NOT all maxRepair", async () => {
+    const stuck = report([{ test: "a", status: "passed" }, { test: "b", status: "failed" }], 0.5);
+    const h = harness([stuck, { ...stuck, results: [...stuck.results] }]);
+    const r = await runRepairLoop({ generate: h.generate, validate: h.validate, maxRepair: 5 });
+    expect(r.stoppedEarly).toBe(true);
+    expect(r.attempts).toBe(1); // initial + 1 no-progress repair → bail (not 5)
+    expect(r.bestValidation.greenRatio).toBe(0.5);
+  });
+
+  it("keeps repairing while improving, capped by maxRepair", async () => {
+    const h = harness([
+      report([{ test: "a", status: "failed" }], 0.2),
+      report([{ test: "a", status: "failed" }], 0.4),
+      report([{ test: "a", status: "failed" }], 0.6),
+    ]);
+    const r = await runRepairLoop({ generate: h.generate, validate: h.validate, maxRepair: 2 });
+    expect(r.attempts).toBe(2);
+    expect(r.stoppedEarly).toBe(false);
+    expect(r.bestValidation.greenRatio).toBeCloseTo(0.6);
+  });
+
+  it("keep-best: a broken (0-test) regeneration does NOT replace the best", async () => {
+    const h = harness([
+      report([{ test: "a", status: "passed" }, { test: "b", status: "failed" }], 0.5),
+      report([], 0), // broken regeneration
+    ]);
+    const r = await runRepairLoop({ generate: h.generate, validate: h.validate, maxRepair: 1 });
+    expect(r.bestValidation.greenRatio).toBe(0.5); // kept, not dropped to 0
+    expect(r.bestSuite.files[0]?.path).toBe("s0.spec.ts"); // the first (best) suite
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
         "src/agent/summary.ts",
         "src/agent/observe-guard.ts",
         "src/agent/finalize.ts",
+        "src/agent/repair-loop.ts",
         "scripts/benchmark-core.ts",
       ],
       thresholds: { lines: 80, functions: 80, branches: 75, statements: 80 },


### PR DESCRIPTION
Fixes the dogfood finding **#40**: `cairn automate` generated code **once** and (optionally) validated — with **no repair loop** — so the recommended `design → automate` review-first flow produced far lower green than `explore`.

| Flow (same target + session) | Before | After |
|---|---|---|
| `cairn explore` | 100% green | 100% green |
| `cairn design` → `automate --validate` | **20%** (one-shot) | **runs the same repair loop** |

## What changed
- **New shared primitive `runRepairLoop`** (`src/agent/repair-loop.ts`): `validate ⇄ repair ⇄ keep-best` with no-progress early-stop. It reuses `progress.ts` (`progressSnapshot`/`madeProgress`) — the **same decision logic** the explore graph uses. Not a parallel system: shared logic, two thin drivers (graph nodes for explore, an async loop for automate). Pure orchestration over injected `generate`/`validate` → **unit-testable without a browser or LLM**.
- **`automate --validate` runs the loop** instead of a single generation; `automateCases` now accepts a `repairHint` (mirrors `generateSuite`).
- **First-run UX parity:** automate now surfaces the consolidated summary footer (pass/fail · cost+tokens · CallBudget used · artifact path) and warns near the budget — same as `explore`.
- `AutomateResult` gains `budget` + `stoppedEarly` (additive); the TUI summary picks them up automatically.

## TDD
- `repair-loop.test.ts` (new): green-first-try → no repair · red→repair→green (hint carried) · persistent identical failures → **stop early, not all maxRepair** · improving → caps at maxRepair · keep-best (broken regen doesn't replace the best).
- `codegen.test.ts`: `automateCases` adds/omits the REPAIR instruction by hint.

## Verification
`npm run build` ✓ · `npm run lint` ✓ · **283 unit tests** ✓ · coverage gate ✓ (97.85% lines / 83.65% branches; `repair-loop.ts` 100%).

> ⚠️ The real-browser integration tests (`tests/integration/*`) and the *full* `npm run test:coverage` could not run locally — the dev machine's `C:` drive is full (0 B free), so Chromium can't create its profile. `#40` does not touch the browser/observe path (automate has no gateway), so they're unaffected; they should run green on CI or after freeing disk space. **Live re-verify** once disk is free: `cairn automate --run runs/<designId> --validate --session app1` — expect green well above the prior one-shot 20%.

Closes #40
Refs #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
