### PR TITLE
explore: emit ATC/MTC case docs + surface the design→automate review flow (#39)

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -7,8 +7,8 @@ import { CallBudget } from "../llm/structured.js";
 import { PromptRegistry } from "../prompts/index.js";
 import { initTelemetry } from "../telemetry/index.js";
 import { ArtifactStore } from "../artifacts/index.js";
-import { renderReportMd, locatorFor } from "../artifacts/report.js";
-import { renderTestCaseMd, parseTestCaseMd, type TestCaseDoc } from "../artifacts/testcase-md.js";
+import { renderReportMd } from "../artifacts/report.js";
+import { parseTestCaseMd } from "../artifacts/testcase-md.js";
 import { automateCases } from "../codegen/index.js";
 import { deterministicScores, type Score } from "../eval/scorers.js";
 import { judgeTestCases, judgeChecklistCoverage } from "../eval/judge.js";
@@ -21,6 +21,7 @@ import { SessionStore } from "../session/index.js";
 import { buildExploreGraph } from "./graph.js";
 import { finalizeFailure } from "./finalize.js";
 import { runRepairLoop } from "./repair-loop.js";
+import { buildTestCaseDocs } from "./testcase-docs.js";
 import type { BudgetReport } from "./summary.js";
 import type { AppConfig } from "../config/index.js";
 import type { StorageState } from "../browser/index.js";
@@ -72,6 +73,8 @@ export interface ExploreResult {
   budget: BudgetReport;
   /** The repair loop bailed early because it stopped making progress (L1-04, Box 2). */
   stoppedEarly: boolean;
+  /** ATC/MTC case docs written to testcases/ (#39 — explore now emits them like design). */
+  testCaseFiles: string[];
 }
 
 /**
@@ -291,6 +294,16 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
     const cost = router.ledger.report(); // L1-01: per-role cost + tokens for this run
     const budgetReport: BudgetReport = { used: budget.spent, max: budget.max }; // L1-04 (Box 3)
     const stoppedEarly = Boolean(out.stoppedEarly); // L1-04 (Box 2)
+
+    // #39: also emit ATC/MTC case docs (.md) — explore now produces the human-readable cases like
+    // design, so manual MTC cases are visible deliverables (not just buried inside report.md).
+    const caseSuite = suiteFromUrl(out.study.url);
+    const caseDocs = buildTestCaseDocs(out.testCases, out.verified, caseSuite, checklistItems.length > 0);
+    const testCaseFiles = await runWriter.writeTestCases(caseDocs.docs);
+    onProgress(
+      `explore — wrote ${testCaseFiles.length} cases: ${caseDocs.autoN} ATC, ${caseDocs.manualN} MTC → testcases/`,
+    );
+
     await runWriter.writeStudy(out.study);
     if (out.study.screenshotB64) await runWriter.writeScreenshot(out.study.screenshotB64);
     await runWriter.writeAria(out.study.ariaYaml);
@@ -346,6 +359,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
       cost,
       budget: budgetReport,
       stoppedEarly,
+      testCaseFiles,
     };
   } catch (err) {
     // L1-04 (Box 1/3/4): the single failure path — write a partial report + a readable, actionable
@@ -473,25 +487,12 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
     // (Expired-session detection now fails fast inside the graph's identifyElements node — L1-05.)
 
     const suite = suiteFromUrl(out.study.url);
-    const verifiedByRef = new Map(out.verified.map((v) => [v.ref, v]));
-    let autoN = 0;
-    let manualN = 0;
-    const docs = out.testCases.map((tc) => {
-      const manual = tc.execution === "manual";
-      const n = manual ? (manualN += 1) : (autoN += 1);
-      const id = `${manual ? "MTC" : "ATC"}-${suite}-${String(n).padStart(3, "0")}`;
-      const automationPath = manual
-        ? "— (manual, not automated)"
-        : `tests/ui/${suite.toLowerCase()}/${id.toLowerCase()}.spec.ts`;
-      const status = manual ? "📋 Manual" : "❌ Not implemented";
-      const selectors = tc.elementRefs
-        .map((r) => verifiedByRef.get(r))
-        .filter((v): v is NonNullable<typeof v> => Boolean(v))
-        .map((v) => ({ label: v.name ?? v.role, locator: locatorFor(v) }));
-      const traceability = checklistItems.length > 0 ? [{ source: "Checklist", reference: "provided plan" }] : [];
-      const doc: TestCaseDoc = { id, suite, status, automationPath, selectors, traceability };
-      return { id, md: renderTestCaseMd(tc, doc) };
-    });
+    const { docs, autoN, manualN } = buildTestCaseDocs(
+      out.testCases,
+      out.verified,
+      suite,
+      checklistItems.length > 0,
+    );
     const testCaseFiles = await runWriter.writeTestCases(docs);
     onProgress(
       `design — wrote ${testCaseFiles.length} cases: ${autoN} auto/ATC, ${manualN} manual/MTC (${suite}) → testcases/`,

--- a/src/agent/testcase-docs.ts
+++ b/src/agent/testcase-docs.ts
@@ -1,0 +1,46 @@
+import { locatorFor } from "../artifacts/report.js";
+import { renderTestCaseMd, type TestCaseDoc } from "../artifacts/testcase-md.js";
+import type { TestCase } from "../design/index.js";
+import type { VerifiedElement } from "../browser/types.js";
+
+export interface TestCaseDocsResult {
+  /** id + rendered ATC/MTC markdown, in input order. */
+  docs: { id: string; md: string }[];
+  /** Count of auto (ATC) cases. */
+  autoN: number;
+  /** Count of manual (MTC) cases. */
+  manualN: number;
+}
+
+/**
+ * Build ATC/MTC case docs (.md, with selectors) from designed cases — the shared logic behind both
+ * `design` (cases-only) and `explore` (#39: explore now emits these too, so manual MTC cases are
+ * visible deliverables and the auto/manual split is explicit). Pure — no I/O.
+ */
+export function buildTestCaseDocs(
+  testCases: TestCase[],
+  verified: VerifiedElement[],
+  suite: string,
+  hasChecklist: boolean,
+): TestCaseDocsResult {
+  const verifiedByRef = new Map(verified.map((v) => [v.ref, v]));
+  let autoN = 0;
+  let manualN = 0;
+  const docs = testCases.map((tc) => {
+    const manual = tc.execution === "manual";
+    const n = manual ? (manualN += 1) : (autoN += 1);
+    const id = `${manual ? "MTC" : "ATC"}-${suite}-${String(n).padStart(3, "0")}`;
+    const automationPath = manual
+      ? "— (manual, not automated)"
+      : `tests/ui/${suite.toLowerCase()}/${id.toLowerCase()}.spec.ts`;
+    const status = manual ? "📋 Manual" : "❌ Not implemented";
+    const selectors = tc.elementRefs
+      .map((r) => verifiedByRef.get(r))
+      .filter((v): v is VerifiedElement => Boolean(v))
+      .map((v) => ({ label: v.name ?? v.role, locator: locatorFor(v) }));
+    const traceability = hasChecklist ? [{ source: "Checklist", reference: "provided plan" }] : [];
+    const doc: TestCaseDoc = { id, suite, status, automationPath, selectors, traceability };
+    return { id, md: renderTestCaseMd(tc, doc) };
+  });
+  return { docs, autoN, manualN };
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -165,6 +165,13 @@ program
     })) {
       process.stdout.write(`${line}\n`);
     }
+    // #39: explore now also writes ATC/MTC cases, and points at the review-first flow for next time.
+    if (result.testCaseFiles.length > 0) {
+      process.stdout.write(`  Cases (ATC/MTC .md): ${result.runDir}\\testcases\\\n`);
+    }
+    process.stdout.write(
+      "\nTip: to review cases BEFORE generating code, run `cairn design` then `cairn automate`.\n",
+    );
   });
 
 program

--- a/tests/unit/testcase-docs.test.ts
+++ b/tests/unit/testcase-docs.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { buildTestCaseDocs } from "../../src/agent/testcase-docs.js";
+import type { TestCase } from "../../src/design/index.js";
+import type { VerifiedElement } from "../../src/browser/types.js";
+
+const tc = (over: Partial<TestCase>): TestCase => ({
+  id: "tc",
+  title: "A case",
+  technique: "exploratory",
+  kind: "static",
+  type: "Positive",
+  execution: "auto",
+  preconditions: [],
+  steps: ["do it"],
+  expected: "it works",
+  priority: "high",
+  elementRefs: [],
+  ...over,
+});
+
+const verified: VerifiedElement[] = [
+  { ref: "e1", role: "button", name: "Save", interactive: true, rank: 3, count: 1, verified: true },
+];
+
+describe("buildTestCaseDocs (#39 — shared ATC/MTC emission)", () => {
+  it("numbers ATC and MTC independently and keeps input order", () => {
+    const cases = [
+      tc({ title: "Auto 1", execution: "auto" }),
+      tc({ title: "Manual 1", execution: "manual" }),
+      tc({ title: "Auto 2", execution: "auto" }),
+    ];
+    const r = buildTestCaseDocs(cases, verified, "DEMO", false);
+    expect(r.autoN).toBe(2);
+    expect(r.manualN).toBe(1);
+    expect(r.docs.map((d) => d.id)).toEqual(["ATC-DEMO-001", "MTC-DEMO-001", "ATC-DEMO-002"]);
+  });
+
+  it("renders verified selectors (label + getByRole locator) into the markdown", () => {
+    const r = buildTestCaseDocs([tc({ elementRefs: ["e1"] })], verified, "DEMO", false);
+    expect(r.docs[0]?.md).toContain("page.getByRole('button', { name: 'Save' })");
+    expect(r.docs[0]?.md).toContain("Save");
+  });
+
+  it("drops refs that aren't in the verified set (no hallucinated selectors)", () => {
+    const r = buildTestCaseDocs([tc({ elementRefs: ["e1", "eGHOST"] })], verified, "DEMO", false);
+    expect(r.docs[0]?.md).not.toContain("eGHOST");
+  });
+
+  it("marks manual cases as Manual in the doc", () => {
+    const r = buildTestCaseDocs([tc({ execution: "manual" })], verified, "DEMO", false);
+    expect(r.docs[0]?.id).toBe("MTC-DEMO-001");
+    expect(r.docs[0]?.md.toLowerCase()).toContain("manual");
+  });
+
+  it("adds checklist traceability only when a checklist was provided", () => {
+    const withCl = buildTestCaseDocs([tc({})], verified, "DEMO", true);
+    const without = buildTestCaseDocs([tc({})], verified, "DEMO", false);
+    expect(withCl.docs[0]?.md).toContain("Checklist");
+    expect(without.docs[0]?.md).not.toContain("Checklist");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
         "src/agent/observe-guard.ts",
         "src/agent/finalize.ts",
         "src/agent/repair-loop.ts",
+        "src/agent/testcase-docs.ts",
         "scripts/benchmark-core.ts",
       ],
       thresholds: { lines: 80, functions: 80, branches: 75, statements: 80 },


### PR DESCRIPTION
Fixes the dogfood UX finding **#39**: `cairn explore` jumped straight to generating + validating code, so the methodology cases lived **only inside `report.md`** — the manual (MTC) cases (XSS, empty-state) were invisible deliverables, and the "7 cases / 5 tests" gap read like a defect.

## What changed
- **Shared `buildTestCaseDocs`** (`src/agent/testcase-docs.ts`): factor design's ATC/MTC doc-building (numbering · verified `getByRole` selectors · checklist traceability) out of `runDesign`, and call it from **both** `design` and `explore` — one source of truth, not a parallel path.
- **`explore` now writes `testcases/ATC-*.md` + `MTC-*.md`** alongside the generated code. Manual cases become visible deliverables, and the auto (→code) vs manual (→doc-only) split is explicit.
- **CLI** prints where the cases landed and a tip: *to review cases before code, run `cairn design` then `cairn automate`*.
- `ExploreResult` gains `testCaseFiles` (TUI/CLI pick it up). Bonus: an `explore` run dir is now `automate`-able (it has a `testcases/`).

## TDD
- `testcase-docs.test.ts` (new): ATC/MTC numbering & ids · verified-selector rendering · ghost-ref drop · manual marking · checklist-only traceability.
- `runDesign` refactored onto the shared helper — existing design/testcase-md tests stay green (behavior-preserving).

## Verification
`npm run build` ✓ · `npm run lint` ✓ · **294 tests** (incl. real-browser integration) ✓ · coverage gate ✓ (98.13% lines / 84.71% branches; `testcase-docs.ts` 100%). A live `cairn explore` on a real login-gated target is running to confirm the `.md` files land on disk — evidence to follow in a comment.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)
