### PR TITLE
C1-01/02 — shared core + gated modality stubs; explore parity

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 /**
- * CLI `cairn`. Commands: observe · explore · design · automate · dataset-add · experiment.
+ * CLI `cairn`. Commands: observe · explore · design · automate · dataset-add · experiment ·
+ * promote · session · login, plus GATED modality stubs (ui|e2e / api / unit / docs — C1-01).
+ * The umbrella router is thin: each modality command dispatches through the shared core
+ * (`runModality`), so a future modality is a thin add, not a fork.
  * `lex-bot` stays as a hidden, deprecated alias (see ./lex-bot.ts) → same code path.
  */
 import "dotenv/config";
@@ -14,7 +17,7 @@ import type { BackendKind, StorageState } from "../browser/index.js";
 import { capture } from "../observe/index.js";
 import { SessionStore, captureSession } from "../session/index.js";
 import { loadConfig } from "../config/index.js";
-import { runExploration, runDesign, runAutomate } from "../agent/index.js";
+import { runDesign, runAutomate } from "../agent/index.js";
 import { renderRunSummary } from "../agent/summary.js";
 import { promoteCase, locatorFor } from "../promote/index.js";
 import type { PromoteDeps } from "../promote/index.js";
@@ -23,391 +26,8 @@ import { structuredInvoker } from "../llm/structured.js";
 import { PromptRegistry, LOCAL_PROMPTS } from "../prompts/index.js";
 import { runExperiment, type DatasetItem, type Variant } from "../eval/experiment.js";
 import type { PageStudy } from "../observe/index.js";
-import type { CostReport } from "../llm/cost.js";
-
-/** Print the per-role cost + token summary (L1-01). */
-function printCost(cost: CostReport): void {
-  if (cost.perRole.length === 0) return;
-  process.stdout.write("\n=== Cost (per role) ===\n");
-  for (const c of cost.perRole) {
-    const usd = c.costUsd === null ? "n/a" : `$${c.costUsd.toFixed(4)}`;
-    process.stdout.write(`  ${c.role.padEnd(9)} ${c.calls} call(s)  ${c.inputTokens}→${c.outputTokens} tok  ${usd}\n`);
-  }
-  const total = cost.totalCostUsd === null ? "n/a (some prices unknown)" : `$${cost.totalCostUsd.toFixed(4)}`;
-  process.stdout.write(`  ${"total".padEnd(9)} ${cost.totalTokens} tok  ${total}\n`);
-}
-
-const program = new Command();
-program
-  .name("cairn")
-  .description(`${BOT_NAME} — autonomous UI test generator`)
-  .version(BOT_VERSION);
-
-program
-  .command("observe")
-  .description("Explore a page: ARIA snapshot + interactive elements + screenshot")
-  .requiredOption("--url <url>", "page URL")
-  .option("--backend <kind>", "lib | cli", "lib")
-  .option("--session <name>", "name of the saved session (.auth/<name>.storageState.json)")
-  .option("--out <file>", "where to save the screenshot", "observe-screenshot.png")
-  .action(async (opts: { url: string; backend: string; session?: string; out: string }) => {
-    const backend: BackendKind = opts.backend === "cli" ? "cli" : "lib";
-    const config = loadConfig(process.env);
-    let storageState: StorageState | undefined;
-    if (opts.session) {
-      storageState = await new SessionStore(resolve(".auth")).load(opts.session);
-    }
-    const gateway = makeGateway({ backend, storageState, channel: config.browser.channel });
-    try {
-      const study = await capture(gateway, opts.url);
-      const interactive = study.elements.filter((e) => e.interactive);
-      process.stdout.write(`URL: ${study.url} (backend: ${study.capturedBy})\n`);
-      process.stdout.write(
-        `Elements: ${study.elements.length}, interactive: ${interactive.length}\n\n`,
-      );
-      process.stdout.write(`${study.ariaYaml}\n\nInteractive:\n`);
-      for (const e of interactive) {
-        process.stdout.write(`  [${e.ref}] ${e.role}${e.name ? ` "${e.name}"` : ""}\n`);
-      }
-      await mkdir(dirname(opts.out), { recursive: true });
-      await writeFile(opts.out, Buffer.from(study.screenshotB64, "base64"));
-      process.stdout.write(`\nScreenshot → ${opts.out}\n`);
-    } finally {
-      await gateway.close();
-    }
-  });
-
-program
-  .command("explore")
-  .description("Explore a page and generate methodology-based test cases (Sprint 2: no code)")
-  .requiredOption("--url <url>", "page URL")
-  .option("--backend <kind>", "lib | cli (overrides BROWSER_BACKEND)")
-  .option("--session <name>", "name of the saved session (.auth/<name>.storageState.json)")
-  .option("--session-file <path>", "direct path to a storageState file (any name)")
-  .option("--headed", "visible browser (debug)")
-  .option("--checklist <file>", "checklist file (md/text) — guides what to test")
-  .option("--style <s>", "planning style: happy | negative | coverage | all")
-  .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
-  .action(
-    async (opts: {
-      url: string;
-      backend?: string;
-      session?: string;
-      sessionFile?: string;
-      headed?: boolean;
-      checklist?: string;
-      style?: string;
-      routing?: string;
-    }) => {
-      const env: Record<string, string | undefined> = { ...process.env };
-      if (opts.backend) env.BROWSER_BACKEND = opts.backend;
-      if (opts.routing) env.LLM_ROUTING = opts.routing;
-      const config = loadConfig(env);
-      const checklistText = opts.checklist ? await readFile(opts.checklist, "utf8") : undefined;
-      process.stderr.write(
-        `▸ Exploring ${opts.url}${opts.session ? ` (session: ${opts.session})` : ""}${opts.checklist ? ` (checklist: ${opts.checklist})` : ""}…\n`,
-      );
-      const result = await runExploration({
-        url: opts.url,
-        config,
-        sessionName: opts.session,
-        sessionFile: opts.sessionFile,
-        headed: opts.headed,
-        checklistText,
-        style: opts.style,
-        onProgress: (e) => process.stderr.write(`  ▸ ${e}\n`),
-      });
-
-    process.stdout.write(`\n=== Exploration of ${result.study.url} (run ${result.runId}) ===\n`);
-    process.stdout.write(`Purpose: ${result.analysis.pageSemantics}\n`);
-    process.stdout.write(`LLM profile: ${config.llmProfile} · test cases: ${result.testCases.length}\n\n`);
-    for (const tc of result.testCases) {
-      process.stdout.write(`[${tc.id}] (${tc.priority} · ${tc.technique}) ${tc.title}\n`);
-      for (const step of tc.steps) process.stdout.write(`    - ${step}\n`);
-      process.stdout.write(`    ⇒ ${tc.expected}\n`);
-      if (tc.elementRefs.length) process.stdout.write(`    refs: ${tc.elementRefs.join(", ")}\n`);
-      process.stdout.write("\n");
-    }
-
-    if (result.validation) {
-      const v = result.validation;
-      process.stdout.write(
-        `=== Validation: ${Math.round(v.greenRatio * 100)}% green (flaky: ${v.flakyCount}) ===\n`,
-      );
-      for (const r of v.results) {
-        const mark = r.status === "passed" ? "✓" : r.status === "flaky" ? "~" : "✗";
-        process.stdout.write(`  ${mark} ${r.test}\n`);
-      }
-    }
-    if (result.scores.length > 0) {
-      process.stdout.write("\n=== Metrics ===\n");
-      for (const s of result.scores) {
-        process.stdout.write(
-          `  ${s.name}: ${s.value.toFixed(2)}${s.comment ? ` — ${s.comment}` : ""}\n`,
-        );
-      }
-    }
-    if (result.pilot) {
-      process.stdout.write(
-        `\n=== Pilot: ${result.pilot.verdict.toUpperCase()} ===\n  ${result.pilot.reason}\n  → ${result.pilot.guidance}\n`,
-      );
-    }
-    printCost(result.cost);
-    // L1-04 (Box 4): one unambiguous footer — pass/fail · cost+tokens · budget used · artifact path.
-    process.stdout.write("\n");
-    for (const line of renderRunSummary({
-      runDir: result.runDir,
-      validation: result.validation,
-      cost: result.cost,
-      budget: result.budget,
-      testCaseCount: result.testCases.length,
-      stoppedEarly: result.stoppedEarly,
-    })) {
-      process.stdout.write(`${line}\n`);
-    }
-    // #39: explore now also writes ATC/MTC cases, and points at the review-first flow for next time.
-    if (result.testCaseFiles.length > 0) {
-      process.stdout.write(`  Cases (ATC/MTC .md): ${result.runDir}\\testcases\\\n`);
-    }
-    process.stdout.write(
-      "\nTip: to review cases BEFORE generating code, run `cairn design` then `cairn automate`.\n",
-    );
-  });
-
-program
-  .command("dataset-add")
-  .description("Add a run (study.json) to an experiment dataset")
-  .requiredOption("--from-run <dir>", "runs/<id> folder")
-  .requiredOption("--to <file>", "dataset file (JSON)")
-  .action(async (opts: { fromRun: string; to: string }) => {
-    const study = JSON.parse(await readFile(join(opts.fromRun, "study.json"), "utf8")) as PageStudy;
-    let pageSemantics = "";
-    try {
-      const rep = JSON.parse(await readFile(join(opts.fromRun, "report.json"), "utf8")) as {
-        pageSemantics?: string;
-      };
-      pageSemantics = rep.pageSemantics ?? "";
-    } catch {
-      // report.json is optional
-    }
-    let ds: { items: DatasetItem[] } = { items: [] };
-    try {
-      ds = JSON.parse(await readFile(opts.to, "utf8")) as { items: DatasetItem[] };
-    } catch {
-      // new dataset
-    }
-    const id = `item-${ds.items.length + 1}`;
-    ds.items.push({ id, study, pageSemantics });
-    await mkdir(dirname(opts.to) || ".", { recursive: true });
-    await writeFile(opts.to, JSON.stringify(ds, null, 2), "utf8");
-    process.stdout.write(`Added ${id} → ${opts.to} (total items: ${ds.items.length})\n`);
-  });
-
-program
-  .command("experiment")
-  .description("Compare prompt versions on a dataset (B2 self-improvement)")
-  .requiredOption("--dataset <file>", "dataset file (JSON)")
-  .option("--candidate <spec>", "promptName=file.md — candidate prompt vs production")
-  .option("--target <metric>", "target verdict metric", "grounding")
-  .action(async (opts: { dataset: string; candidate?: string; target: string }) => {
-    const config = loadConfig(process.env);
-    const keys = {
-      anthropicApiKey: config.anthropicApiKey,
-      openrouterApiKey: config.openrouterApiKey,
-      groqApiKey: config.groqApiKey,
-    };
-    const ds = JSON.parse(await readFile(opts.dataset, "utf8")) as { items: DatasetItem[] };
-
-    const variants: Variant[] = [{ label: "production", prompts: new PromptRegistry() }];
-    if (opts.candidate) {
-      const eq = opts.candidate.indexOf("=");
-      const name = opts.candidate.slice(0, eq);
-      const text = await readFile(opts.candidate.slice(eq + 1), "utf8");
-      variants.push({
-        label: "candidate",
-        prompts: new PromptRegistry({ local: { ...LOCAL_PROMPTS, [name]: text } }),
-      });
-    }
-
-    process.stderr.write(`▸ Experiment: ${ds.items.length} items × ${variants.length} versions…\n`);
-    const result = await runExperiment(
-      ds.items,
-      variants,
-      {
-        designInvoke: structuredInvoker(
-          makeModel(config.models.reasoning, keys),
-          structuredMethodFor(config.models.reasoning.provider),
-        ),
-        judgeInvoke: structuredInvoker(
-          makeModel(config.models.judge, keys),
-          structuredMethodFor(config.models.judge.provider),
-        ),
-      },
-      { target: opts.target },
-    );
-
-    process.stdout.write(`\n=== Experiment (${ds.items.length} items) ===\n`);
-    for (const v of result.perVariant) {
-      process.stdout.write(`\n[${v.label}]\n`);
-      for (const [name, val] of Object.entries(v.meanScores)) {
-        process.stdout.write(`  ${name}: ${val.toFixed(3)}\n`);
-      }
-    }
-    if (result.verdict) {
-      const vd = result.verdict;
-      const reg = vd.guardrailRegressions.length ? `; regressions: ${vd.guardrailRegressions.join(", ")}` : "";
-      process.stdout.write(
-        `\n=== Verdict: candidate ${vd.improved ? "BETTER ✓" : "NOT better ✗"} (${vd.target} Δ=${vd.delta.toFixed(3)})${reg} ===\n`,
-      );
-      process.stdout.write(
-        vd.improved
-          ? "  → the version can be promoted (Langfuse label=production) — runbook promote-prompt.\n"
-          : "  → reject/iterate the prompt.\n",
-      );
-    }
-  });
-
-program
-  .command("design")
-  .description("Explore a page and WRITE test cases in ATC format (.md, with selectors), WITHOUT code")
-  .requiredOption("--url <url>", "page URL")
-  .option("--session <name>", "name of the saved session")
-  .option("--session-file <path>", "path to a storageState file")
-  .option("--checklist <file>", "checklist file — guides what to test")
-  .option("--style <s>", "planning style: happy | negative | coverage | all")
-  .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
-  .option("--headed", "visible browser (debug)")
-  .action(
-    async (opts: {
-      url: string;
-      session?: string;
-      sessionFile?: string;
-      checklist?: string;
-      style?: string;
-      headed?: boolean;
-      routing?: string;
-    }) => {
-      const env: Record<string, string | undefined> = { ...process.env };
-      if (opts.routing) env.LLM_ROUTING = opts.routing;
-      const config = loadConfig(env);
-      const checklistText = opts.checklist ? await readFile(opts.checklist, "utf8") : undefined;
-      process.stderr.write(`▸ Designing test cases for ${opts.url}${opts.session ? ` (session: ${opts.session})` : ""}…\n`);
-      const result = await runDesign({
-        url: opts.url,
-        config,
-        sessionName: opts.session,
-        sessionFile: opts.sessionFile,
-        checklistText,
-        style: opts.style,
-        headed: opts.headed,
-        onProgress: (e) => process.stderr.write(`  ▸ ${e}\n`),
-      });
-
-      process.stdout.write(
-        `\n=== ${result.testCases.length} test cases → ${result.runDir}\\testcases\\ ===\n`,
-      );
-      for (const tc of result.testCases) {
-        const exec = tc.execution === "manual" ? "MTC/manual" : "ATC/auto";
-        process.stdout.write(`[${exec} · ${tc.priority}/${tc.type}] ${tc.title}\n`);
-      }
-      for (const f of result.testCaseFiles) process.stdout.write(`  ${f}\n`);
-      if (result.scores.length > 0) {
-        process.stdout.write("\n=== Metrics ===\n");
-        for (const s of result.scores) {
-          process.stdout.write(`  ${s.name}: ${s.value.toFixed(2)}${s.comment ? ` — ${s.comment}` : ""}\n`);
-        }
-      }
-      printCost(result.cost);
-    },
-  );
-
-program
-  .command("automate")
-  .description("Generate @playwright/test from ready cases (runs/<id>/testcases/*.md)")
-  .requiredOption("--run <dir>", "design run folder (runs/<id>)")
-  .option("--validate", "run the generated tests (a session is required)")
-  .option("--session <name>", "session name for validation")
-  .option("--session-file <path>", "path to storageState for validation")
-  .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
-  .action(
-    async (opts: { run: string; validate?: boolean; session?: string; sessionFile?: string; routing?: string }) => {
-      const env: Record<string, string | undefined> = { ...process.env };
-      if (opts.routing) env.LLM_ROUTING = opts.routing;
-      const config = loadConfig(env);
-      process.stderr.write(`▸ Automating cases from ${opts.run}…\n`);
-      const result = await runAutomate({
-        runDir: opts.run,
-        config,
-        validate: opts.validate,
-        sessionName: opts.session,
-        sessionFile: opts.sessionFile,
-        onProgress: (e) => process.stderr.write(`  ▸ ${e}\n`),
-      });
-      process.stdout.write(
-        `\n=== ${result.specFiles.length} spec files → ${result.runDir}\\tests\\ ===\n`,
-      );
-      for (const f of result.specFiles) process.stdout.write(`  ${f}\n`);
-      if (result.validation) {
-        process.stdout.write(
-          `\nValidation: ${Math.round(result.validation.greenRatio * 100)}% green out of ${result.validation.results.length} tests\n`,
-        );
-      }
-      printCost(result.cost);
-      // L1-04 (Box 4): same consolidated footer as `explore` — pass/fail · cost · budget · path.
-      process.stdout.write("\n");
-      for (const line of renderRunSummary({
-        runDir: result.runDir,
-        validation: result.validation,
-        cost: result.cost,
-        budget: result.budget,
-        stoppedEarly: result.stoppedEarly,
-      })) {
-        process.stdout.write(`${line}\n`);
-      }
-    },
-  );
-
-program
-  .command("promote")
-  .description("Promote manual MTC case(s) to automatable ATC (.md only; run `automate` to generate code)")
-  .requiredOption("--run <dir>", "run folder (runs/<id>)")
-  .requiredOption("--cases <ids>", "comma-separated MTC ids, e.g. MTC-DEMO-001,MTC-DEMO-003")
-  .option("--session <name>", "session for the live selector fallback")
-  .option("--session-file <path>", "storageState path for the live selector fallback")
-  .action(
-    async (opts: { run: string; cases: string; session?: string; sessionFile?: string }) => {
-      const config = loadConfig(process.env);
-      const runDir = resolve(opts.run);
-      const ids = opts.cases.split(",").map((s) => s.trim()).filter(Boolean);
-
-      // Live fallback only when a session is provided (best-effort — see note).
-      let collectLive: PromoteDeps["collectLive"];
-      let storageState: StorageState | undefined;
-      if (opts.sessionFile) storageState = await new SessionStore(resolve(".auth")).loadFile(resolve(opts.sessionFile));
-      else if (opts.session) storageState = await new SessionStore(resolve(".auth")).load(opts.session);
-      if (storageState) {
-        collectLive = async (url: string, refs: string[]): Promise<Map<string, string>> => {
-          const gateway = makeGateway({ backend: config.browser.backend, storageState, channel: config.browser.channel });
-          try {
-            await gateway.observe({ url });
-            const verified = await gateway.verify(refs.map((ref) => ({ ref, role: "", name: undefined, interactive: true, rank: 0 })));
-            const out = new Map<string, string>();
-            for (const v of verified) if (v.verified) out.set(v.ref, locatorFor(v));
-            return out;
-          } finally {
-            await gateway.close();
-          }
-        };
-      }
-
-      process.stderr.write(`▸ Promoting ${String(ids.length)} case(s) from ${opts.run}…\n`);
-      for (const id of ids) {
-        const res = await promoteCase(runDir, id, { collectLive });
-        process.stdout.write(`${res.oldId} → ${res.newId}${res.warning ? ` (⚠ ${res.warning})` : ""}\n`);
-      }
-      process.stdout.write(`\nDone. Run \`cairn automate --run ${opts.run}\` to generate code for the new ATC case(s).\n`);
-    },
-  );
+// C1-01 — shared umbrella core: flag→config, the cost footer, and the modality registry/dispatch.
+import { resolveConfig, printCost, runModality, MODALITIES } from "../core/index.js";
 
 /**
  * Shared capture action for `cairn session capture` and the flat `cairn login` alias.
@@ -428,58 +48,368 @@ async function runCapture(opts: { url: string; name?: string; channel?: string; 
   process.stdout.write(`  Note: .auth/ is gitignored — never commit session files.\n`);
 }
 
-// `cairn session <capture|ls|rm>` — first-class management of saved login sessions (L1-05).
-const session = program.command("session").description("Manage saved login sessions (.auth/)");
+/**
+ * Build the `cairn` commander program. Exported (C1-02) so tests can drive commands and snapshot
+ * `--help` without running the process entry point. Each call returns a fresh, independent program.
+ */
+export function buildProgram(): Command {
+  const program = new Command();
+  program
+    .name("cairn")
+    .description(`${BOT_NAME} — autonomous UI test generator`)
+    .version(BOT_VERSION);
 
-session
-  .command("capture")
-  .description("Capture a login session interactively (opens a headed browser; press Enter when logged in)")
-  .requiredOption("--url <loginUrl>", "login page URL to open")
-  .option("--name <name>", "session name (default: derived from the URL host)")
-  .option("--channel <channel>", "browser channel, e.g. chrome (helps with OAuth; default from config)")
-  .option("--dir <dir>", "sessions directory", ".auth")
-  .action(runCapture);
+  program
+    .command("observe")
+    .description("Explore a page: ARIA snapshot + interactive elements + screenshot")
+    .requiredOption("--url <url>", "page URL")
+    .option("--backend <kind>", "lib | cli", "lib")
+    .option("--session <name>", "name of the saved session (.auth/<name>.storageState.json)")
+    .option("--out <file>", "where to save the screenshot", "observe-screenshot.png")
+    .action(async (opts: { url: string; backend: string; session?: string; out: string }) => {
+      const backend: BackendKind = opts.backend === "cli" ? "cli" : "lib";
+      const config = loadConfig(process.env);
+      let storageState: StorageState | undefined;
+      if (opts.session) {
+        storageState = await new SessionStore(resolve(".auth")).load(opts.session);
+      }
+      const gateway = makeGateway({ backend, storageState, channel: config.browser.channel });
+      try {
+        const study = await capture(gateway, opts.url);
+        const interactive = study.elements.filter((e) => e.interactive);
+        process.stdout.write(`URL: ${study.url} (backend: ${study.capturedBy})\n`);
+        process.stdout.write(
+          `Elements: ${study.elements.length}, interactive: ${interactive.length}\n\n`,
+        );
+        process.stdout.write(`${study.ariaYaml}\n\nInteractive:\n`);
+        for (const e of interactive) {
+          process.stdout.write(`  [${e.ref}] ${e.role}${e.name ? ` "${e.name}"` : ""}\n`);
+        }
+        await mkdir(dirname(opts.out), { recursive: true });
+        await writeFile(opts.out, Buffer.from(study.screenshotB64, "base64"));
+        process.stdout.write(`\nScreenshot → ${opts.out}\n`);
+      } finally {
+        await gateway.close();
+      }
+    });
 
-session
-  .command("ls")
-  .description("List saved sessions")
-  .option("--dir <dir>", "sessions directory", ".auth")
-  .action(async (opts: { dir: string }) => {
-    const names = await new SessionStore(resolve(opts.dir)).list();
-    if (names.length === 0) {
-      process.stdout.write(
-        "No saved sessions. Capture one: cairn session capture --url <loginUrl> --name <name>\n",
+  // explore = the first REAL modality. The command keeps its exact flags/description (parity,
+  // C1-02); its action delegates to the shared core (runModality → exploreModality.run).
+  program
+    .command("explore")
+    .description("Explore a page and generate methodology-based test cases (Sprint 2: no code)")
+    .requiredOption("--url <url>", "page URL")
+    .option("--backend <kind>", "lib | cli (overrides BROWSER_BACKEND)")
+    .option("--session <name>", "name of the saved session (.auth/<name>.storageState.json)")
+    .option("--session-file <path>", "direct path to a storageState file (any name)")
+    .option("--headed", "visible browser (debug)")
+    .option("--checklist <file>", "checklist file (md/text) — guides what to test")
+    .option("--style <s>", "planning style: happy | negative | coverage | all")
+    .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
+    .action(async (opts: Record<string, unknown>) => {
+      await runModality("explore", opts);
+    });
+
+  program
+    .command("dataset-add")
+    .description("Add a run (study.json) to an experiment dataset")
+    .requiredOption("--from-run <dir>", "runs/<id> folder")
+    .requiredOption("--to <file>", "dataset file (JSON)")
+    .action(async (opts: { fromRun: string; to: string }) => {
+      const study = JSON.parse(await readFile(join(opts.fromRun, "study.json"), "utf8")) as PageStudy;
+      let pageSemantics = "";
+      try {
+        const rep = JSON.parse(await readFile(join(opts.fromRun, "report.json"), "utf8")) as {
+          pageSemantics?: string;
+        };
+        pageSemantics = rep.pageSemantics ?? "";
+      } catch {
+        // report.json is optional
+      }
+      let ds: { items: DatasetItem[] } = { items: [] };
+      try {
+        ds = JSON.parse(await readFile(opts.to, "utf8")) as { items: DatasetItem[] };
+      } catch {
+        // new dataset
+      }
+      const id = `item-${ds.items.length + 1}`;
+      ds.items.push({ id, study, pageSemantics });
+      await mkdir(dirname(opts.to) || ".", { recursive: true });
+      await writeFile(opts.to, JSON.stringify(ds, null, 2), "utf8");
+      process.stdout.write(`Added ${id} → ${opts.to} (total items: ${ds.items.length})\n`);
+    });
+
+  program
+    .command("experiment")
+    .description("Compare prompt versions on a dataset (B2 self-improvement)")
+    .requiredOption("--dataset <file>", "dataset file (JSON)")
+    .option("--candidate <spec>", "promptName=file.md — candidate prompt vs production")
+    .option("--target <metric>", "target verdict metric", "grounding")
+    .action(async (opts: { dataset: string; candidate?: string; target: string }) => {
+      const config = loadConfig(process.env);
+      const keys = {
+        anthropicApiKey: config.anthropicApiKey,
+        openrouterApiKey: config.openrouterApiKey,
+        groqApiKey: config.groqApiKey,
+      };
+      const ds = JSON.parse(await readFile(opts.dataset, "utf8")) as { items: DatasetItem[] };
+
+      const variants: Variant[] = [{ label: "production", prompts: new PromptRegistry() }];
+      if (opts.candidate) {
+        const eq = opts.candidate.indexOf("=");
+        const name = opts.candidate.slice(0, eq);
+        const text = await readFile(opts.candidate.slice(eq + 1), "utf8");
+        variants.push({
+          label: "candidate",
+          prompts: new PromptRegistry({ local: { ...LOCAL_PROMPTS, [name]: text } }),
+        });
+      }
+
+      process.stderr.write(`▸ Experiment: ${ds.items.length} items × ${variants.length} versions…\n`);
+      const result = await runExperiment(
+        ds.items,
+        variants,
+        {
+          designInvoke: structuredInvoker(
+            makeModel(config.models.reasoning, keys),
+            structuredMethodFor(config.models.reasoning.provider),
+          ),
+          judgeInvoke: structuredInvoker(
+            makeModel(config.models.judge, keys),
+            structuredMethodFor(config.models.judge.provider),
+          ),
+        },
+        { target: opts.target },
       );
-      return;
-    }
-    process.stdout.write(`Saved sessions (${opts.dir}):\n`);
-    for (const n of names) process.stdout.write(`  ${n}\n`);
-  });
 
-session
-  .command("rm <name>")
-  .description("Remove a saved session")
-  .option("--dir <dir>", "sessions directory", ".auth")
-  .action(async (name: string, opts: { dir: string }) => {
-    const removed = await new SessionStore(resolve(opts.dir)).remove(name);
-    process.stdout.write(removed ? `✓ Removed session "${name}".\n` : `No session "${name}" to remove.\n`);
-  });
+      process.stdout.write(`\n=== Experiment (${ds.items.length} items) ===\n`);
+      for (const v of result.perVariant) {
+        process.stdout.write(`\n[${v.label}]\n`);
+        for (const [name, val] of Object.entries(v.meanScores)) {
+          process.stdout.write(`  ${name}: ${val.toFixed(3)}\n`);
+        }
+      }
+      if (result.verdict) {
+        const vd = result.verdict;
+        const reg = vd.guardrailRegressions.length ? `; regressions: ${vd.guardrailRegressions.join(", ")}` : "";
+        process.stdout.write(
+          `\n=== Verdict: candidate ${vd.improved ? "BETTER ✓" : "NOT better ✗"} (${vd.target} Δ=${vd.delta.toFixed(3)})${reg} ===\n`,
+        );
+        process.stdout.write(
+          vd.improved
+            ? "  → the version can be promoted (Langfuse label=production) — runbook promote-prompt.\n"
+            : "  → reject/iterate the prompt.\n",
+        );
+      }
+    });
 
-// Flat alias: `cairn login` == `cairn session capture` (issue #27 — acceptable shorthand).
-program
-  .command("login")
-  .description("Alias for `cairn session capture` — capture a login session interactively")
-  .requiredOption("--url <loginUrl>", "login page URL to open")
-  .option("--name <name>", "session name (default: derived from the URL host)")
-  .option("--channel <channel>", "browser channel, e.g. chrome (helps with OAuth; default from config)")
-  .option("--dir <dir>", "sessions directory", ".auth")
-  .action(runCapture);
+  program
+    .command("design")
+    .description("Explore a page and WRITE test cases in ATC format (.md, with selectors), WITHOUT code")
+    .requiredOption("--url <url>", "page URL")
+    .option("--session <name>", "name of the saved session")
+    .option("--session-file <path>", "path to a storageState file")
+    .option("--checklist <file>", "checklist file — guides what to test")
+    .option("--style <s>", "planning style: happy | negative | coverage | all")
+    .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
+    .option("--headed", "visible browser (debug)")
+    .action(
+      async (opts: {
+        url: string;
+        session?: string;
+        sessionFile?: string;
+        checklist?: string;
+        style?: string;
+        headed?: boolean;
+        routing?: string;
+      }) => {
+        const config = resolveConfig({ routing: opts.routing });
+        const checklistText = opts.checklist ? await readFile(opts.checklist, "utf8") : undefined;
+        process.stderr.write(`▸ Designing test cases for ${opts.url}${opts.session ? ` (session: ${opts.session})` : ""}…\n`);
+        const result = await runDesign({
+          url: opts.url,
+          config,
+          sessionName: opts.session,
+          sessionFile: opts.sessionFile,
+          checklistText,
+          style: opts.style,
+          headed: opts.headed,
+          onProgress: (e) => process.stderr.write(`  ▸ ${e}\n`),
+        });
+
+        process.stdout.write(
+          `\n=== ${result.testCases.length} test cases → ${result.runDir}\\testcases\\ ===\n`,
+        );
+        for (const tc of result.testCases) {
+          const exec = tc.execution === "manual" ? "MTC/manual" : "ATC/auto";
+          process.stdout.write(`[${exec} · ${tc.priority}/${tc.type}] ${tc.title}\n`);
+        }
+        for (const f of result.testCaseFiles) process.stdout.write(`  ${f}\n`);
+        if (result.scores.length > 0) {
+          process.stdout.write("\n=== Metrics ===\n");
+          for (const s of result.scores) {
+            process.stdout.write(`  ${s.name}: ${s.value.toFixed(2)}${s.comment ? ` — ${s.comment}` : ""}\n`);
+          }
+        }
+        printCost(result.cost);
+      },
+    );
+
+  program
+    .command("automate")
+    .description("Generate @playwright/test from ready cases (runs/<id>/testcases/*.md)")
+    .requiredOption("--run <dir>", "design run folder (runs/<id>)")
+    .option("--validate", "run the generated tests (a session is required)")
+    .option("--session <name>", "session name for validation")
+    .option("--session-file <path>", "path to storageState for validation")
+    .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
+    .action(
+      async (opts: { run: string; validate?: boolean; session?: string; sessionFile?: string; routing?: string }) => {
+        const config = resolveConfig({ routing: opts.routing });
+        process.stderr.write(`▸ Automating cases from ${opts.run}…\n`);
+        const result = await runAutomate({
+          runDir: opts.run,
+          config,
+          validate: opts.validate,
+          sessionName: opts.session,
+          sessionFile: opts.sessionFile,
+          onProgress: (e) => process.stderr.write(`  ▸ ${e}\n`),
+        });
+        process.stdout.write(
+          `\n=== ${result.specFiles.length} spec files → ${result.runDir}\\tests\\ ===\n`,
+        );
+        for (const f of result.specFiles) process.stdout.write(`  ${f}\n`);
+        if (result.validation) {
+          process.stdout.write(
+            `\nValidation: ${Math.round(result.validation.greenRatio * 100)}% green out of ${result.validation.results.length} tests\n`,
+          );
+        }
+        printCost(result.cost);
+        // L1-04 (Box 4): same consolidated footer as `explore` — pass/fail · cost · budget · path.
+        process.stdout.write("\n");
+        for (const line of renderRunSummary({
+          runDir: result.runDir,
+          validation: result.validation,
+          cost: result.cost,
+          budget: result.budget,
+          stoppedEarly: result.stoppedEarly,
+        })) {
+          process.stdout.write(`${line}\n`);
+        }
+      },
+    );
+
+  program
+    .command("promote")
+    .description("Promote manual MTC case(s) to automatable ATC (.md only; run `automate` to generate code)")
+    .requiredOption("--run <dir>", "run folder (runs/<id>)")
+    .requiredOption("--cases <ids>", "comma-separated MTC ids, e.g. MTC-DEMO-001,MTC-DEMO-003")
+    .option("--session <name>", "session for the live selector fallback")
+    .option("--session-file <path>", "storageState path for the live selector fallback")
+    .action(
+      async (opts: { run: string; cases: string; session?: string; sessionFile?: string }) => {
+        const config = loadConfig(process.env);
+        const runDir = resolve(opts.run);
+        const ids = opts.cases.split(",").map((s) => s.trim()).filter(Boolean);
+
+        // Live fallback only when a session is provided (best-effort — see note).
+        let collectLive: PromoteDeps["collectLive"];
+        let storageState: StorageState | undefined;
+        if (opts.sessionFile) storageState = await new SessionStore(resolve(".auth")).loadFile(resolve(opts.sessionFile));
+        else if (opts.session) storageState = await new SessionStore(resolve(".auth")).load(opts.session);
+        if (storageState) {
+          collectLive = async (url: string, refs: string[]): Promise<Map<string, string>> => {
+            const gateway = makeGateway({ backend: config.browser.backend, storageState, channel: config.browser.channel });
+            try {
+              await gateway.observe({ url });
+              const verified = await gateway.verify(refs.map((ref) => ({ ref, role: "", name: undefined, interactive: true, rank: 0 })));
+              const out = new Map<string, string>();
+              for (const v of verified) if (v.verified) out.set(v.ref, locatorFor(v));
+              return out;
+            } finally {
+              await gateway.close();
+            }
+          };
+        }
+
+        process.stderr.write(`▸ Promoting ${String(ids.length)} case(s) from ${opts.run}…\n`);
+        for (const id of ids) {
+          const res = await promoteCase(runDir, id, { collectLive });
+          process.stdout.write(`${res.oldId} → ${res.newId}${res.warning ? ` (⚠ ${res.warning})` : ""}\n`);
+        }
+        process.stdout.write(`\nDone. Run \`cairn automate --run ${opts.run}\` to generate code for the new ATC case(s).\n`);
+      },
+    );
+
+  // `cairn session <capture|ls|rm>` — first-class management of saved login sessions (L1-05).
+  const session = program.command("session").description("Manage saved login sessions (.auth/)");
+
+  session
+    .command("capture")
+    .description("Capture a login session interactively (opens a headed browser; press Enter when logged in)")
+    .requiredOption("--url <loginUrl>", "login page URL to open")
+    .option("--name <name>", "session name (default: derived from the URL host)")
+    .option("--channel <channel>", "browser channel, e.g. chrome (helps with OAuth; default from config)")
+    .option("--dir <dir>", "sessions directory", ".auth")
+    .action(runCapture);
+
+  session
+    .command("ls")
+    .description("List saved sessions")
+    .option("--dir <dir>", "sessions directory", ".auth")
+    .action(async (opts: { dir: string }) => {
+      const names = await new SessionStore(resolve(opts.dir)).list();
+      if (names.length === 0) {
+        process.stdout.write(
+          "No saved sessions. Capture one: cairn session capture --url <loginUrl> --name <name>\n",
+        );
+        return;
+      }
+      process.stdout.write(`Saved sessions (${opts.dir}):\n`);
+      for (const n of names) process.stdout.write(`  ${n}\n`);
+    });
+
+  session
+    .command("rm <name>")
+    .description("Remove a saved session")
+    .option("--dir <dir>", "sessions directory", ".auth")
+    .action(async (name: string, opts: { dir: string }) => {
+      const removed = await new SessionStore(resolve(opts.dir)).remove(name);
+      process.stdout.write(removed ? `✓ Removed session "${name}".\n` : `No session "${name}" to remove.\n`);
+    });
+
+  // Flat alias: `cairn login` == `cairn session capture` (issue #27 — acceptable shorthand).
+  program
+    .command("login")
+    .description("Alias for `cairn session capture` — capture a login session interactively")
+    .requiredOption("--url <loginUrl>", "login page URL to open")
+    .option("--name <name>", "session name (default: derived from the URL host)")
+    .option("--channel <channel>", "browser channel, e.g. chrome (helps with OAuth; default from config)")
+    .option("--dir <dir>", "sessions directory", ".auth")
+    .action(runCapture);
+
+  // C1-01: GATED modality stubs (ui|e2e, api, unit, docs). Discoverable placeholders with ZERO
+  // generation logic — each dispatches through runModality, which prints the coming-soon notice and
+  // exits 0. #21–24 stay gated behind a named-user pull (L-G2 / #25): build by demand, one at a time.
+  for (const m of MODALITIES.filter((x) => x.gated)) {
+    const c = program
+      .command(m.name)
+      .description(`${m.summary} — coming soon (gated; see L-G2)`)
+      .action(async () => {
+        await runModality(m.name, {});
+      });
+    if (m.aliases?.length) c.aliases(m.aliases);
+  }
+
+  return program;
+}
 
 /**
  * Run the CLI. Shared by the primary `cairn` entry (this file) and the deprecated
  * `lex-bot` alias shim (./lex-bot.ts), so both go through the exact same code path.
  */
 export async function runCli(): Promise<void> {
+  const program = buildProgram();
   const cliArgs = process.argv.slice(2);
   if (cliArgs.length === 0 && process.stdin.isTTY && process.stdout.isTTY) {
     // No command in an interactive terminal → launch the TUI (lazy: keeps React/Ink

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,0 +1,32 @@
+/**
+ * C1-01 — shared core: the single place that turns CLI flags into an {@link AppConfig}.
+ *
+ * Every modality command (explore today; ui/api/unit/docs tomorrow) used to repeat the same
+ * `{ ...process.env }` + override + `loadConfig` dance. Centralizing it here means a new modality
+ * is a thin add, not a fork, and the flag→env mapping lives in exactly one place.
+ */
+import { loadConfig } from "../config/index.js";
+import type { AppConfig } from "../config/index.js";
+
+type Env = Record<string, string | undefined>;
+
+/** CLI flags shared across modality commands that influence configuration. */
+export interface ConfigFlags {
+  /** `--backend lib|cli` → `BROWSER_BACKEND` (browser gateway selection). */
+  backend?: string;
+  /** `--routing <preset>` → `LLM_ROUTING` (per-role routing preset, L1-01/ADR-0011). */
+  routing?: string;
+}
+
+/**
+ * Resolve an {@link AppConfig} from CLI flags layered over `env` (defaults to `process.env`).
+ * Pure: never mutates `env` — overrides are applied to a shallow copy. A set flag wins over the
+ * corresponding env var; an absent flag leaves the env value untouched. All validation (missing
+ * provider keys, bad presets, …) is delegated to {@link loadConfig}, so errors stay identical.
+ */
+export function resolveConfig(flags: ConfigFlags = {}, env: Env = process.env): AppConfig {
+  const merged: Env = { ...env };
+  if (flags.backend) merged.BROWSER_BACKEND = flags.backend;
+  if (flags.routing) merged.LLM_ROUTING = flags.routing;
+  return loadConfig(merged);
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,14 @@
+/**
+ * C1-01 — shared CLI core (the umbrella seam).
+ *
+ * Everything a modality reuses lives here so a new modality is a thin add, not a fork:
+ *  - resolveConfig: the one place CLI flags become an AppConfig
+ *  - printCost: the shared cost footer
+ *  - the Modality type + registry + dispatch (runModality) + gated-stub notice
+ */
+export { resolveConfig } from "./config.js";
+export type { ConfigFlags } from "./config.js";
+export { printCost } from "./reporting.js";
+export { defaultIO, gatedNotice } from "./modality.js";
+export type { Modality, ModalityContext, IO, Sink } from "./modality.js";
+export { MODALITIES, getModality, runModality } from "./registry.js";

--- a/src/core/modalities/explore.ts
+++ b/src/core/modalities/explore.ts
@@ -1,0 +1,101 @@
+/**
+ * C1-01 — the `explore` modality: the first REAL modality consuming the shared core.
+ *
+ * It wraps {@link runExploration} plus the shared render/cost/summary helpers (resolveConfig +
+ * printCost + renderRunSummary). The CLI `explore` command is now a thin delegate to this `run`,
+ * so its output is identical to the pre-extraction inline action (locked by the C1-02 parity test).
+ */
+import { readFile } from "node:fs/promises";
+import { runExploration } from "../../agent/index.js";
+import { renderRunSummary } from "../../agent/summary.js";
+import { resolveConfig } from "../config.js";
+import { printCost } from "../reporting.js";
+import type { Modality, ModalityContext } from "../modality.js";
+
+/** Parsed flags for `cairn explore` (mirrors the command's option definitions). */
+interface ExploreFlags {
+  url: string;
+  backend?: string;
+  session?: string;
+  sessionFile?: string;
+  headed?: boolean;
+  checklist?: string;
+  style?: string;
+  routing?: string;
+}
+
+export const exploreModality: Modality = {
+  name: "explore",
+  gated: false,
+  summary: "Explore a page and generate methodology-based UI test cases (validate ⇄ repair)",
+  async run(ctx: ModalityContext): Promise<void> {
+    // commander hands the action untyped options; the command's option defs guarantee this shape.
+    const opts = ctx.flags as unknown as ExploreFlags;
+    const config = resolveConfig({ backend: opts.backend, routing: opts.routing });
+    const checklistText = opts.checklist ? await readFile(opts.checklist, "utf8") : undefined;
+    ctx.err(
+      `▸ Exploring ${opts.url}${opts.session ? ` (session: ${opts.session})` : ""}${opts.checklist ? ` (checklist: ${opts.checklist})` : ""}…\n`,
+    );
+    const result = await runExploration({
+      url: opts.url,
+      config,
+      sessionName: opts.session,
+      sessionFile: opts.sessionFile,
+      headed: opts.headed,
+      checklistText,
+      style: opts.style,
+      onProgress: (e) => ctx.err(`  ▸ ${e}\n`),
+    });
+
+    ctx.out(`\n=== Exploration of ${result.study.url} (run ${result.runId}) ===\n`);
+    ctx.out(`Purpose: ${result.analysis.pageSemantics}\n`);
+    ctx.out(`LLM profile: ${config.llmProfile} · test cases: ${result.testCases.length}\n\n`);
+    for (const tc of result.testCases) {
+      ctx.out(`[${tc.id}] (${tc.priority} · ${tc.technique}) ${tc.title}\n`);
+      for (const step of tc.steps) ctx.out(`    - ${step}\n`);
+      ctx.out(`    ⇒ ${tc.expected}\n`);
+      if (tc.elementRefs.length) ctx.out(`    refs: ${tc.elementRefs.join(", ")}\n`);
+      ctx.out("\n");
+    }
+
+    if (result.validation) {
+      const v = result.validation;
+      ctx.out(`=== Validation: ${Math.round(v.greenRatio * 100)}% green (flaky: ${v.flakyCount}) ===\n`);
+      for (const r of v.results) {
+        const mark = r.status === "passed" ? "✓" : r.status === "flaky" ? "~" : "✗";
+        ctx.out(`  ${mark} ${r.test}\n`);
+      }
+    }
+    if (result.scores.length > 0) {
+      ctx.out("\n=== Metrics ===\n");
+      for (const s of result.scores) {
+        ctx.out(`  ${s.name}: ${s.value.toFixed(2)}${s.comment ? ` — ${s.comment}` : ""}\n`);
+      }
+    }
+    if (result.pilot) {
+      ctx.out(
+        `\n=== Pilot: ${result.pilot.verdict.toUpperCase()} ===\n  ${result.pilot.reason}\n  → ${result.pilot.guidance}\n`,
+      );
+    }
+    printCost(result.cost, ctx.out);
+    // L1-04 (Box 4): one unambiguous footer — pass/fail · cost+tokens · budget used · artifact path.
+    ctx.out("\n");
+    for (const line of renderRunSummary({
+      runDir: result.runDir,
+      validation: result.validation,
+      cost: result.cost,
+      budget: result.budget,
+      testCaseCount: result.testCases.length,
+      stoppedEarly: result.stoppedEarly,
+    })) {
+      ctx.out(`${line}\n`);
+    }
+    // #39: explore now also writes ATC/MTC cases, and points at the review-first flow for next time.
+    if (result.testCaseFiles.length > 0) {
+      ctx.out(`  Cases (ATC/MTC .md): ${result.runDir}\\testcases\\\n`);
+    }
+    ctx.out(
+      "\nTip: to review cases BEFORE generating code, run `cairn design` then `cairn automate`.\n",
+    );
+  },
+};

--- a/src/core/modality.ts
+++ b/src/core/modality.ts
@@ -1,0 +1,61 @@
+/**
+ * C1-01 — shared core: the `Modality` type + its supporting IO and the gated-stub notice.
+ *
+ * A "modality" is one kind of test artifact Cairn can generate (UI/API/unit/docs…). Today only
+ * `explore` (UI) is REAL; the rest are GATED stubs (L-G2 / #25): discoverable placeholders with
+ * ZERO generation logic. A future modality is a thin add — register an entry and give it a `run`
+ * that consumes the shared core — not a fork of the whole CLI.
+ */
+
+/** Sink for one chunk of CLI output (stdout or stderr). */
+export type Sink = (s: string) => void;
+
+/** The stdout/stderr sinks a modality writes through — injected in tests, real streams in the CLI. */
+export interface IO {
+  out: Sink;
+  err: Sink;
+}
+
+/** Default IO → the process streams (the production CLI path). */
+export const defaultIO: IO = {
+  out: (s) => void process.stdout.write(s),
+  err: (s) => void process.stderr.write(s),
+};
+
+/** Everything a modality's `run` needs: the parsed CLI flags + output sinks. */
+export interface ModalityContext {
+  /** Parsed commander options for this modality's command. */
+  flags: Record<string, unknown>;
+  out: Sink;
+  err: Sink;
+}
+
+/**
+ * One generation modality. `run` is ABSENT for gated stubs — that absence IS the gate: a stub
+ * carries no runner, so it can never trigger generation. The real `explore` modality supplies a
+ * `run` that wraps {@link runExploration} + the shared render/cost/summary helpers.
+ */
+export interface Modality {
+  /** Command name as typed: `cairn <name>`. */
+  name: string;
+  /** Extra command aliases (e.g. ui ⇄ e2e). */
+  aliases?: string[];
+  /** Gated = coming-soon placeholder; built one at a time, by named demand (L-G2). */
+  gated: boolean;
+  /** One-line description shown in `cairn --help`. */
+  summary: string;
+  /** Optional extra line appended to the gated notice (e.g. ui → points at `cairn explore`). */
+  hint?: string;
+  /** Run the modality. Absent for gated stubs. */
+  run?(ctx: ModalityContext): Promise<void>;
+}
+
+/**
+ * The notice printed when a user runs a gated modality. Pure (returns lines, like
+ * {@link renderRunSummary}) so it is trivially testable: the canonical one-liner + the optional hint.
+ */
+export function gatedNotice(m: Modality): string[] {
+  const lines = [`${m.name}: coming soon — gated (see L-G2). Build by demand, one at a time.`];
+  if (m.hint) lines.push(m.hint);
+  return lines;
+}

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -1,0 +1,48 @@
+/**
+ * C1-01 — the modality registry: the single list every surface (CLI, tests) reads.
+ *
+ * `explore` (UI) is the only REAL modality today. ui/api/unit/docs are GATED stubs (L-G2 / #25):
+ * placeholders with no `run`, pulled one at a time by named demand. Adding a modality = append one
+ * entry (+ a `run` that consumes the shared core). #21–24 stay gated until a named user pulls.
+ */
+import { defaultIO, gatedNotice } from "./modality.js";
+import type { IO, Modality } from "./modality.js";
+import { exploreModality } from "./modalities/explore.js";
+
+export const MODALITIES: Modality[] = [
+  exploreModality,
+  {
+    name: "ui",
+    aliases: ["e2e"],
+    gated: true,
+    summary: "Generate UI / end-to-end tests",
+    hint: "For UI test generation today, use: cairn explore --url <url>",
+  },
+  { name: "api", gated: true, summary: "Generate API / contract tests" },
+  { name: "unit", gated: true, summary: "Generate unit tests" },
+  { name: "docs", gated: true, summary: "Generate docs / doctest examples" },
+];
+
+/** Look up a modality by its name or one of its aliases (e.g. `e2e` → the `ui` modality). */
+export function getModality(nameOrAlias: string): Modality | undefined {
+  return MODALITIES.find((m) => m.name === nameOrAlias || (m.aliases?.includes(nameOrAlias) ?? false));
+}
+
+/**
+ * Dispatch a modality command — the single entry point the CLI actions and tests both drive.
+ * Gated stubs print the coming-soon notice (no generation logic ever runs); a real modality runs
+ * through its `run`. An unknown name throws.
+ */
+export async function runModality(
+  name: string,
+  flags: Record<string, unknown>,
+  io: IO = defaultIO,
+): Promise<void> {
+  const m = getModality(name);
+  if (!m) throw new Error(`Unknown modality "${name}".`);
+  if (!m.run) {
+    for (const line of gatedNotice(m)) io.out(`${line}\n`);
+    return;
+  }
+  await m.run({ flags, out: io.out, err: io.err });
+}

--- a/src/core/reporting.ts
+++ b/src/core/reporting.ts
@@ -1,0 +1,20 @@
+/**
+ * C1-01 — shared core: the cost/summary footer every modality prints.
+ *
+ * `printCost` moved here verbatim out of cli/index.ts so all modalities print the SAME footer.
+ * The default `write` is stdout, so output is byte-identical to the pre-extraction helper.
+ */
+import type { CostReport } from "../llm/cost.js";
+import type { Sink } from "./modality.js";
+
+/** Print the per-role cost + token summary (L1-01). `write` is injectable for tests. */
+export function printCost(cost: CostReport, write: Sink = (s) => void process.stdout.write(s)): void {
+  if (cost.perRole.length === 0) return;
+  write("\n=== Cost (per role) ===\n");
+  for (const c of cost.perRole) {
+    const usd = c.costUsd === null ? "n/a" : `$${c.costUsd.toFixed(4)}`;
+    write(`  ${c.role.padEnd(9)} ${c.calls} call(s)  ${c.inputTokens}→${c.outputTokens} tok  ${usd}\n`);
+  }
+  const total = cost.totalCostUsd === null ? "n/a (some prices unknown)" : `$${cost.totalCostUsd.toFixed(4)}`;
+  write(`  ${"total".padEnd(9)} ${cost.totalTokens} tok  ${total}\n`);
+}

--- a/tests/unit/__snapshots__/cli-modalities.test.ts.snap
+++ b/tests/unit/__snapshots__/cli-modalities.test.ts.snap
@@ -1,0 +1,58 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CLI surface lock (C1-02) > cairn --help lists the four gated stubs, marked coming-soon 1`] = `
+"Usage: cairn [options] [command]
+
+@plune-ai/cairn — autonomous UI test generator
+
+Options:
+  -V, --version          output the version number
+  -h, --help             display help for command
+
+Commands:
+  observe [options]      Explore a page: ARIA snapshot + interactive elements +
+                         screenshot
+  explore [options]      Explore a page and generate methodology-based test
+                         cases (Sprint 2: no code)
+  dataset-add [options]  Add a run (study.json) to an experiment dataset
+  experiment [options]   Compare prompt versions on a dataset (B2
+                         self-improvement)
+  design [options]       Explore a page and WRITE test cases in ATC format (.md,
+                         with selectors), WITHOUT code
+  automate [options]     Generate @playwright/test from ready cases
+                         (runs/<id>/testcases/*.md)
+  promote [options]      Promote manual MTC case(s) to automatable ATC (.md
+                         only; run \`automate\` to generate code)
+  session                Manage saved login sessions (.auth/)
+  login [options]        Alias for \`cairn session capture\` — capture a login
+                         session interactively
+  ui|e2e                 Generate UI / end-to-end tests — coming soon (gated;
+                         see L-G2)
+  api                    Generate API / contract tests — coming soon (gated; see
+                         L-G2)
+  unit                   Generate unit tests — coming soon (gated; see L-G2)
+  docs                   Generate docs / doctest examples — coming soon (gated;
+                         see L-G2)
+  help [command]         display help for command
+"
+`;
+
+exports[`CLI surface lock (C1-02) > cairn explore --help is stable (flags unchanged) 1`] = `
+"Usage: cairn explore [options]
+
+Explore a page and generate methodology-based test cases (Sprint 2: no code)
+
+Options:
+  --url <url>            page URL
+  --backend <kind>       lib | cli (overrides BROWSER_BACKEND)
+  --session <name>       name of the saved session
+                         (.auth/<name>.storageState.json)
+  --session-file <path>  direct path to a storageState file (any name)
+  --headed               visible browser (debug)
+  --checklist <file>     checklist file (md/text) — guides what to test
+  --style <s>            planning style: happy | negative | coverage | all
+  --routing <preset>     role-routing preset: fast (Groq worker) | volume
+                         (OpenRouter worker) (sets LLM_ROUTING)
+  -h, --help             display help for command
+"
+`;

--- a/tests/unit/cli-modalities.test.ts
+++ b/tests/unit/cli-modalities.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * C1-02: CLI parity + back-compat for the umbrella router (C1-01).
+ *  - `explore` 1:1 parity: same flags accepted, same option mapping to runExploration, same output.
+ *  - Gated stubs (ui|e2e|api|unit|docs): print the coming-soon notice, exit 0, NEVER call a runner.
+ *  - Surface lock: snapshot `cairn --help` (now with the 4 stubs) and `cairn explore --help`.
+ *
+ * No live LLM/browser: the agent runners are mocked.
+ */
+const { runExploration, runDesign, runAutomate } = vi.hoisted(() => ({
+  runExploration: vi.fn(),
+  runDesign: vi.fn(),
+  runAutomate: vi.fn(),
+}));
+
+vi.mock("../../src/agent/index.js", () => ({
+  runExploration,
+  runDesign,
+  runAutomate,
+  // re-exported by src/index.ts (BOT_NAME/BOT_VERSION path) — must exist on the mocked module.
+  buildExploreGraph: vi.fn(),
+  ExploreState: {},
+}));
+
+import { buildProgram } from "../../src/cli/index.js";
+
+/** A minimal-but-complete ExploreResult so the explore renderer exercises every branch. */
+const exploreFixture = {
+  runId: "run-1",
+  runDir: "/runs/run-1",
+  study: { url: "https://app.test" },
+  analysis: { pageSemantics: "A login page" },
+  testCases: [
+    {
+      id: "tc-1",
+      priority: "high",
+      technique: "boundary-value",
+      title: "Title",
+      steps: ["step one"],
+      expected: "ok",
+      elementRefs: ["e1"],
+    },
+  ],
+  validation: {
+    results: [
+      { test: "loads", status: "passed" },
+      { test: "rejects empty", status: "failed" },
+    ],
+    greenRatio: 0.5,
+    flakyCount: 0,
+  },
+  scores: [{ name: "grounding", value: 0.9, comment: "good" }],
+  pilot: { verdict: "pass", reason: "looks fine", guidance: "ship it" },
+  cost: {
+    perRole: [
+      { role: "worker", models: ["m"], calls: 2, inputTokens: 100, outputTokens: 20, totalTokens: 120, costUsd: 0.01 },
+    ],
+    totalTokens: 120,
+    totalCostUsd: 0.01,
+  },
+  budget: { used: 5, max: 80 },
+  stoppedEarly: false,
+  testCaseFiles: ["/runs/run-1/testcases/ATC-1.md"],
+};
+
+let outChunks: string[];
+let errChunks: string[];
+let outSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  outChunks = [];
+  errChunks = [];
+  outSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    outChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+    return true;
+  });
+  errSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+    errChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+    return true;
+  });
+  runExploration.mockReset();
+  runDesign.mockReset();
+  runAutomate.mockReset();
+  runExploration.mockResolvedValue(exploreFixture);
+  // Deterministic config (independent of any .env): anthropic profile, no routing by default.
+  vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-test");
+  vi.stubEnv("OPENROUTER_API_KEY", "sk-or-test");
+  vi.stubEnv("LLM_PROFILE", "anthropic");
+  vi.stubEnv("LLM_ROUTING", "");
+});
+
+afterEach(() => {
+  outSpy.mockRestore();
+  errSpy.mockRestore();
+  vi.unstubAllEnvs();
+});
+
+describe("explore parity (C1-02)", () => {
+  it("accepts exactly the documented flag surface", () => {
+    const explore = buildProgram().commands.find((c) => c.name() === "explore");
+    expect(explore).toBeDefined();
+    const longs = (explore?.options ?? []).map((o) => o.long);
+    for (const f of [
+      "--url",
+      "--backend",
+      "--session",
+      "--session-file",
+      "--headed",
+      "--checklist",
+      "--style",
+      "--routing",
+    ]) {
+      expect(longs, `explore should accept ${f}`).toContain(f);
+    }
+    expect(longs).toHaveLength(8); // no flags added or dropped by the refactor
+  });
+
+  it("maps flags to runExploration the same way as before the refactor", async () => {
+    await buildProgram().parseAsync([
+      "node",
+      "cairn",
+      "explore",
+      "--url",
+      "https://app.test",
+      "--session",
+      "mysess",
+      "--style",
+      "happy",
+      "--backend",
+      "cli",
+      "--routing",
+      "volume",
+    ]);
+
+    expect(runExploration).toHaveBeenCalledTimes(1);
+    const arg = runExploration.mock.calls[0][0];
+    expect(arg.url).toBe("https://app.test");
+    expect(arg.sessionName).toBe("mysess");
+    expect(arg.sessionFile).toBeUndefined();
+    expect(arg.headed).toBeUndefined();
+    expect(arg.checklistText).toBeUndefined();
+    expect(arg.style).toBe("happy");
+    expect(typeof arg.onProgress).toBe("function");
+    // --backend / --routing flow through resolveConfig into the AppConfig
+    expect(arg.config.browser.backend).toBe("cli");
+    expect(arg.config.roles?.worker?.provider).toBe("openrouter");
+  });
+
+  it("prints the same exploration / metrics / cost / summary structure", async () => {
+    await buildProgram().parseAsync(["node", "cairn", "explore", "--url", "https://app.test", "--session", "mysess"]);
+    const stdout = outChunks.join("");
+    const stderr = errChunks.join("");
+
+    expect(stderr).toContain("▸ Exploring https://app.test (session: mysess)");
+    expect(stdout).toContain("=== Exploration of https://app.test (run run-1) ===");
+    expect(stdout).toContain("Purpose: A login page");
+    expect(stdout).toContain("LLM profile: anthropic · test cases: 1");
+    expect(stdout).toContain("[tc-1] (high · boundary-value) Title");
+    expect(stdout).toContain("    ⇒ ok");
+    expect(stdout).toContain("=== Validation: 50% green (flaky: 0) ===");
+    expect(stdout).toContain("=== Metrics ===");
+    expect(stdout).toContain("=== Pilot: PASS ===");
+    expect(stdout).toContain("=== Cost (per role) ===");
+    expect(stdout).toContain("=== Run summary ===");
+    expect(stdout).toContain("Cases (ATC/MTC .md):");
+    expect(stdout).toContain("Tip: to review cases BEFORE generating code, run `cairn design` then `cairn automate`.");
+  });
+});
+
+describe("gated modality stubs (C1-02)", () => {
+  for (const name of ["ui", "e2e", "api", "unit", "docs"]) {
+    it(`cairn ${name} prints coming-soon, exits 0, and calls NO runner`, async () => {
+      await buildProgram().parseAsync(["node", "cairn", name]);
+      expect(outChunks.join("")).toContain("coming soon — gated (see L-G2). Build by demand, one at a time.");
+      expect(runExploration).not.toHaveBeenCalled();
+      expect(runDesign).not.toHaveBeenCalled();
+      expect(runAutomate).not.toHaveBeenCalled();
+      expect(process.exitCode ?? 0).toBe(0);
+    });
+  }
+
+  it("the ui stub additionally points at today's path (cairn explore)", async () => {
+    await buildProgram().parseAsync(["node", "cairn", "ui"]);
+    expect(outChunks.join("")).toContain("For UI test generation today, use: cairn explore --url <url>");
+  });
+});
+
+describe("CLI surface lock (C1-02)", () => {
+  it("cairn --help lists the four gated stubs, marked coming-soon", () => {
+    const program = buildProgram();
+    program.configureHelp({ helpWidth: 80 });
+    const help = program.helpInformation();
+    expect(help).toContain("ui|e2e");
+    expect(help).toContain("api");
+    expect(help).toContain("unit");
+    expect(help).toContain("docs");
+    expect(help).toMatch(/coming soon|gated/i);
+    expect(help).toMatchSnapshot();
+  });
+
+  it("cairn explore --help is stable (flags unchanged)", () => {
+    const explore = buildProgram().commands.find((c) => c.name() === "explore");
+    explore?.configureHelp({ helpWidth: 80 });
+    expect(explore?.helpInformation()).toMatchSnapshot();
+  });
+});

--- a/tests/unit/core-config.test.ts
+++ b/tests/unit/core-config.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { resolveConfig } from "../../src/core/config.js";
+
+/**
+ * C1-01: resolveConfig is the ONE place that maps CLI flags (--backend, --routing) onto the
+ * env contract loadConfig reads. Previously this `{...process.env}` + override dance was
+ * duplicated verbatim in the explore/design/automate commands.
+ */
+const baseEnv = {
+  ANTHROPIC_API_KEY: "sk-ant-test",
+  OPENROUTER_API_KEY: "sk-or-test",
+};
+
+describe("resolveConfig (C1-01 — shared flag→config seam)", () => {
+  it("with no flags, behaves like loadConfig(env) (defaults: anthropic + lib backend)", () => {
+    const cfg = resolveConfig({}, { ...baseEnv });
+    expect(cfg.llmProfile).toBe("anthropic");
+    expect(cfg.browser.backend).toBe("lib");
+    expect(cfg.roles).toBeUndefined();
+  });
+
+  it("--backend maps to BROWSER_BACKEND", () => {
+    expect(resolveConfig({ backend: "cli" }, { ...baseEnv }).browser.backend).toBe("cli");
+  });
+
+  it("--routing maps to LLM_ROUTING (volume → cheap worker / smart reasoner)", () => {
+    const cfg = resolveConfig({ routing: "volume" }, { ...baseEnv });
+    expect(cfg.roles?.worker?.provider).toBe("openrouter");
+    expect(cfg.roles?.reasoner?.provider).toBe("anthropic");
+  });
+
+  it("--backend and --routing compose", () => {
+    const cfg = resolveConfig({ backend: "cli", routing: "volume" }, { ...baseEnv });
+    expect(cfg.browser.backend).toBe("cli");
+    expect(cfg.roles?.worker?.provider).toBe("openrouter");
+  });
+
+  it("absent flags do NOT clobber env values already set", () => {
+    const cfg = resolveConfig({}, { ...baseEnv, BROWSER_BACKEND: "cli" });
+    expect(cfg.browser.backend).toBe("cli"); // env wins because no flag overrides it
+  });
+
+  it("does not mutate the caller's env object (pure)", () => {
+    const env = { ...baseEnv };
+    resolveConfig({ backend: "cli", routing: "volume" }, env);
+    expect("BROWSER_BACKEND" in env).toBe(false);
+    expect("LLM_ROUTING" in env).toBe(false);
+  });
+
+  it("propagates loadConfig validation errors (e.g. a routed role with a missing key)", () => {
+    // volume routes worker→OpenRouter; only the Anthropic key is present → must throw by role+provider
+    expect(() => resolveConfig({ routing: "volume" }, { ANTHROPIC_API_KEY: "a" })).toThrow(
+      /Role 'worker'.*OpenRouter/i,
+    );
+  });
+});

--- a/tests/unit/core-modality.test.ts
+++ b/tests/unit/core-modality.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { gatedNotice } from "../../src/core/modality.js";
+import { MODALITIES, getModality, runModality } from "../../src/core/registry.js";
+
+/**
+ * C1-01: a `Modality` is one kind of test artifact Cairn can generate. Today only `explore` (UI)
+ * is real; ui/api/unit/docs are GATED stubs (L-G2 / #25) — discoverable placeholders with ZERO
+ * generation logic. The registry is the seam every modality reuses.
+ */
+
+/** Collect what a modality would write to stdout/stderr. */
+function capture(): { io: { out: (s: string) => void; err: (s: string) => void }; out: string[]; err: string[] } {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { io: { out: (s) => void out.push(s), err: (s) => void err.push(s) }, out, err };
+}
+
+describe("gatedNotice (pure)", () => {
+  it("renders the canonical coming-soon line for a gated modality", () => {
+    expect(gatedNotice({ name: "api", gated: true, summary: "x" })).toEqual([
+      "api: coming soon — gated (see L-G2). Build by demand, one at a time.",
+    ]);
+  });
+
+  it("appends the modality's hint line when present (ui → points at explore)", () => {
+    const lines = gatedNotice({
+      name: "ui",
+      gated: true,
+      summary: "x",
+      hint: "For UI test generation today, use: cairn explore --url <url>",
+    });
+    expect(lines[0]).toBe("ui: coming soon — gated (see L-G2). Build by demand, one at a time.");
+    expect(lines[1]).toBe("For UI test generation today, use: cairn explore --url <url>");
+  });
+});
+
+describe("registry (C1-01)", () => {
+  it("registers explore as the only REAL modality (has a run); ui/api/unit/docs are gated stubs", () => {
+    const explore = getModality("explore");
+    expect(explore?.gated).toBe(false);
+    expect(typeof explore?.run).toBe("function");
+
+    for (const name of ["ui", "api", "unit", "docs"]) {
+      const m = getModality(name);
+      expect(m, `modality ${name} should exist`).toBeDefined();
+      expect(m?.gated, `${name} should be gated`).toBe(true);
+      // ZERO generation logic — a gated stub must not carry a runner.
+      expect(m?.run, `${name} must not carry a runner`).toBeUndefined();
+    }
+  });
+
+  it("resolves the e2e alias to the ui modality", () => {
+    expect(getModality("e2e")?.name).toBe("ui");
+  });
+
+  it("ui carries the explore pointer as its hint", () => {
+    expect(getModality("ui")?.hint).toContain("cairn explore --url");
+  });
+
+  it("returns undefined for an unknown modality", () => {
+    expect(getModality("nope")).toBeUndefined();
+  });
+
+  it("exposes exactly the four gated stubs (build-by-demand discipline)", () => {
+    const gated = MODALITIES.filter((m) => m.gated).map((m) => m.name).sort();
+    expect(gated).toEqual(["api", "docs", "ui", "unit"]);
+  });
+});
+
+describe("runModality dispatch (C1-01)", () => {
+  it("a gated modality prints the coming-soon notice and does NOT throw", async () => {
+    const { io, out } = capture();
+    await runModality("api", {}, io);
+    expect(out.join("")).toContain("api: coming soon — gated (see L-G2). Build by demand, one at a time.");
+  });
+
+  it("dispatches through an alias (e2e → ui notice, incl. the explore pointer)", async () => {
+    const { io, out } = capture();
+    await runModality("e2e", {}, io);
+    const text = out.join("");
+    expect(text).toContain("coming soon — gated");
+    expect(text).toContain("cairn explore --url");
+  });
+
+  it("throws on an unknown modality", async () => {
+    const { io } = capture();
+    await expect(runModality("nope", {}, io)).rejects.toThrow(/unknown modality/i);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,6 +32,11 @@ export default defineConfig({
         "src/agent/finalize.ts",
         "src/agent/repair-loop.ts",
         "src/agent/testcase-docs.ts",
+        // C1-01 — shared umbrella core: pure flag→config + modality registry/dispatch.
+        // (modalities/explore.ts + reporting.ts are CLI/agent glue → integration, outside the gate.)
+        "src/core/config.ts",
+        "src/core/modality.ts",
+        "src/core/registry.ts",
         "scripts/benchmark-core.ts",
       ],
       thresholds: { lines: 80, functions: 80, branches: 75, statements: 80 },


### PR DESCRIPTION
Closes #19. Closes #20.

Extracts a shared CLI **core** the modality commands were duplicating, and adds **gated modality stubs** to the umbrella `cairn` CLI — while proving `explore` is unchanged. The router (RoleRouter + CostLedger behind `loadConfig`) was already centralized in L1-01 and is **not** rebuilt here.

## The `src/core` seam (C1-01, #19)

| Unit | What it is |
|---|---|
| `resolveConfig(flags, env)` | The `--backend`→`BROWSER_BACKEND` / `--routing`→`LLM_ROUTING` env-override + `loadConfig`, in **one** place (was duplicated verbatim in explore/design/automate). Pure — never mutates `env`. |
| `Modality` + `registry` + `runModality` | A modality = one kind of test artifact. `getModality` resolves aliases; `runModality` dispatches (gated → notice, real → `run`, unknown → throw). |
| `gatedNotice(m)` | Pure (returns lines, like `renderRunSummary`) → the coming-soon notice. |
| `printCost(cost, write?)` | Moved out of `cli/index.ts` so every modality prints the **same** footer. |
| `exploreModality` | `explore` is the **first REAL modality** consuming the core; the command now delegates through `runModality` (output byte-identical). |

`design`/`automate` also resolve config via `resolveConfig` now (identical behavior). `modalities/explore.ts` + `reporting.ts` are CLI/agent glue → integration, outside the coverage gate; the pure bits (`config.ts`, `modality.ts`, `registry.ts`) are **in** the gate at 100%.

## Gated stubs (C1-01) — `cairn --help` (grouped, marked coming-soon)

```
  ui|e2e                 Generate UI / end-to-end tests — coming soon (gated; see L-G2)
  api                    Generate API / contract tests — coming soon (gated; see L-G2)
  unit                   Generate unit tests — coming soon (gated; see L-G2)
  docs                   Generate docs / doctest examples — coming soon (gated; see L-G2)
```

Running one prints the notice and exits 0 — **zero** generation logic, no runner attached:

```
$ cairn ui
ui: coming soon — gated (see L-G2). Build by demand, one at a time.
For UI test generation today, use: cairn explore --url <url>

$ cairn api
api: coming soon — gated (see L-G2). Build by demand, one at a time.
```

`e2e` is an alias of `ui`. **#21–24 remain gated** behind a named-user pull (L-G2 / #25): build by demand, one at a time — no Explorbot-style breadth chased here.

## Back-compat (C1-02, #20)

- bare `cairn` → TUI (TTY) / help (non-TTY); `lex-bot` alias → deprecation notice + same code path. ✔ (verified from the built `dist/`)
- every existing command keeps its flags, output, and artifacts. The public CLI surface only **adds** the four stubs.

## Parity + lock tests (vitest, no live LLM/browser)

- **explore 1:1 parity**: the command still accepts `--url/--backend/--session/--session-file/--headed/--checklist/--style/--routing` (exactly 8), and with `runExploration` mocked it’s invoked with the **same** option mapping (`sessionName←session`, `--backend/--routing` flow through `resolveConfig`) and prints the same exploration/metrics/cost/summary structure.
- **gated stubs**: each of `ui|e2e|api|unit|docs` exits 0, prints the coming-soon line, and the agent runners are asserted **never** called.
- **surface lock**: snapshots of `cairn --help` (now +4 stubs) and `cairn explore --help` (unchanged).

## Gates

`npm run build` ✔ · `npm test` ✔ **322 passed** (58 files; +28 new) · `npm run lint` ✔ · `npm run test:coverage` ✔ (core pure bits 100%).
