### PR TITLE
fix(browser): clear message + fail-fast when Playwright browsers are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,32 @@ The typical flow:
 ## Install
 
 ```bash
-npm install -g @plune-ai/cairn     # CLI
-# or as a library:
-npm install @plune-ai/cairn
+npm install -g @plune-ai/cairn      # global CLI → run `cairn …`
+# …or local / library install:
+npm install @plune-ai/cairn         # → run via `npx cairn …`
+
+# one-time: download the Chromium build Cairn drives (NOT shipped inside the npm package)
+npx playwright install chromium
 ```
 
 Requires Node.js 20+. Copy `.env.example` → `.env` and fill in your keys.
 
+> **Two ways to invoke.** A **global** install (`-g`) puts `cairn` on your PATH, so `cairn design …` works
+> anywhere. A **local** install does *not* — run it as **`npx cairn design …`** from the folder where you
+> installed it. The examples below use the bare `cairn`; prefix them with `npx` if you installed locally.
+>
+> **Browsers are a separate download.** `npm install` pulls the Playwright *library* but not its *browser
+> binaries*. Run **`npx playwright install chromium`** once — otherwise `explore` / `automate --validate`
+> stop early with a clear *"Playwright browsers are not installed"* message (not a wall of failed tests).
+
 ## Quickstart
 
+> Installed locally (without `-g`)? Prefix every `cairn …` below with `npx` (e.g. `npx cairn design …`).
+
 ```bash
+# 0. One-time: download the browser Cairn drives (skip if you already ran it during install)
+npx playwright install chromium
+
 # 1. Capture a session (opens a browser to log in)
 cairn session capture --url https://app.example.com/login --name myapp
 
@@ -84,6 +100,9 @@ cairn automate --run runs/<id> --validate --session myapp
 # …or do everything at once:
 cairn explore --url https://app.example.com/page --session myapp --checklist plan.md
 ```
+
+The `--checklist` file steers **what** the bot tests (and is scored as coverage). Copy
+[`examples/plan.md`](examples/plan.md) — a ready-to-run checklist for `https://plune.ai/cairn` — as a starting point.
 
 New here? Read the **[Getting started guide](docs/getting-started.md)** — it walks the whole cycle with explanations.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,8 +29,15 @@ If you review an MTC and decide it really is safe to automate, **promote** it �
 ## Step 1 — Install and configure
 
 ```bash
-npm install -g @plune-ai/cairn
+npm install -g @plune-ai/cairn      # global → `cairn …`   (local install? use `npx cairn …`)
+
+# one-time: download the Chromium build Cairn drives (not bundled with the npm package)
+npx playwright install chromium
 ```
+
+> If you skip `npx playwright install chromium`, the first command that needs a browser (`explore`,
+> `automate --validate`, `observe`, or capturing a session) stops with a clear message telling you to run
+> exactly that — so this is a quick fix, not a mysterious failure.
 
 Create a `.env` (copy `.env.example`) with at least your LLM key:
 
@@ -111,7 +118,7 @@ This runs design → code → validate → repair → a holistic "Pilot" verdict
 
 ## Guiding what gets tested
 
-- **Checklist:** pass `--checklist plan.md` (a Markdown list of what to cover) to steer the design.
+- **Checklist:** pass `--checklist plan.md` (a Markdown list of what to cover) to steer the design — copy [`examples/plan.md`](../examples/plan.md) as a starting point.
 - **Domain knowledge:** drop `*.md` files in `./knowledge/` (with a `url:` front-matter) to inject
   credentials / validation rules / notes for matching pages.
 - **Planning style:** `--style happy | negative | coverage | all`.

--- a/examples/plan.md
+++ b/examples/plan.md
@@ -1,0 +1,38 @@
+# Test plan — Cairn landing page (https://plune.ai/cairn)
+#
+# Example checklist for:  cairn design --url https://plune.ai/cairn --checklist examples/plan.md
+# It steers WHAT the bot tests and is scored as coverage.
+#
+# Format: one test intent per bullet (`-`). Lines starting with `#` are notes and are ignored.
+# Do NOT use `##` headings here — a `##` line flips the parser into "headings-as-items" mode and
+# your bullets are dropped. Single `#` lines (like these) are safe section dividers.
+
+# Header & navigation
+- The top navigation shows the Platform, Docs, Blog and Cairn links
+- The "Get started" button in the header is visible and clickable
+- The "GitHub" link points to the project repository
+- Clicking the "Plune" logo returns to the home page
+
+# Hero
+- The hero shows the "Cairn" heading and the tagline "An AI that walks your system and leaves a trail of tests"
+- The Node.js, TypeScript and Playwright tech badges are visible
+- The Explore / Design / Automate anchors scroll to their sections
+
+# Content sections
+- The 5-stage pipeline (Observe, Ground, Design, Generate & validate, Judge & learn) is visible
+- The Human-in-the-loop section explains ATC (automatable) vs MTC (manual) cases
+- Each of the three modes (design, automate, explore) shows an example command
+- Every command block has a working "copy" button
+- The Quickstart section lists the numbered steps 1–6
+
+# Install & docs
+- The install section shows the npm command and the "Node 20+ · Apache-2.0 · v0.3.0" version line
+- The "Read the docs" link opens the documentation
+- The "Next: evaluate & gate your app with the Plune platform" call-to-action is present
+
+# Footer
+- The footer shows the Product, Docs and Company link columns
+- The newsletter field accepts a valid email address
+- The newsletter field rejects an invalid email (e.g. "abc") with a validation message
+- The "All systems operational" status indicator is visible
+- The theme toggle switches between light and dark

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { resolve, dirname, basename, join } from "node:path";
 import { readFile, readdir } from "node:fs/promises";
 import { makeGateway } from "../browser/index.js";
+import { ensureBrowsersInstalled } from "../browser/preflight.js";
 import { RoleRouter, type CostReport } from "../llm/index.js";
 import { CallBudget } from "../llm/structured.js";
 import { PromptRegistry } from "../prompts/index.js";
@@ -83,6 +84,9 @@ export interface ExploreResult {
  */
 export async function runExploration(input: ExploreInput): Promise<ExploreResult> {
   const cfg = input.config;
+  // Onboarding guardrail: explore always validates → it needs the bundled Chromium. Fail fast with a
+  // copy-paste fix BEFORE spending any LLM calls, instead of dying deep in the run (see preflight.ts).
+  ensureBrowsersInstalled();
   const keys = { anthropicApiKey: cfg.anthropicApiKey, openrouterApiKey: cfg.openrouterApiKey, groqApiKey: cfg.groqApiKey };
   const budget = new CallBudget(80); // cost-guardrail: safeguard (normally ~6-10 calls/run)
 
@@ -407,6 +411,9 @@ function suiteFromUrl(url: string): string {
  */
 export async function runDesign(input: ExploreInput): Promise<DesignResult> {
   const cfg = input.config;
+  // Onboarding guardrail: design drives the bundled Chromium to observe the page (skipped when a
+  // system-browser channel is configured) → fail fast with a copy-paste fix before any LLM call.
+  ensureBrowsersInstalled({ channel: cfg.browser.channel });
   const keys = { anthropicApiKey: cfg.anthropicApiKey, openrouterApiKey: cfg.openrouterApiKey, groqApiKey: cfg.groqApiKey };
   const budget = new CallBudget(80); // cost-guardrail: safeguard (normally ~6-10 calls/run)
   const router = new RoleRouter(cfg, keys, budget); // L1-01: per-role routing + cost ledger
@@ -638,6 +645,9 @@ export async function runAutomate(input: {
   let validation: ValidationReport | undefined;
   let stoppedEarly = false;
   if (input.validate) {
+    // Onboarding guardrail: validation runs the generated suite through the bundled Chromium → fail
+    // fast with a copy-paste fix before spending LLM calls on codegen (see preflight.ts).
+    ensureBrowsersInstalled();
     // #40: validate ⇄ repair ⇄ keep-best (+ no-progress early-stop) — the SAME convergence the explore
     // graph uses, instead of a single one-shot generation. Lifts the decoupled flow to explore-grade green.
     const result = await runRepairLoop({

--- a/src/browser/backends/playwright-lib.ts
+++ b/src/browser/backends/playwright-lib.ts
@@ -1,5 +1,6 @@
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import type { BrowserBackend } from "../gateway.js";
+import { isMissingBrowserError, missingBrowsersError } from "../preflight.js";
 import type {
   ActResult,
   Action,
@@ -39,12 +40,20 @@ export class PlaywrightLibBackend implements BrowserBackend {
 
   constructor(private readonly opts: PlaywrightLibOptions = {}) {}
 
-  private launch(): Promise<Browser> {
-    return chromium.launch({
-      headless: this.opts.headless ?? true,
-      channel: this.opts.channel,
-      args: ["--disable-blink-features=AutomationControlled"],
-    });
+  private async launch(): Promise<Browser> {
+    try {
+      return await chromium.launch({
+        headless: this.opts.headless ?? true,
+        channel: this.opts.channel,
+        args: ["--disable-blink-features=AutomationControlled"],
+      });
+    } catch (e) {
+      // Backstop for observe/design: translate Playwright's raw "Executable doesn't exist …" into
+      // the one actionable message. Covers the case the up-front preflight can't (e.g. the
+      // headless-shell binary missing while full Chromium is present). Other launch errors pass through.
+      if (isMissingBrowserError(e)) throw missingBrowsersError();
+      throw e;
+    }
   }
 
   private async ensurePage(): Promise<Page> {

--- a/src/browser/preflight.ts
+++ b/src/browser/preflight.ts
@@ -1,0 +1,78 @@
+import { existsSync } from "node:fs";
+import { chromium } from "playwright";
+
+/**
+ * Browser preflight (onboarding guardrail).
+ *
+ * `npm install @plune-ai/cairn` pulls the `playwright` *library* but NOT the browser
+ * *binaries* — those are a separate `npx playwright install` download. On a fresh machine
+ * `chromium.launch()` (observe/design) and the `@playwright/test` runner (automate --validate)
+ * therefore die with a raw "Executable doesn't exist …" deep inside the run, which surfaces to
+ * the user as a misleading "0% green · N failed" with the real cause buried in a child's stderr.
+ *
+ * This module turns that into one clear, actionable message — and lets callers fail fast BEFORE
+ * spending any LLM calls. Two layers cooperate (defense in depth):
+ *   1. {@link ensureBrowsersInstalled} — a cheap up-front check (is the bundled Chromium on disk?).
+ *   2. {@link isMissingBrowserError} — a string/error detector used as a backstop where a launch
+ *      actually fails (e.g. the headless-shell binary is missing while full Chromium is present).
+ */
+
+/** The single source of truth for the install command we point users at. */
+export const INSTALL_BROWSERS_HINT =
+  "Playwright browsers are not installed.\n" +
+  "Cairn drives a Chromium build that ships separately from the npm package.\n" +
+  "Install it once, then re-run your command:\n\n" +
+  "    npx playwright install chromium\n";
+
+/**
+ * True when an error (or raw stderr/stdout text) is Playwright's "browser binary is missing"
+ * signature. Deliberately broad: matches the launch error, the executablePath() error, and the
+ * "please run … playwright install" banner — so it catches both the full-Chromium and the
+ * headless-shell variants regardless of which surface raised it.
+ */
+export function isMissingBrowserError(err: unknown): boolean {
+  const msg =
+    typeof err === "string" ? err : err instanceof Error ? err.message : err == null ? "" : String(err);
+  if (!msg) return false;
+  return (
+    /Executable doesn't exist/i.test(msg) ||
+    /please run the following command to download/i.test(msg) ||
+    /playwright install/i.test(msg)
+  );
+}
+
+/**
+ * A clean, actionable Error for the missing-browser case — no stack trace is needed because the
+ * fix is a copy-paste command. The CLI prints `error.message` verbatim (see cli/index.ts).
+ */
+export function missingBrowsersError(detail?: string): Error {
+  const e = new Error(detail ? `${INSTALL_BROWSERS_HINT}\n(${detail})` : INSTALL_BROWSERS_HINT);
+  e.name = "BrowsersNotInstalledError";
+  return e;
+}
+
+/**
+ * Is the bundled Chromium that `chromium.launch()` and the `@playwright/test` runner use by
+ * default actually present on disk? `executablePath()` returns the computed path (and throws on
+ * some Playwright versions when nothing is installed) — we treat both "throws" and "path absent"
+ * as not-installed.
+ */
+export function chromiumInstalled(): boolean {
+  try {
+    const p = chromium.executablePath();
+    return Boolean(p) && existsSync(p);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Preflight gate: throw an actionable error if the bundled Chromium is missing.
+ *
+ * Skipped when a browser `channel` (system Chrome/Edge — e.g. for OAuth) is configured, because
+ * that path drives the *system* browser, not the bundled build, so the bundle's absence is moot.
+ */
+export function ensureBrowsersInstalled(opts: { channel?: string } = {}): void {
+  if (opts.channel) return; // system browser — not the bundled Chromium
+  if (!chromiumInstalled()) throw missingBrowsersError();
+}

--- a/src/validate/runner.ts
+++ b/src/validate/runner.ts
@@ -3,6 +3,7 @@ import { promisify } from "node:util";
 import { createRequire } from "node:module";
 import { writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { isMissingBrowserError, missingBrowsersError } from "../browser/preflight.js";
 
 const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
@@ -78,16 +79,35 @@ export async function runSpecs(runDir: string, opts: RunSpecsOptions = {}): Prom
   delete childEnv.NODE_OPTIONS;
 
   let stdout = "";
+  let stderr = "";
   try {
     const r = await execFileAsync(process.execPath, [PW_CLI, "test", `--config=${configPath}`], {
       maxBuffer: 64 * 1024 * 1024,
       env: childEnv,
     });
     stdout = r.stdout;
+    stderr = r.stderr;
   } catch (e) {
-    stdout = (e as { stdout?: string }).stdout ?? "";
+    // A non-zero exit (there ARE failing tests) is normal — keep the reporter output. But ALSO keep
+    // stderr: a missing-browser death writes its cause there, and dropping it is exactly what made
+    // the runner report a misleading "0% green" with no reason (the onboarding bug we're fixing).
+    const err = e as { stdout?: string; stderr?: string };
+    stdout = err.stdout ?? "";
+    stderr = err.stderr ?? "";
   }
 
+  return resultsFromRunnerOutput(stdout, stderr);
+}
+
+/**
+ * Turn the runner's stdout/stderr into per-test results — or, when the output shows the browser
+ * binary was missing, throw ONE actionable error instead of silently reporting every test "failed".
+ * Pure (no process/IO) so the failure-surfacing logic is unit-tested without spawning a runner.
+ */
+export function resultsFromRunnerOutput(stdout: string, stderr: string): RawTestResult[] {
+  if (isMissingBrowserError(stderr) || isMissingBrowserError(stdout)) {
+    throw missingBrowsersError("Playwright could not launch a browser to run the generated tests.");
+  }
   const start = stdout.indexOf("{");
   if (start < 0) return [];
   try {

--- a/tests/integration/runner.test.ts
+++ b/tests/integration/runner.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { startFixtureServer, type FixtureServer } from "../fixtures/server.js";
 import { ArtifactStore } from "../../src/artifacts/index.js";
 import { runSpecs } from "../../src/validate/runner.js";
+import { isMissingBrowserError } from "../../src/browser/preflight.js";
 
 // Run directories must live INSIDE the project: spec files resolve @playwright/test via node_modules.
 const ITEST_BASE = join(process.cwd(), "runs", ".itest-runner");
@@ -17,7 +18,7 @@ describe("runSpecs (integration, real playwright runner)", () => {
     await server.close();
   });
 
-  it("passed for a valid spec, failed/timedOut for a broken one", { timeout: 120000 }, async () => {
+  it("passed for a valid spec, failed/timedOut for a broken one", { timeout: 120000 }, async (ctx) => {
     await rm(ITEST_BASE, { recursive: true, force: true });
     try {
       const run = await new ArtifactStore(ITEST_BASE).openRun("rtest");
@@ -42,7 +43,19 @@ test('bad', async ({ page }) => {
         ],
       });
 
-      const results = await runSpecs(run.dir);
+      let results: Awaited<ReturnType<typeof runSpecs>>;
+      try {
+        results = await runSpecs(run.dir);
+      } catch (e) {
+        // This integration test needs the @playwright/test runner's browser (chrome-headless-shell).
+        // If it isn't installed, skip rather than fail — `npx playwright install chromium` provisions it.
+        // (Verifies, in passing, that runSpecs now surfaces the missing browser instead of a fake 0%.)
+        if (isMissingBrowserError(e)) {
+          ctx.skip();
+          return;
+        }
+        throw e;
+      }
       const good = results.find((r) => r.title === "good");
       const bad = results.find((r) => r.title === "bad");
       expect(good?.status).toBe("passed");

--- a/tests/unit/preflight.test.ts
+++ b/tests/unit/preflight.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mutable mock state (vi.hoisted so the factories below can see it).
+const h = vi.hoisted(() => ({ exePath: "" as string, exists: false }));
+vi.mock("playwright", () => ({
+  chromium: {
+    executablePath: () => {
+      if (!h.exePath) throw new Error("Executable doesn't exist"); // recent Playwright behavior
+      return h.exePath;
+    },
+  },
+}));
+vi.mock("node:fs", () => ({ existsSync: () => h.exists }));
+
+import {
+  isMissingBrowserError,
+  missingBrowsersError,
+  chromiumInstalled,
+  ensureBrowsersInstalled,
+  INSTALL_BROWSERS_HINT,
+} from "../../src/browser/preflight.js";
+
+beforeEach(() => {
+  h.exePath = "";
+  h.exists = false;
+});
+
+describe("isMissingBrowserError — recognizes Playwright's missing-browser signature", () => {
+  it("matches the real launch error the user hit", () => {
+    const real =
+      "browserType.launch: Executable doesn't exist at " +
+      "C:\\Users\\u\\AppData\\Local\\ms-playwright\\chromium_headless_shell-1228\\chrome-headless-shell.exe";
+    expect(isMissingBrowserError(real)).toBe(true);
+    expect(isMissingBrowserError(new Error(real))).toBe(true);
+  });
+
+  it("matches the 'please run … playwright install' banner", () => {
+    expect(isMissingBrowserError("Please run the following command to download new browsers")).toBe(true);
+    expect(isMissingBrowserError("npx playwright install")).toBe(true);
+  });
+
+  it("does NOT match unrelated errors or empty/non-string values", () => {
+    expect(isMissingBrowserError("Timeout 30000ms exceeded")).toBe(false);
+    expect(isMissingBrowserError(new Error("ECONNREFUSED"))).toBe(false);
+    expect(isMissingBrowserError("")).toBe(false);
+    expect(isMissingBrowserError(null)).toBe(false);
+    expect(isMissingBrowserError(undefined)).toBe(false);
+  });
+});
+
+describe("missingBrowsersError — clean, actionable error", () => {
+  it("carries the install command and a stable name (no stack noise needed)", () => {
+    const e = missingBrowsersError();
+    expect(e).toBeInstanceOf(Error);
+    expect(e.name).toBe("BrowsersNotInstalledError");
+    expect(e.message).toContain("npx playwright install chromium");
+    // The error it produces must be recognizable by our own detector (round-trip).
+    expect(isMissingBrowserError(e)).toBe(true);
+  });
+
+  it("INSTALL_BROWSERS_HINT is the single source of the command string", () => {
+    expect(INSTALL_BROWSERS_HINT).toContain("npx playwright install chromium");
+  });
+});
+
+describe("ensureBrowsersInstalled — preflight gate", () => {
+  it("throws an actionable error when the bundled Chromium is absent", () => {
+    h.exePath = "C:\\ms-playwright\\chromium\\chrome.exe";
+    h.exists = false; // path computed, but the binary is not on disk
+    expect(() => ensureBrowsersInstalled()).toThrow(/npx playwright install chromium/);
+    expect(chromiumInstalled()).toBe(false);
+  });
+
+  it("passes silently when the bundled Chromium is present", () => {
+    h.exePath = "C:\\ms-playwright\\chromium\\chrome.exe";
+    h.exists = true;
+    expect(() => ensureBrowsersInstalled()).not.toThrow();
+    expect(chromiumInstalled()).toBe(true);
+  });
+
+  it("is SKIPPED when a system browser channel is configured (uses system Chrome/Edge, not the bundle)", () => {
+    h.exePath = "";
+    h.exists = false; // bundled chromium missing…
+    // …but a channel means Playwright drives the system browser → preflight must not block.
+    expect(() => ensureBrowsersInstalled({ channel: "chrome" })).not.toThrow();
+  });
+});

--- a/tests/unit/runner-output.test.ts
+++ b/tests/unit/runner-output.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { resultsFromRunnerOutput } from "../../src/validate/runner.js";
+
+// Minimal Playwright JSON-reporter shape (one passed + one failed spec).
+const REPORTER_JSON = JSON.stringify({
+  suites: [
+    {
+      specs: [
+        { title: "loads", tests: [{ results: [{ status: "passed" }] }] },
+        { title: "submits", tests: [{ results: [{ status: "failed" }] }] },
+      ],
+    },
+  ],
+});
+
+const MISSING_BROWSER_STDERR =
+  "Error: browserType.launch: Executable doesn't exist at " +
+  "C:\\Users\\u\\AppData\\Local\\ms-playwright\\chromium_headless_shell-1228\\chrome-headless-shell.exe\n" +
+  "Please run the following command to download new browsers:\n    npx playwright install";
+
+describe("resultsFromRunnerOutput — surfaces a missing browser instead of a fake 0% green", () => {
+  it("throws an actionable error when the browser binary is missing (cause is in stderr)", () => {
+    // Even if the JSON reporter still emitted 'all failed', the real cause wins.
+    expect(() => resultsFromRunnerOutput(REPORTER_JSON, MISSING_BROWSER_STDERR)).toThrow(
+      /npx playwright install chromium/,
+    );
+  });
+
+  it("also catches the cause when Playwright printed it to stdout", () => {
+    expect(() => resultsFromRunnerOutput(MISSING_BROWSER_STDERR, "")).toThrow(/playwright install/);
+  });
+
+  it("parses real pass/fail results when the run actually executed (non-zero exit is normal)", () => {
+    const out = resultsFromRunnerOutput(REPORTER_JSON, "");
+    expect(out).toEqual([
+      { title: "loads", status: "passed" },
+      { title: "submits", status: "failed" },
+    ]);
+  });
+
+  it("returns [] when there is no JSON and no missing-browser signature", () => {
+    expect(resultsFromRunnerOutput("", "")).toEqual([]);
+    expect(resultsFromRunnerOutput("some noise without json", "warning: slow test")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

A fresh `npm install @plune-ai/cairn` pulls the Playwright **library** but not its **browser binaries** (those are a separate `npx playwright install` download). On a clean machine:

- `explore` / `automate --validate` died deep in the run with a raw `browserType.launch: Executable doesn't exist …`.
- `validate/runner.ts` **discarded the child's stderr**, so the real cause was lost and the run reported a misleading **"0% green · N failed"** with no explanation.

Reported from a real run (29 tests all failed; cause buried in stderr). Also: a **local** install doesn't put `cairn` on PATH, but the docs showed bare `cairn …` everywhere — so a local install looked broken until you knew to use `npx cairn …`.

## Fix — browser preflight (defense in depth)

- **`src/browser/preflight.ts`** *(new)* — `ensureBrowsersInstalled()` + `isMissingBrowserError()` + `missingBrowsersError()`. Single source of the actionable hint: **`npx playwright install chromium`**.
- **Fail fast before LLM spend** — preflight at the top of `explore` / `design` / `automate --validate`. `design` skips the check when a system-browser `channel` is configured (it drives system Chrome, not the bundle); `explore` / `automate --validate` always check (validation runs the bundled Chromium regardless).
- **Stop dropping stderr** — `validate/runner.ts` now surfaces the missing-browser cause via a pure, unit-tested `resultsFromRunnerOutput()` instead of silently classifying every test as failed. This catches the exact reported case (full Chromium present, `chrome-headless-shell` missing).
- **Backstop** — `playwright-lib` `launch()` translates the raw launch error for the observe path.

## Docs & example

- `README.md` + `docs/getting-started.md`: add `npx playwright install chromium`, and clarify **global (`cairn …`) vs local (`npx cairn …`)** invocation.
- **`examples/plan.md`** *(new)* — a ready-to-run `--checklist` for `https://plune.ai/cairn`, referenced from both docs. Verified it parses to 20 clean checklist items (no stray notes, no heading-mode flip).

## Verification

- `npm run build` ✓ · `npm run lint` ✓ · **334 tests green** (60 files), incl. **+12 new** (preflight detection/gating, runner stderr surfacing).
- Live run of the built CLI with browsers simulated absent (`PLAYWRIGHT_BROWSERS_PATH` → empty dir): `explore` now prints the `npx playwright install chromium` hint and exits 1 **before** observe/LLM — instead of a wall of failed tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)