### PR TITLE
ci(publish): set package.json version from the release tag (no manual npm version)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to publish (e.g. v0.2.0). Must match the version in package.json."
+        description: "Tag to publish (e.g. v0.3.1). package.json is set to this tag automatically."
         required: true
 
 permissions:
@@ -47,16 +47,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # --- Guard (fail-fast): tag must match the version in package.json ---
-      - name: Verify package.json version matches tag
+      # --- Version: the release TAG is the source of truth. Set package.json to it for THIS publish
+      # (ephemeral — runs in CI, is NOT committed back to the repo). Build reads the version from
+      # package.json (BOT_VERSION, #30), so `cairn --version` and the published tarball both match the
+      # tag — no manual `npm version` before tagging. `--allow-same-version` keeps re-runs idempotent. ---
+      - name: Set package.json version from the release tag
         run: |
-          PKG=$(node -p "require('./package.json').version")
           WANT="${{ steps.meta.outputs.version }}"
-          if [ "$PKG" != "$WANT" ]; then
-            echo "::error::package.json version ($PKG) != release tag ($WANT). Run 'npm version' before tagging."
-            exit 1
-          fi
-          echo "Version OK: $PKG"
+          npm version "$WANT" --no-git-tag-version --allow-same-version
+          echo "package.json set to $WANT for this publish."
 
       # --- Checks (mirror of ci.yml) ---
       - name: Install Playwright Chromium (for integration tests)


### PR DESCRIPTION
## Problem

Tagging release **v0.3.1** failed the publish workflow:

```
Error: package.json version (0.3.0) != release tag (0.3.1). Run 'npm version' before tagging.
```

The workflow only **guarded** that `package.json` matched the tag and aborted otherwise — there was **no step that actually set** the version. So every release required a manual `npm version` bump *before* tagging; forget it and the release dies.

## Fix — the git tag is the source of truth

Replace the guard with an auto-set step (after `npm ci`, before build/publish):

```yaml
- name: Set package.json version from the release tag
  run: |
    WANT="${{ steps.meta.outputs.version }}"
    npm version "$WANT" --no-git-tag-version --allow-same-version
```

- Build reads the version from `package.json` (`BOT_VERSION`, #30), so `cairn --version` **and** the published tarball both match the tag.
- Releasing is now just **create the tag/release** — no manual bump.
- The set is **ephemeral** (CI only, not committed back to the repo); `--allow-same-version` keeps re-runs idempotent.
- Ordering: version is set **before** Build and Publish (verified: step 6 of 15).

## Unblocking v0.3.1

After merge, re-run the publish for the existing tag (it will set the version to `0.3.1` automatically):

```
gh workflow run publish.yml --ref main -f tag=v0.3.1
```

(The original release-triggered run can't simply be re-run — it checks out the pre-merge commit with the old guard; `workflow_dispatch` runs the updated workflow from `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)