### PR TITLE
fix(tui,agent,cli): Escape/q exit, incremental design persistence, CLI progress spinner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,10 @@ coverage/
 
 # Internal dev / agent context — NOT for the public repo
 CLAUDE.md
+.claude/
 .claude-memory/
 .claude-notes/
+graphify-out/
 
 # Local ad-hoc working files (curated examples live under examples/)
 /ATC-*.md

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "smoke:pack": "node scripts/smoke-install.mjs",
     "lint": "eslint .",
     "session:save": "tsx scripts/save-session.ts",
     "bench": "tsx scripts/benchmark.ts",

--- a/scripts/smoke-install.mjs
+++ b/scripts/smoke-install.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * Packaged-install smoke test (`npm run smoke:pack`).
+ *
+ * Source tests (vitest) run against ./src and miss PACKAGING bugs: a file left out of the `files`
+ * whitelist, a wrong `bin` path, an export that doesn't resolve once installed. This script proves
+ * the published artifact actually works: it builds → `npm pack`s → installs the tarball into a fresh
+ * temp project (no link, no source) → runs the CLI from node_modules and exercises real, HERMETIC
+ * actions (no API keys, no browser, no network beyond `npm install`).
+ *
+ * Hermetic command coverage: --version · --help · doctor · a gated stub · session ls, plus two real
+ * artifact actions on crafted fixtures — `dataset-add` (reads study.json → dataset) and `promote`
+ * (deterministic MTC→ATC .md rewrite). Browser/LLM commands (explore/design/observe) need a real
+ * browser + keys + a page and are intentionally OUT of scope here.
+ *
+ * Not part of `npm test` (pack+install is slow and pulls the full dep tree). Run it before publishing.
+ */
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  existsSync,
+  copyFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+const expectedVersion = pkg.version;
+
+/** Run npm (via shell so npm.cmd resolves on Windows). Throws with output on a non-zero exit. */
+function npm(args, opts = {}) {
+  const r = spawnSync("npm", args, { encoding: "utf8", shell: true, ...opts });
+  if (r.status !== 0) {
+    throw new Error(`npm ${args.join(" ")} failed (${r.status})\n${r.stdout ?? ""}\n${r.stderr ?? ""}`);
+  }
+  return r;
+}
+
+const results = [];
+function check(name, ok, detail = "") {
+  results.push({ name, ok });
+  console.log(`  ${ok ? "✓" : "✗"} ${name}${ok ? "" : detail ? ` — ${detail}` : ""}`);
+}
+
+const work = mkdtempSync(join(tmpdir(), "cairn-smoke-"));
+const appDir = join(work, "app");
+
+try {
+  // 1. Build → the tarball only ships `dist/` (files whitelist) and there is no prepack hook.
+  console.log("▸ building (tsc)…");
+  npm(["run", "build"], { cwd: root });
+
+  // 2. Pack the local package into the temp dir.
+  console.log("▸ npm pack…");
+  const packed = npm(["pack", "--json", "--pack-destination", work], { cwd: root });
+  let tarball;
+  try {
+    tarball = join(work, JSON.parse(packed.stdout)[0].filename);
+  } catch {
+    tarball = join(work, `plune-ai-cairn-${expectedVersion}.tgz`); // @scope/name → scope-name-version
+  }
+  if (!existsSync(tarball)) throw new Error(`tarball not found: ${tarball}`);
+
+  // 3. Install the tarball into a fresh project. --ignore-scripts skips Playwright's chromium
+  //    download (hermetic CLI commands don't need a browser); --prefer-offline uses the npm cache.
+  console.log("▸ installing the tarball into a fresh project…");
+  mkdirSync(appDir, { recursive: true });
+  writeFileSync(join(appDir, "package.json"), JSON.stringify({ name: "cairn-smoke-app", private: true, version: "0.0.0" }, null, 2));
+  copyFileSync(tarball, join(appDir, "cairn-pkg.tgz"));
+  npm(["install", "cairn-pkg.tgz", "--ignore-scripts", "--no-audit", "--no-fund", "--prefer-offline"], { cwd: appDir });
+
+  // 4. The bin path declared in package.json must exist in the installed package.
+  const cliPath = join(appDir, "node_modules", "@plune-ai", "cairn", "dist", "cli", "index.js");
+  check("installed package exposes its bin (dist/cli/index.js)", existsSync(cliPath), cliPath);
+  if (!existsSync(cliPath)) throw new Error("CLI entry missing from the installed package — cannot run commands.");
+
+  /**
+   * Run the INSTALLED cairn CLI via node (no shell needed — node binary + arg array).
+   * A DUMMY ANTHROPIC_API_KEY satisfies loadConfig's profile gate (some commands — e.g. `promote`
+   * without --session — load config but never make an LLM call, so the key is never used). This
+   * keeps the smoke hermetic (no real network/LLM) while letting those commands run.
+   */
+  const cairn = (args, opts = {}) => {
+    const r = spawnSync(process.execPath, [cliPath, ...args], {
+      cwd: appDir,
+      encoding: "utf8",
+      env: { ...process.env, ANTHROPIC_API_KEY: "sk-ant-smoke-unused", LLM_PROFILE: "anthropic" },
+      ...opts,
+    });
+    return { status: r.status, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+  };
+
+  console.log("▸ running hermetic CLI commands…");
+
+  const v = cairn(["--version"]);
+  check(`--version prints ${expectedVersion}`, v.status === 0 && v.out.includes(expectedVersion), v.out.trim());
+
+  const h = cairn(["--help"]);
+  check("--help lists the core commands", h.status === 0 && /design/.test(h.out) && /explore/.test(h.out) && /automate/.test(h.out));
+
+  const doctor = cairn(["doctor"]);
+  check("doctor exits 0", doctor.status === 0, `status ${doctor.status}`);
+
+  const gated = cairn(["ui"]);
+  check("gated stub (ui) prints coming-soon and exits 0", gated.status === 0 && /coming soon/i.test(gated.out));
+
+  mkdirSync(join(appDir, ".auth"), { recursive: true }); // empty sessions dir → deterministic "none"
+  const sess = cairn(["session", "ls"]);
+  check("session ls works with no saved sessions", sess.status === 0 && /No saved sessions/.test(sess.out), sess.out.trim());
+
+  // 5. Real, hermetic artifact actions on a crafted run dir (no LLM / no browser).
+  console.log("▸ running real artifact actions on fixtures…");
+  const runFix = join(appDir, "fixture-run");
+  const tcDir = join(runFix, "testcases");
+  mkdirSync(tcDir, { recursive: true });
+  writeFileSync(
+    join(runFix, "study.json"),
+    JSON.stringify({ url: "https://smoke.test/page", elements: [{ ref: "e49", role: "button", name: "Submit", interactive: true, rank: 9 }] }),
+  );
+  writeFileSync(
+    join(runFix, "report.json"),
+    JSON.stringify({
+      url: "https://smoke.test/page",
+      pageSemantics: "A smoke-test page",
+      testCases: [{ id: "tc-9", title: "Submit empty form shows errors", elementRefs: ["e49"] }],
+    }),
+  );
+  writeFileSync(join(tcDir, "ATC-DEMO-001.md"), "---\nid: ATC-DEMO-001\n---\n# x\n");
+  writeFileSync(join(tcDir, "ATC-DEMO-002.md"), "---\nid: ATC-DEMO-002\n---\n# x\n");
+  writeFileSync(
+    join(tcDir, "MTC-DEMO-001.md"),
+    `---\nid: MTC-DEMO-001\ntitle: "Submit empty form shows errors"\nsuite: DEMO\npriority: P1\ntype: Negative\nexecution: manual\nstatus: 📋 Manual\nautomation: — (manual, not automated)\n---\n\n# MTC-DEMO-001: Submit empty form shows errors\n\n## Preconditions\n\n- The form is open\n\n## Steps\n\n1. Click Submit without filling fields\n\n## Expected Result\n\n- Validation errors are shown\n`,
+  );
+
+  const dsFile = join(appDir, "dataset.json");
+  const da = cairn(["dataset-add", "--from-run", runFix, "--to", dsFile]);
+  let dsOk = false;
+  try {
+    const ds = JSON.parse(readFileSync(dsFile, "utf8"));
+    dsOk = da.status === 0 && Array.isArray(ds.items) && ds.items.length === 1 && ds.items[0].pageSemantics === "A smoke-test page";
+  } catch {
+    dsOk = false;
+  }
+  check("dataset-add reads the run and writes a dataset item", dsOk, da.out.trim());
+
+  const pr = cairn(["promote", "--run", runFix, "--cases", "MTC-DEMO-001"]);
+  const tcAfter = existsSync(tcDir) ? readdirSync(tcDir) : [];
+  const promoteOk =
+    pr.status === 0 &&
+    tcAfter.includes("ATC-DEMO-003.md") && // 001/002 taken → next free is 003
+    !tcAfter.includes("MTC-DEMO-001.md"); // promoted in place
+  check("promote rewrites MTC-DEMO-001 → ATC-DEMO-003 (.md transform)", promoteOk, pr.out.trim());
+
+  // 6. Verdict.
+  const failed = results.filter((r) => !r.ok);
+  console.log(`\n${failed.length === 0 ? "✓ smoke passed" : `✗ smoke FAILED (${failed.length}/${results.length})`} — ${results.length} checks`);
+  process.exitCode = failed.length === 0 ? 0 : 1;
+} catch (e) {
+  console.error(`\n✗ smoke errored: ${e instanceof Error ? e.message : String(e)}`);
+  process.exitCode = 1;
+} finally {
+  // Always clean up the temp project (best-effort; Windows can hold file locks briefly).
+  try {
+    rmSync(work, { recursive: true, force: true, maxRetries: 3 });
+  } catch {
+    console.error(`(note: could not remove temp dir ${work})`);
+  }
+}

--- a/src/agent/graph.ts
+++ b/src/agent/graph.ts
@@ -39,6 +39,13 @@ export interface ExploreDeps {
    * (L1-04, #38). Best-effort: a throw here must not break the run.
    */
   onStudy?: (study: PageStudy) => void | Promise<void>;
+  /**
+   * Called with the freshly designed cases the moment `designTestCases` succeeds — mirrors onStudy
+   * (#38) so an interrupt during the later codegen/validate phase doesn't lose the generated cases.
+   * Best-effort: a throw here must not break the run. `studyUrl` lets the caller derive the SAME
+   * suite label the final write uses, so the early and final writes produce identical files.
+   */
+  onTestCases?: (testCases: TestCase[], verified: VerifiedElement[], studyUrl: string) => void | Promise<void>;
   /** Codeless mode: stop after designTestCases (cases only, no codegen/validate). */
   codeless?: boolean;
   /**
@@ -232,6 +239,13 @@ export function buildExploreGraph(deps: ExploreDeps) {
         { invoke: deps.designInvoke, prompts: deps.prompts },
       );
       deps.onProgress?.(`designTestCases — generated ${testCases.length} cases`);
+      // Durability: persist the cases NOW (best-effort), mirroring onStudy (#38) — a kill during the later
+      // codegen/validate phase (minutes for explore) must not lose what we already designed.
+      try {
+        await deps.onTestCases?.(testCases, s.verified, s.study.url);
+      } catch {
+        // durability is best-effort — never let it break the run.
+      }
       return { testCases };
     })
     .addNode("generateCode", async (s) => {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -185,6 +185,17 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
         // durability is best-effort
       }
     },
+    // Durability: persist the ATC/MTC case docs the moment they are designed, so a kill during the long
+    // codegen/validate phase still leaves the cases on disk (best-effort). suiteFromUrl(studyUrl)
+    // matches the final write below → identical files, no duplicates.
+    onTestCases: async (testCases, verified, studyUrl) => {
+      try {
+        const { docs } = buildTestCaseDocs(testCases, verified, suiteFromUrl(studyUrl), checklistItems.length > 0);
+        await runWriter.writeTestCases(docs);
+      } catch {
+        // durability is best-effort
+      }
+    },
     // L1-05: a session was supplied → fail fast if the first page is a login screen (expired session).
     expectAuthenticated: Boolean(input.sessionName || input.sessionFile),
     sessionName: input.sessionName,
@@ -420,9 +431,13 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
   const budget = new CallBudget(80); // cost-guardrail: safeguard (normally ~6-10 calls/run)
   const router = new RoleRouter(cfg, keys, budget); // L1-01: per-role routing + cost ledger
   const logLines: string[] = [];
+  // Parity with runExploration (#38): buffer progress into run.log, flushed incrementally so a
+  // mid-run kill leaves the log on disk. `persistLog` is wired once the run dir exists.
+  let persistLog: () => void = () => undefined; // no-op until the run dir exists
   const onProgress = (event: string): void => {
     logLines.push(`${new Date().toISOString()}  ${event}`);
     input.onProgress?.(event);
+    persistLog();
   };
 
   let storageState: StorageState | undefined;
@@ -442,6 +457,8 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
   const artifacts = new ArtifactStore(resolve(input.runsBaseDir ?? resolve(process.cwd(), "runs")));
   const runId = randomUUID();
   const runWriter = await artifacts.openRun(runId);
+  // #38: now that the run dir exists, flush run.log on every progress event (best-effort).
+  persistLog = () => void runWriter.writeLog(logLines.join("\n")).catch(() => undefined);
 
   const checklistItems = input.checklistText ? ingestChecklist(input.checklistText) : [];
   const knowledgeText = await loadKnowledge(resolve(input.knowledgeDir ?? "knowledge"), input.url);
@@ -476,6 +493,27 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
     validate: () => Promise.resolve({ results: [], greenRatio: 0, flakyCount: 0 }),
     maxRepair: 0,
     onProgress,
+    // #38 parity with explore: persist study + snapshots the moment observe succeeds, so a mid-run
+    // kill still leaves the page study/screenshot/ARIA on disk (best-effort — never break the run).
+    onStudy: async (study) => {
+      try {
+        await runWriter.writeStudy(study);
+        if (study.screenshotB64) await runWriter.writeScreenshot(study.screenshotB64);
+        await runWriter.writeAria(study.ariaYaml);
+      } catch {
+        // durability is best-effort
+      }
+    },
+    // Durability: design's loss window is small (END right after designTestCases), but still real — flush
+    // the case docs the instant they are designed so an interrupt before the final write keeps them.
+    onTestCases: async (testCases, verified, studyUrl) => {
+      try {
+        const { docs } = buildTestCaseDocs(testCases, verified, suiteFromUrl(studyUrl), checklistItems.length > 0);
+        await runWriter.writeTestCases(docs);
+      } catch {
+        // durability is best-effort
+      }
+    },
     codeless: true,
     // L1-05: a session was supplied → fail fast if the first page is a login screen (expired session).
     expectAuthenticated: Boolean(input.sessionName || input.sessionFile),
@@ -567,6 +605,19 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
       scores,
       cost,
     };
+  } catch (err) {
+    // L1-04 parity with runExploration: write a partial report + a friendly, actionable summary
+    // instead of leaking a raw traceback. Study/snapshots/log/cases were already persisted
+    // incrementally (onStudy/persistLog/onTestCases), so the partial run is still useful on disk.
+    throw await finalizeFailure(runWriter, {
+      runId,
+      url: input.url,
+      error: err,
+      cost: router.ledger.report(),
+      budget: { used: budget.spent, max: budget.max },
+      sessionName: input.sessionName,
+      onProgress,
+    });
   } finally {
     await gateway.close();
     await telemetry.shutdown();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,7 +28,7 @@ import { PromptRegistry, LOCAL_PROMPTS } from "../prompts/index.js";
 import { runExperiment, type DatasetItem, type Variant } from "../eval/experiment.js";
 import type { PageStudy } from "../observe/index.js";
 // C1-01 — shared umbrella core: flag→config, the cost footer, and the modality registry/dispatch.
-import { resolveConfig, printCost, runModality, MODALITIES } from "../core/index.js";
+import { resolveConfig, printCost, runModality, MODALITIES, makeCliProgress } from "../core/index.js";
 
 /**
  * Shared capture action for `cairn session capture` and the flat `cairn login` alias.
@@ -231,6 +231,11 @@ export function buildProgram(): Command {
         const config = resolveConfig({ routing: opts.routing, channel: opts.channel });
         const checklistText = opts.checklist ? await readFile(opts.checklist, "utf8") : undefined;
         process.stderr.write(`▸ Designing test cases for ${opts.url}${opts.session ? ` (session: ${opts.session})` : ""}…\n`);
+        const progress = makeCliProgress({
+          write: (s) => void process.stderr.write(s),
+          isTTY: Boolean(process.stderr.isTTY),
+          now: Date.now,
+        });
         const result = await runDesign({
           url: opts.url,
           config,
@@ -239,8 +244,8 @@ export function buildProgram(): Command {
           checklistText,
           style: opts.style,
           headed: opts.headed,
-          onProgress: (e) => process.stderr.write(`  ▸ ${e}\n`),
-        });
+          onProgress: progress.event,
+        }).finally(() => progress.stop());
 
         process.stdout.write(
           `\n=== ${result.testCases.length} test cases → ${result.runDir}\\testcases\\ ===\n`,
@@ -273,14 +278,19 @@ export function buildProgram(): Command {
       async (opts: { run: string; validate?: boolean; session?: string; sessionFile?: string; channel?: string; routing?: string }) => {
         const config = resolveConfig({ routing: opts.routing, channel: opts.channel });
         process.stderr.write(`▸ Automating cases from ${opts.run}…\n`);
+        const progress = makeCliProgress({
+          write: (s) => void process.stderr.write(s),
+          isTTY: Boolean(process.stderr.isTTY),
+          now: Date.now,
+        });
         const result = await runAutomate({
           runDir: opts.run,
           config,
           validate: opts.validate,
           sessionName: opts.session,
           sessionFile: opts.sessionFile,
-          onProgress: (e) => process.stderr.write(`  ▸ ${e}\n`),
-        });
+          onProgress: progress.event,
+        }).finally(() => progress.stop());
         process.stdout.write(
           `\n=== ${result.specFiles.length} spec files → ${result.runDir}\\tests\\ ===\n`,
         );

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -9,6 +9,8 @@
 export { resolveConfig } from "./config.js";
 export type { ConfigFlags } from "./config.js";
 export { printCost } from "./reporting.js";
+export { makeCliProgress } from "./progress.js";
+export type { CliProgress } from "./progress.js";
 export { defaultIO, gatedNotice } from "./modality.js";
 export type { Modality, ModalityContext, IO, Sink } from "./modality.js";
 export { MODALITIES, getModality, runModality } from "./registry.js";

--- a/src/core/modalities/explore.ts
+++ b/src/core/modalities/explore.ts
@@ -10,6 +10,7 @@ import { runExploration } from "../../agent/index.js";
 import { renderRunSummary } from "../../agent/summary.js";
 import { resolveConfig } from "../config.js";
 import { printCost } from "../reporting.js";
+import { makeCliProgress } from "../progress.js";
 import type { Modality, ModalityContext } from "../modality.js";
 
 /** Parsed flags for `cairn explore` (mirrors the command's option definitions). */
@@ -37,6 +38,9 @@ export const exploreModality: Modality = {
     ctx.err(
       `▸ Exploring ${opts.url}${opts.session ? ` (session: ${opts.session})` : ""}${opts.checklist ? ` (checklist: ${opts.checklist})` : ""}…\n`,
     );
+    // Progress UX: animate the current step in a TTY (long LLM steps emit no events for ~a minute, so the
+    // CLI looked frozen). In a pipe/CI this falls back to one plain `  ▸ <event>` line per event.
+    const progress = makeCliProgress({ write: ctx.err, isTTY: Boolean(ctx.isTTY), now: Date.now });
     const result = await runExploration({
       url: opts.url,
       config,
@@ -45,8 +49,8 @@ export const exploreModality: Modality = {
       headed: opts.headed,
       checklistText,
       style: opts.style,
-      onProgress: (e) => ctx.err(`  ▸ ${e}\n`),
-    });
+      onProgress: progress.event,
+    }).finally(() => progress.stop());
 
     ctx.out(`\n=== Exploration of ${result.study.url} (run ${result.runId}) ===\n`);
     ctx.out(`Purpose: ${result.analysis.pageSemantics}\n`);

--- a/src/core/modality.ts
+++ b/src/core/modality.ts
@@ -14,12 +14,15 @@ export type Sink = (s: string) => void;
 export interface IO {
   out: Sink;
   err: Sink;
+  /** Whether the err stream is a TTY → drives the in-place progress spinner (off in pipes/CI). */
+  isTTY?: boolean;
 }
 
 /** Default IO → the process streams (the production CLI path). */
 export const defaultIO: IO = {
   out: (s) => void process.stdout.write(s),
   err: (s) => void process.stderr.write(s),
+  isTTY: Boolean(process.stderr.isTTY),
 };
 
 /** Everything a modality's `run` needs: the parsed CLI flags + output sinks. */
@@ -28,6 +31,8 @@ export interface ModalityContext {
   flags: Record<string, unknown>;
   out: Sink;
   err: Sink;
+  /** Whether the err stream is a TTY → drives the in-place progress spinner (off in pipes/CI). */
+  isTTY?: boolean;
 }
 
 /**

--- a/src/core/progress.ts
+++ b/src/core/progress.ts
@@ -1,0 +1,77 @@
+/**
+ * CLI progress renderer. Long LLM-bound steps (designTestCases ~a minute) emit no progress
+ * events while they run, so the CLI looked frozen. In a TTY we animate the CURRENT step in place
+ * (`▸ <label> ⠋ 12s`) on a single stderr line; when the next event arrives the previous step is
+ * frozen as a permanent line. In a pipe/CI (no TTY) we fall back to one plain line per event.
+ *
+ * Lives in core/ (shared CLI presentation, like reporting.ts) so both the inline CLI actions
+ * (design/automate) and the explore modality can use it without a cli→core layering inversion.
+ * Pure of process globals (write/isTTY/now are injected) so it is unit-testable with fake timers.
+ * CR/LF/ESC are built from char codes to keep invisible control bytes out of the source.
+ */
+const FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const CR = String.fromCharCode(13);
+const LF = String.fromCharCode(10);
+const ESC = String.fromCharCode(27);
+const CLEAR_LINE = CR + ESC + "[K"; // carriage-return + ANSI erase-to-end-of-line
+
+export interface CliProgress {
+  /** Report a new step. Freezes the previous step's line, then animates this one (TTY). */
+  event: (text: string) => void;
+  /** Commit the current step and stop animating. Always call once when the run settles. */
+  stop: () => void;
+}
+
+export function makeCliProgress(opts: {
+  write: (s: string) => void;
+  isTTY: boolean;
+  now: () => number;
+  intervalMs?: number;
+}): CliProgress {
+  const { write, isTTY, now } = opts;
+  const intervalMs = opts.intervalMs ?? 120;
+
+  // Non-TTY: a spinner would just spew control codes into a pipe/file — print plain lines instead.
+  if (!isTTY) {
+    return {
+      event: (text) => write(`  ▸ ${text}${LF}`),
+      stop: () => undefined,
+    };
+  }
+
+  let current: string | null = null;
+  let startedAt = 0;
+  let frame = 0;
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const render = (): void => {
+    if (current === null) return;
+    const elapsed = Math.floor((now() - startedAt) / 1000);
+    write(`${CLEAR_LINE}  ▸ ${current} ${FRAMES[frame % FRAMES.length]} ${elapsed}s`);
+    frame += 1;
+  };
+
+  const commit = (): void => {
+    if (current === null) return;
+    write(`${CLEAR_LINE}  ▸ ${current}${LF}`); // freeze the step as a permanent line (no spinner)
+  };
+
+  return {
+    event: (text) => {
+      commit(); // the previous step is done
+      current = text;
+      startedAt = now();
+      frame = 0;
+      render(); // show the label immediately, don't wait for the first tick
+      if (!timer) timer = setInterval(render, intervalMs);
+    },
+    stop: () => {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+      commit();
+      current = null;
+    },
+  };
+}

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -44,5 +44,5 @@ export async function runModality(
     for (const line of gatedNotice(m)) io.out(`${line}\n`);
     return;
   }
-  await m.run({ flags, out: io.out, err: io.err });
+  await m.run({ flags, out: io.out, err: io.err, isTTY: io.isTTY });
 }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,7 +1,8 @@
-import { useReducer, useState } from "react";
+import { useReducer, useRef, useState } from "react";
 import { Box, useApp, useInput } from "ink";
 import { routerReducer, initialRouter, currentScreen, canGoBack, type Screen } from "./router.js";
 import { RouterProvider, type RouterApi } from "./router-context.js";
+import { globalKeyAction } from "./keys.js";
 import { ErrorBoundary } from "./components/error-boundary.js";
 import { Help } from "./components/help.js";
 import { LauncherScreen } from "./screens/launcher-screen.js";
@@ -19,6 +20,9 @@ export function App() {
   const { exit } = useApp();
   const [router, dispatch] = useReducer(routerReducer, initialRouter);
   const [inTextField, setInTextField] = useState(false);
+  // A screen (e.g. the wizard) can register a back handler that intercepts Escape; a ref avoids
+  // re-rendering and lets the global useInput closure always read the latest handler.
+  const backHandler = useRef<(() => boolean) | null>(null);
   const screen = currentScreen(router);
   const backable = canGoBack(router);
 
@@ -28,15 +32,21 @@ export function App() {
     replace: (s) => dispatch({ type: "replace", screen: s }),
     canGoBack: backable,
     setInTextField,
+    setBackHandler: (fn) => {
+      backHandler.current = fn;
+    },
   };
 
   useInput((input, key) => {
-    if (inTextField) return; // text fields own their keystrokes
-    if (input === "q") {
-      exit();
+    const action = globalKeyAction(input, key, { inTextField });
+    if (action?.type === "back") {
+      // A screen may consume the back (e.g. the wizard steps to its previous field) — only when it
+      // does NOT consume do we pop the router stack. Escape works even inside a text field now.
+      const consumed = backHandler.current?.() ?? false;
+      if (!consumed && backable) dispatch({ type: "back" });
       return;
     }
-    if (key.escape && backable) dispatch({ type: "back" });
+    if (action?.type === "quit") exit();
   });
 
   return (

--- a/src/tui/keys.ts
+++ b/src/tui/keys.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure key-handling logic for the TUI, kept free of React/Ink so it is trivially unit-testable
+ * (same philosophy as router.ts). App.tsx maps these intents onto exit()/router navigation.
+ */
+
+export type KeyAction = { type: "quit" } | { type: "back" } | null;
+
+/**
+ * Maps a keypress to a global intent.
+ * - Escape ALWAYS backs out — even while a text field owns the keyboard (esc is not a printable key,
+ *   so the field does not need it). This is what lets the user leave a form from its first (text) step.
+ * - "q" quits only when no text field is focused (otherwise it is a character being typed).
+ */
+export function globalKeyAction(
+  input: string,
+  key: { escape?: boolean },
+  opts: { inTextField: boolean },
+): KeyAction {
+  if (key.escape) return { type: "back" };
+  if (opts.inTextField) return null; // the focused text field owns printable keys (incl. "q")
+  if (input === "q") return { type: "quit" };
+  return null;
+}
+
+/**
+ * Wizard step-back. Returns the previous step and `consumed: true` when there is somewhere to go back
+ * to; at step 0 returns `consumed: false` so the caller pops the whole screen (form → launcher) instead.
+ */
+export function stepBack(stepIndex: number): { stepIndex: number; consumed: boolean } {
+  return stepIndex > 0 ? { stepIndex: stepIndex - 1, consumed: true } : { stepIndex, consumed: false };
+}

--- a/src/tui/router-context.ts
+++ b/src/tui/router-context.ts
@@ -10,8 +10,13 @@ export interface RouterApi {
   back: () => void;
   replace: (screen: Screen) => void;
   canGoBack: boolean;
-  /** Screens with a focused text input set this true so global `q`/esc don't steal keys. */
+  /** Screens with a focused text input set this true so the global `q` shortcut doesn't steal a typed key. */
   setInTextField: (v: boolean) => void;
+  /**
+   * A screen may intercept the global "back" (Escape) — e.g. a wizard steps back internally.
+   * Return `true` if consumed; `false`/unset → the global handler does the default router pop.
+   */
+  setBackHandler: (fn: (() => boolean) | null) => void;
 }
 
 const RouterContext = createContext<RouterApi | null>(null);

--- a/src/tui/screens/form-screen.tsx
+++ b/src/tui/screens/form-screen.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Box, Text, useInput } from "ink";
 import SelectInput from "ink-select-input";
 import { useRouter } from "../router-context.js";
+import { stepBack } from "../keys.js";
 import { Field } from "../components/field.js";
 import { SessionPicker } from "../components/session-picker.js";
 import type { Command, FormValues, PlanningStyle } from "../types.js";
@@ -35,7 +36,7 @@ const YESNO = [
 
 /** Sequential wizard: one field per step, ⏎ advances, last step runs the command. */
 export function FormScreen({ command, initial }: { command: Command; initial?: Partial<FormValues> }) {
-  const { navigate, setInTextField } = useRouter();
+  const { navigate, setInTextField, setBackHandler } = useRouter();
   const [values, setValues] = useState<FormValues>({ url: "", style: "all", headed: false, ...initial });
   const [stepIndex, setStepIndex] = useState(0);
 
@@ -43,11 +44,21 @@ export function FormScreen({ command, initial }: { command: Command; initial?: P
   const step: StepKey = steps[stepIndex] ?? "submit";
   const isText = step === "url" || step === "runDir" || step === "checklist";
 
-  // Suppress global q/esc only while a text field owns the keyboard.
+  // Suppress the global `q` shortcut only while a text field owns the keyboard (Escape is unaffected).
   useEffect(() => {
     setInTextField(isText);
     return () => setInTextField(false);
   }, [isText, setInTextField]);
+
+  // Escape steps back through the wizard; at step 0 it isn't consumed, so App pops to the launcher.
+  useEffect(() => {
+    setBackHandler(() => {
+      const r = stepBack(stepIndex);
+      if (r.consumed) setStepIndex(r.stepIndex);
+      return r.consumed;
+    });
+    return () => setBackHandler(null);
+  }, [stepIndex, setBackHandler]);
 
   const advance = () => setStepIndex((i) => Math.min(i + 1, steps.length - 1));
   const set = <K extends keyof FormValues>(k: K, v: FormValues[K]) =>

--- a/tests/unit/cli-progress.test.ts
+++ b/tests/unit/cli-progress.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import { makeCliProgress } from "../../src/core/progress.js";
+
+describe("makeCliProgress — non-TTY (pipe / CI)", () => {
+  it("prints one plain line per event with no carriage-return animation", () => {
+    const out: string[] = [];
+    const p = makeCliProgress({ write: (s) => out.push(s), isTTY: false, now: () => 0 });
+    p.event("observe — opening");
+    p.event("design — thinking");
+    p.stop();
+    const joined = out.join("");
+    expect(joined).toBe("  ▸ observe — opening\n  ▸ design — thinking\n");
+    expect(joined).not.toContain("\r"); // no in-place rewrites in a pipe
+  });
+});
+
+describe("makeCliProgress — TTY (in-place spinner)", () => {
+  it("animates the current step in place with a growing elapsed counter", () => {
+    vi.useFakeTimers();
+    let t = 0;
+    const out: string[] = [];
+    const p = makeCliProgress({ write: (s) => out.push(s), isTTY: true, now: () => t, intervalMs: 100 });
+
+    p.event("designTestCases — designing");
+    expect(out.join("")).toContain("designTestCases — designing");
+
+    t = 2000;
+    vi.advanceTimersByTime(100); // fire one tick at elapsed = 2s
+    const joined = out.join("");
+    expect(joined).toContain("\r"); // in-place updates use a carriage return
+    expect(joined).toContain(`${String.fromCharCode(27)}[K`); // proper ANSI erase, not a literal "[K"
+    expect(joined).toContain("2s"); // elapsed counter rendered
+
+    p.stop();
+    vi.useRealTimers();
+  });
+
+  it("commits the previous step as a permanent line when a new event arrives", () => {
+    vi.useFakeTimers();
+    const out: string[] = [];
+    const p = makeCliProgress({ write: (s) => out.push(s), isTTY: true, now: () => 0, intervalMs: 100 });
+
+    p.event("observe — opening");
+    p.event("design — thinking"); // observe is now done → frozen on its own line
+
+    expect(out.join("")).toContain("  ▸ observe — opening\n");
+    p.stop();
+    vi.useRealTimers();
+  });
+
+  it("commits the final step and stops the timer on stop()", () => {
+    vi.useFakeTimers();
+    const out: string[] = [];
+    const p = makeCliProgress({ write: (s) => out.push(s), isTTY: true, now: () => 0, intervalMs: 100 });
+
+    p.event("design — thinking");
+    p.stop();
+    expect(out.join("")).toContain("  ▸ design — thinking\n");
+
+    const writesAfterStop = out.length;
+    vi.advanceTimersByTime(500); // a dangling interval would emit more frames here
+    expect(out.length).toBe(writesAfterStop);
+    vi.useRealTimers();
+  });
+});

--- a/tests/unit/explore-graph.test.ts
+++ b/tests/unit/explore-graph.test.ts
@@ -6,6 +6,7 @@ import type { RunWriter } from "../../src/artifacts/index.js";
 import type { BrowserGateway, Observation, Action } from "../../src/browser/index.js";
 import type { ValidationReport } from "../../src/validate/index.js";
 import type { PageStudy } from "../../src/observe/index.js";
+import type { TestCase } from "../../src/design/index.js";
 
 /** A StructuredInvoke that ignores its args and yields a fixed value (no LLM). */
 const fixed = (value: unknown): StructuredInvoke =>
@@ -233,5 +234,49 @@ describe("buildExploreGraph — durable artifacts (L1-04, #38)", () => {
     expect(seen).toHaveLength(1);
     expect(seen[0]?.elements.some((e) => e.name === "Reject all")).toBe(false); // re-observed after dismissal
     expect(seen[0]?.elements.some((e) => e.name === "Email")).toBe(true);
+  });
+});
+
+describe("buildExploreGraph — durable test cases (onTestCases)", () => {
+  it("hands the cases to onTestCases as soon as designTestCases succeeds, before codegen/validate can fail", async () => {
+    const seen: TestCase[][] = [];
+    const { gateway } = fakeGateway(() => obs('- button "Sign in"'));
+    const graph = buildExploreGraph(
+      makeDeps({
+        gateway,
+        onTestCases: (cases) => {
+          seen.push(cases);
+        },
+        // a later node throws → proves the cases were already persisted before the failure.
+        validate: async () => {
+          throw new Error("boom after design");
+        },
+      }),
+    );
+
+    await graph.invoke({ url: "https://app.test/page", runId: "r" }).catch(() => undefined);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.length).toBe(1); // the single sampleCase
+  });
+
+  it("fires onTestCases in codeless (design) mode too — the flow ends right after designTestCases", async () => {
+    const seen: TestCase[][] = [];
+    const { gateway } = fakeGateway(() => obs('- button "Sign in"'));
+    const graph = buildExploreGraph(
+      makeDeps({
+        gateway,
+        codeless: true,
+        onTestCases: (cases) => {
+          seen.push(cases);
+        },
+        validate: async () => ({ results: [], greenRatio: 0, flakyCount: 0 }),
+      }),
+    );
+
+    await graph.invoke({ url: "https://app.test/page", runId: "r" });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.length).toBe(1);
   });
 });

--- a/tests/unit/tui/dashboard.test.tsx
+++ b/tests/unit/tui/dashboard.test.tsx
@@ -36,6 +36,7 @@ function routerApi(over: Partial<RouterApi>): RouterApi {
     replace: vi.fn(),
     canGoBack: true,
     setInTextField: vi.fn(),
+    setBackHandler: vi.fn(),
     ...over,
   };
 }
@@ -71,6 +72,23 @@ describe("RunDashboardScreen", () => {
       expect(replace).toHaveBeenCalledWith(expect.objectContaining({ name: "summary" })),
     );
     expect(lastFrame() ?? "").toContain("Observe page"); // checklist label rendered
+    unmount();
+  });
+
+  it("surfaces a classified failure + recovery hint when the run throws (expired session)", async () => {
+    vi.mocked(runExploration).mockImplementation((async () => {
+      throw new Error("storageState is missing — session expired; recapture it");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any);
+
+    const { lastFrame, unmount } = render(
+      <RouterProvider value={routerApi({})}>
+        <RunDashboardScreen command="explore" values={{ url: "https://x", style: "all", headed: false }} />
+      </RouterProvider>,
+    );
+
+    await waitFor(() => expect(lastFrame() ?? "").toContain("Failed: session"));
+    expect(lastFrame() ?? "").toContain("recapture"); // ERROR_HINTS.session
     unmount();
   });
 });

--- a/tests/unit/tui/form-screen.test.tsx
+++ b/tests/unit/tui/form-screen.test.tsx
@@ -1,0 +1,66 @@
+import { render } from "ink-testing-library";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../../src/tui/hooks/use-sessions.js", () => ({
+  useSessions: () => ({ names: [], loading: false }),
+}));
+
+import { FormScreen } from "../../../src/tui/screens/form-screen.js";
+import { RouterProvider, type RouterApi } from "../../../src/tui/router-context.js";
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+function routerApi(over: Partial<RouterApi> = {}): RouterApi {
+  return {
+    navigate: vi.fn(),
+    back: vi.fn(),
+    replace: vi.fn(),
+    canGoBack: true,
+    setInTextField: vi.fn(),
+    setBackHandler: vi.fn(),
+    ...over,
+  };
+}
+
+describe("FormScreen", () => {
+  it("starts on the URL text step and flags a focused text field", async () => {
+    const setInTextField = vi.fn();
+    const { lastFrame, unmount } = render(
+      <RouterProvider value={routerApi({ setInTextField })}>
+        <FormScreen command="design" />
+      </RouterProvider>,
+    );
+    await delay(40);
+    expect(lastFrame() ?? "").toContain("URL");
+    expect(setInTextField).toHaveBeenCalledWith(true); // a text field owns the keyboard on the URL step
+    unmount();
+  });
+
+  it("walks the wizard to the submit step and starts the run (navigates to the dashboard)", async () => {
+    const navigate = vi.fn();
+    const { lastFrame, stdin, unmount } = render(
+      <RouterProvider value={routerApi({ navigate })}>
+        <FormScreen command="design" />
+      </RouterProvider>,
+    );
+    await delay(40);
+    // design steps: url → session → checklist → style → headed → submit
+    stdin.write("https://app.test");
+    await delay(20);
+    stdin.write("\r"); // url → session
+    await delay(50);
+    stdin.write("\r"); // session: (no session) → checklist
+    await delay(50);
+    stdin.write("\r"); // checklist: empty → style
+    await delay(50);
+    stdin.write("\r"); // style: highlighted "all" → headed
+    await delay(50);
+    stdin.write("\r"); // headed: highlighted "no" → submit
+    await delay(50);
+    expect(lastFrame() ?? "").toContain("Ready to run");
+    stdin.write("\r"); // submit → start the run
+    await delay(50);
+    expect(navigate).toHaveBeenCalledWith(expect.objectContaining({ name: "dashboard", command: "design" }));
+    unmount();
+  });
+});

--- a/tests/unit/tui/help.test.tsx
+++ b/tests/unit/tui/help.test.tsx
@@ -1,0 +1,21 @@
+import { render } from "ink-testing-library";
+import { describe, it, expect } from "vitest";
+import { Help } from "../../../src/tui/components/help.js";
+
+describe("Help", () => {
+  it("shows the esc-back hint when back navigation is possible", () => {
+    const { lastFrame, unmount } = render(<Help canGoBack={true} />);
+    const f = lastFrame() ?? "";
+    expect(f).toContain("esc back");
+    expect(f).toContain("q quit");
+    unmount();
+  });
+
+  it("omits the esc-back hint at the root (nothing to go back to)", () => {
+    const { lastFrame, unmount } = render(<Help canGoBack={false} />);
+    const f = lastFrame() ?? "";
+    expect(f).not.toContain("esc back");
+    expect(f).toContain("q quit"); // quit is always offered
+    unmount();
+  });
+});

--- a/tests/unit/tui/keys.test.ts
+++ b/tests/unit/tui/keys.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { globalKeyAction, stepBack } from "../../../src/tui/keys.js";
+
+describe("globalKeyAction", () => {
+  it("Escape always backs out — even while a text field owns the keyboard", () => {
+    expect(globalKeyAction("", { escape: true }, { inTextField: true })).toEqual({ type: "back" });
+  });
+
+  it("Escape backs out on a non-text step too", () => {
+    expect(globalKeyAction("", { escape: true }, { inTextField: false })).toEqual({ type: "back" });
+  });
+
+  it('"q" quits when no text field owns the keyboard', () => {
+    expect(globalKeyAction("q", {}, { inTextField: false })).toEqual({ type: "quit" });
+  });
+
+  it('"q" is NOT a quit while a text field is focused (it is a printable char there)', () => {
+    expect(globalKeyAction("q", {}, { inTextField: true })).toBeNull();
+  });
+
+  it("an ordinary character on a non-text step is ignored", () => {
+    expect(globalKeyAction("a", {}, { inTextField: false })).toBeNull();
+  });
+
+  it("an ordinary character in a text field is ignored (the field handles it)", () => {
+    expect(globalKeyAction("a", {}, { inTextField: true })).toBeNull();
+  });
+
+  it("Escape takes priority over a coincident printable input", () => {
+    // esc is reported with input "" by Ink, but guard against any input leaking through.
+    expect(globalKeyAction("q", { escape: true }, { inTextField: false })).toEqual({ type: "back" });
+  });
+});
+
+describe("stepBack", () => {
+  it("does not consume at step 0 (caller pops the screen instead)", () => {
+    expect(stepBack(0)).toEqual({ stepIndex: 0, consumed: false });
+  });
+
+  it("steps back and consumes from step 1", () => {
+    expect(stepBack(1)).toEqual({ stepIndex: 0, consumed: true });
+  });
+
+  it("steps back and consumes from a later step", () => {
+    expect(stepBack(3)).toEqual({ stepIndex: 2, consumed: true });
+  });
+});

--- a/tests/unit/tui/launcher.test.tsx
+++ b/tests/unit/tui/launcher.test.tsx
@@ -1,0 +1,72 @@
+import { render } from "ink-testing-library";
+import { describe, it, expect, vi } from "vitest";
+import { LauncherScreen } from "../../../src/tui/screens/launcher-screen.js";
+import { RouterProvider, type RouterApi } from "../../../src/tui/router-context.js";
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+function routerApi(over: Partial<RouterApi> = {}): RouterApi {
+  return {
+    navigate: vi.fn(),
+    back: vi.fn(),
+    replace: vi.fn(),
+    canGoBack: false,
+    setInTextField: vi.fn(),
+    setBackHandler: vi.fn(),
+    ...over,
+  };
+}
+
+// ink-select-input moves with j/k as well as the arrow keys — j is a plain char (no escape sequence),
+// so menu navigation in tests is deterministic.
+describe("LauncherScreen", () => {
+  it("opens the Explore form on the first item", async () => {
+    const navigate = vi.fn();
+    const { stdin, unmount } = render(
+      <RouterProvider value={routerApi({ navigate })}>
+        <LauncherScreen />
+      </RouterProvider>,
+    );
+    await delay(30);
+    stdin.write("\r");
+    await delay(30);
+    expect(navigate).toHaveBeenCalledWith({ name: "form", command: "explore" });
+    unmount();
+  });
+
+  it("opens the Design form one step down", async () => {
+    const navigate = vi.fn();
+    const { stdin, unmount } = render(
+      <RouterProvider value={routerApi({ navigate })}>
+        <LauncherScreen />
+      </RouterProvider>,
+    );
+    await delay(30);
+    stdin.write("j"); // → Design
+    await delay(20);
+    stdin.write("\r");
+    await delay(30);
+    expect(navigate).toHaveBeenCalledWith({ name: "form", command: "design" });
+    unmount();
+  });
+
+  it("opens the past-runs browser (Browse past runs)", async () => {
+    const navigate = vi.fn();
+    const { stdin, unmount } = render(
+      <RouterProvider value={routerApi({ navigate })}>
+        <LauncherScreen />
+      </RouterProvider>,
+    );
+    await delay(30);
+    stdin.write("j"); // → Design
+    await delay(20);
+    stdin.write("j"); // → Automate
+    await delay(20);
+    stdin.write("j"); // → Browse past runs
+    await delay(20);
+    stdin.write("\r");
+    await delay(30);
+    expect(navigate).toHaveBeenCalledWith({ name: "runsList" });
+    unmount();
+  });
+});

--- a/tests/unit/tui/navigation.test.tsx
+++ b/tests/unit/tui/navigation.test.tsx
@@ -1,8 +1,16 @@
 import { render } from "ink-testing-library";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+// The session step renders a SelectInput backed by useSessions (reads .auth/). Stub it so the
+// wizard advances deterministically in tests without touching the filesystem.
+vi.mock("../../../src/tui/hooks/use-sessions.js", () => ({
+  useSessions: () => ({ names: [], loading: false }),
+}));
+
 import { App } from "../../../src/tui/App.js";
 
 const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+const ESC = String.fromCharCode(27); // 0x1B — the Escape key byte
 
 describe("TUI navigation", () => {
   it("launcher lists the commands", () => {
@@ -20,6 +28,38 @@ describe("TUI navigation", () => {
     stdin.write("\r"); // Enter on the first menu item
     await delay(80);
     expect(lastFrame() ?? "").toContain("URL");
+    unmount();
+  });
+});
+
+describe("TUI Escape / exit", () => {
+  it("Escape on the first (URL) step leaves the form for the launcher", async () => {
+    const { lastFrame, stdin, unmount } = render(<App />);
+    await delay(30);
+    stdin.write("\r"); // launcher → Explore form (URL step)
+    await delay(80);
+    expect(lastFrame() ?? "").toContain("URL");
+    stdin.write(ESC);
+    await delay(80);
+    expect(lastFrame() ?? "").toContain("Quit"); // back at the launcher menu
+    unmount();
+  });
+
+  it("Escape on a later step steps back through the wizard (does not exit to the launcher)", async () => {
+    const { lastFrame, stdin, unmount } = render(<App />);
+    await delay(30);
+    stdin.write("\r"); // Explore form, URL step
+    await delay(80);
+    stdin.write("https://example.test"); // fill the URL
+    await delay(30);
+    stdin.write("\r"); // advance → session step
+    await delay(80);
+    expect(lastFrame() ?? "").toContain("Session");
+    stdin.write(ESC); // step back
+    await delay(80);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("URL"); // back on the URL step
+    expect(frame).not.toContain("Quit"); // NOT the launcher
     unmount();
   });
 });

--- a/tests/unit/tui/run-detail-nav.test.tsx
+++ b/tests/unit/tui/run-detail-nav.test.tsx
@@ -1,0 +1,56 @@
+import { render } from "ink-testing-library";
+import { describe, it, expect, vi } from "vitest";
+
+// Stub the filesystem-backed hooks so launcher → runsList → runDetail is deterministic.
+vi.mock("../../../src/tui/hooks/use-runs.js", () => ({
+  useRuns: () => ({
+    runs: [
+      {
+        runId: "a",
+        dir: "runs/a",
+        url: "https://app.example.com/login",
+        mode: "design",
+        testCaseCount: 1,
+        date: new Date("2026-06-01T10:00:00Z"),
+      },
+    ],
+    loading: false,
+    reload: () => {},
+  }),
+}));
+vi.mock("../../../src/tui/hooks/use-run-artifacts.js", () => ({
+  useRunArtifacts: () => ({ cases: [], report: "r", log: "l", loading: false, reload: () => {} }),
+}));
+
+import { App } from "../../../src/tui/App.js";
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+const ESC = String.fromCharCode(27);
+
+describe("TUI run-detail navigation", () => {
+  it("Escape on the run detail pops exactly ONE level (back to the runs list, not the launcher)", async () => {
+    const { lastFrame, stdin, unmount } = render(<App />);
+    await delay(30);
+    // launcher → "Browse past runs" is the 4th item (j moves down; j is a plain key in ink-select-input).
+    stdin.write("j");
+    await delay(20);
+    stdin.write("j");
+    await delay(20);
+    stdin.write("j");
+    await delay(20);
+    stdin.write("\r"); // → runs list
+    await delay(80);
+    expect(lastFrame() ?? "").toContain("Past runs");
+
+    stdin.write("\r"); // select the first run → run detail
+    await delay(80);
+    expect(lastFrame() ?? "").toContain("Cases"); // the tabbed artifact viewer
+
+    stdin.write(ESC); // back
+    await delay(80);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Past runs"); // ONE pop → runs list
+    expect(frame).not.toContain("pick a command"); // NOT the launcher (would be a double pop)
+    unmount();
+  });
+});

--- a/tests/unit/tui/runs-list.test.tsx
+++ b/tests/unit/tui/runs-list.test.tsx
@@ -32,7 +32,14 @@ import { RunsListScreen } from "../../../src/tui/screens/runs-list-screen.js";
 import { RouterProvider, type RouterApi } from "../../../src/tui/router-context.js";
 
 function routerApi(): RouterApi {
-  return { navigate: vi.fn(), back: vi.fn(), replace: vi.fn(), canGoBack: true, setInTextField: vi.fn() };
+  return {
+    navigate: vi.fn(),
+    back: vi.fn(),
+    replace: vi.fn(),
+    canGoBack: true,
+    setInTextField: vi.fn(),
+    setBackHandler: vi.fn(),
+  };
 }
 
 describe("RunsListScreen", () => {

--- a/tests/unit/tui/session-picker.test.tsx
+++ b/tests/unit/tui/session-picker.test.tsx
@@ -1,0 +1,32 @@
+import { render } from "ink-testing-library";
+import { describe, it, expect, vi } from "vitest";
+
+const { useSessions } = vi.hoisted(() => ({ useSessions: vi.fn() }));
+vi.mock("../../../src/tui/hooks/use-sessions.js", () => ({ useSessions }));
+
+import { SessionPicker } from "../../../src/tui/components/session-picker.js";
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+describe("SessionPicker", () => {
+  it("shows a loading line while sessions are being scanned", () => {
+    useSessions.mockReturnValue({ names: [], loading: true });
+    const { lastFrame, unmount } = render(<SessionPicker onSelect={vi.fn()} />);
+    expect(lastFrame() ?? "").toContain("loading sessions");
+    unmount();
+  });
+
+  it("offers (no session) + named sessions, and selecting none yields undefined", async () => {
+    useSessions.mockReturnValue({ names: ["acme"], loading: false });
+    const onSelect = vi.fn();
+    const { lastFrame, stdin, unmount } = render(<SessionPicker onSelect={onSelect} />);
+    await delay(30);
+    const f = lastFrame() ?? "";
+    expect(f).toContain("(no session)");
+    expect(f).toContain("acme");
+    stdin.write("\r"); // first item is "(no session)" → empty value → undefined
+    await delay(30);
+    expect(onSelect).toHaveBeenCalledWith(undefined);
+    unmount();
+  });
+});

--- a/tests/unit/tui/summary.test.tsx
+++ b/tests/unit/tui/summary.test.tsx
@@ -10,6 +10,7 @@ function routerApi(): RouterApi {
     replace: vi.fn(),
     canGoBack: true,
     setInTextField: vi.fn(),
+    setBackHandler: vi.fn(),
   };
 }
 


### PR DESCRIPTION
## What & why

Four issues surfaced while running `cairn design`, plus the interface test coverage that was missing (which is why the keyboard bug went unnoticed).

### 🐛 TUI: can't exit a form by keyboard
`Escape` was swallowed on text steps — the `if (inTextField) return` guard in `App.tsx` ran *before* the Escape check, so on the first (URL) step of design mode neither `Esc` nor `q` did anything and the user was trapped.
- `Esc` now backs out from anywhere (it isn't a printable key); `q` still types in text fields.
- Pure, unit-tested key logic in `src/tui/keys.ts` (`globalKeyAction`/`stepBack`).
- `Esc` steps back through the wizard; from step 0 it exits to the launcher (new `setBackHandler` on the router context).

### 🐛 Data loss on interrupt (design mode)
On `cairn design`, nothing hit disk until the very end — interrupting at `designTestCases` lost everything (the run dir held only an empty `tests/`). `runExploration` had incremental persistence (#38); `runDesign` had none.
- New `onTestCases` graph hook flushes the ATC/MTC `.md` cases the instant `designTestCases` finishes (mirrors `onStudy`), in **both** explore and design.
- `runDesign` brought to parity: wired `persistLog` (live `run.log`) + `onStudy` (study/screenshot/ARIA right after `observe`) + a `catch` that writes a partial report on failure.

### ✨ CLI looked frozen
Long LLM steps emit no progress for ~a minute. New `src/core/progress.ts` renders an in-place spinner (`▸ step ⠋ 12s`) on stderr in a TTY, and falls back to one plain line per event in a pipe/CI. Wired into `design`/`automate`/`explore`. The TUI already animates (ink-spinner) — unchanged.

### ✅ Interface tests + packaged-install smoke
- Comprehensive TUI tests: keys, wizard navigation (real `Esc`/step-back via `ink-testing-library`), form-screen, launcher, session-picker, help, run-detail single-pop, dashboard error states.
- Graph `onTestCases` durability test; CLI progress test (fake timers, TTY + non-TTY).
- `scripts/smoke-install.mjs` + `npm run smoke:pack`: build → `npm pack` → install the tarball into a fresh temp project → run the **installed** CLI's hermetic actions (`--version`/`--help`/`doctor`/gated stub/`session ls` + real `dataset-add` & `promote`). Catches packaging bugs (missing `files`, wrong `bin`, broken exports) that source tests miss.

## Verification
- `npm run build` ✅ · `npm run lint` ✅
- `npm test` → **378 passed, 2 skipped** (browser integration)
- `npm run test:coverage` ✅ gate holds (lines 98.2% / branches 85.7%)
- `npm run smoke:pack` → **8/8 checks** from a real installed tarball

## Notes
- The smoke caught that `cairn promote` requires `ANTHROPIC_API_KEY` via `loadConfig` even though the offline `.md` transform never calls the LLM — a pre-existing coupling nit (smoke injects a dummy, unused key). Worth a follow-up to decouple.
- Not wired into `npm test` (pack+install is heavy) — run before publishing.

## Not covered (needs a real terminal + keys + browser)
Manual checks for you: real `cairn design` + Ctrl+C (artifacts on disk), the live spinner in a real TTY, and the TUI escape/step-back in a real terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
