### PR TITLE
feat: case-quality guardrails — dedup + technique coverage

### DIFF
--- a/docs/superpowers/plans/2026-06-19-case-quality.md
+++ b/docs/superpowers/plans/2026-06-19-case-quality.md
@@ -1,0 +1,467 @@
+# Case-quality guardrails (#58) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dedup near-identical test cases (merge the obvious, flag the borderline) and report ISO
+29119-4 technique coverage — a meaningful suite, not 50 redundant clicks.
+
+**Architecture:** One deterministic `caseSimilarity(a,b)` verdict drives both `dedupCases` (applied
+inside `designTestCases`) and the new `case_redundancy` scorer — a single definition of "near-duplicate".
+A `technique_coverage` scorer + a prompt nudge round it out. All in `design/` + `eval/`, behind the seams.
+
+**Tech Stack:** TypeScript (strict, ESM/NodeNext), vitest, zod.
+
+## Global Constraints
+
+- Behavior-preserving: identical CLI surface, run artifacts (`runs/<id>/…`), config.
+- Stay behind the seams (`StructuredInvoke`, `onProgress`). **ZERO change to `src/agent/graph.ts`. NO design-retry loop.**
+- `designTestCases` keeps its signature (`(input, deps) => Promise<TestCase[]>`).
+- **DRY:** ONE exported `caseSimilarity(a, b): "merge" | "flag" | "distinct"` in `src/design/dedup.ts`,
+  shared by `dedupCases` AND the `case_redundancy` scorer. Do NOT restate the "near-duplicate" rule anywhere else.
+- Conservative merge key: same `technique` AND `type` AND identical `elementRefs` set AND normalized-`steps`
+  Jaccard ≥ 0.9. Representative by `priority` (critical>high>medium>low) > more `steps` > earliest.
+- Per-task gate (before each commit): `npm run typecheck && npm run lint && npm test && npm run build`.
+- Spec source of truth: `docs/superpowers/specs/2026-06-19-case-quality-design.md`.
+
+**Plan refinements vs the spec (recon-driven):**
+- `designTestCases` has NO `onProgress` hook (`DesignDeps = { invoke, prompts }`), and adding one /
+  touching `graph.ts` is out of scope. So the dedup is surfaced via the **reduced case count** (the graph's
+  existing "designTestCases — generated N cases" line now reflects the merged total) + the **`case_redundancy`
+  score**. AC2 ("redundancy reported") is satisfied by the score; the separate dedup `onProgress` line is dropped.
+- Tests are EXCLUDED from `npm run typecheck` (`tsconfig.json` excludes `tests/`), so test fixtures use a
+  `tc()` helper and need only the fields the logic reads (`technique`, `type`, `elementRefs`, `steps`,
+  `priority`, `title`, `id`).
+
+---
+
+### Task 1: `caseSimilarity` + `dedupCases` (the deterministic core)
+
+**Files:**
+- Create: `src/design/dedup.ts`
+- Test: `tests/unit/dedup.test.ts`
+
+**Interfaces:**
+- Consumes: `TestCase` from `./schema.js` (`{ id, title, technique, type, kind, execution, preconditions, steps, expected, priority, elementRefs }`).
+- Produces:
+  - `caseSimilarity(a: TestCase, b: TestCase): "merge" | "flag" | "distinct"`
+  - `dedupCases(cases: TestCase[]): { merged: TestCase[]; flagged: DuplicateGroup[] }`
+  - `interface DuplicateGroup { representative: TestCase; duplicates: TestCase[]; reason: "merged" | "flagged" }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/dedup.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { caseSimilarity, dedupCases } from "../../src/design/dedup.js";
+import type { TestCase } from "../../src/design/schema.js";
+
+const tc = (over: Partial<TestCase>): TestCase => ({
+  id: "x", title: "t", technique: "exploratory", type: "Positive", kind: "active",
+  execution: "auto", preconditions: [], steps: ["a"], expected: "e", priority: "medium",
+  elementRefs: [], ...over,
+});
+
+describe("caseSimilarity", () => {
+  it("merge: same technique+type, identical refs, near-identical steps", () => {
+    const a = tc({ technique: "boundary-value", type: "Positive", elementRefs: ["e1"], steps: ["enter 0"] });
+    const b = tc({ technique: "boundary-value", type: "Positive", elementRefs: ["e1"], steps: ["enter 0"] });
+    expect(caseSimilarity(a, b)).toBe("merge");
+  });
+  it("distinct: different technique on the same field (diversity protected)", () => {
+    const a = tc({ technique: "boundary-value", type: "Positive", elementRefs: ["e1"], steps: ["enter 0"] });
+    const b = tc({ technique: "equivalence-partitioning", type: "Positive", elementRefs: ["e1"], steps: ["enter 0"] });
+    expect(caseSimilarity(a, b)).toBe("distinct");
+  });
+  it("distinct: Positive vs Negative never merge", () => {
+    const a = tc({ technique: "boundary-value", type: "Positive", elementRefs: ["e1"], steps: ["enter 0"] });
+    const b = tc({ technique: "boundary-value", type: "Negative", elementRefs: ["e1"], steps: ["enter 0"] });
+    expect(caseSimilarity(a, b)).toBe("distinct");
+  });
+  it("flag: same technique+type, overlapping but not identical refs, different steps", () => {
+    const a = tc({ technique: "exploratory", type: "Positive", elementRefs: ["e1", "e2"], steps: ["click a"] });
+    const b = tc({ technique: "exploratory", type: "Positive", elementRefs: ["e2", "e3"], steps: ["click b totally different"] });
+    expect(caseSimilarity(a, b)).toBe("flag");
+  });
+});
+
+describe("dedupCases", () => {
+  it("merges high-confidence dups, keeping the higher-priority representative", () => {
+    const a = tc({ id: "tc-1", priority: "low", technique: "boundary-value", type: "Positive", elementRefs: ["e1"], steps: ["click x"] });
+    const b = tc({ id: "tc-2", priority: "critical", technique: "boundary-value", type: "Positive", elementRefs: ["e1"], steps: ["click x"] });
+    const { merged, flagged } = dedupCases([a, b]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.id).toBe("tc-2"); // critical beats low
+    expect(flagged.some((g) => g.reason === "merged")).toBe(true);
+  });
+  it("keeps borderline pairs (flagged, not dropped)", () => {
+    const a = tc({ id: "tc-1", technique: "exploratory", type: "Positive", elementRefs: ["e1", "e2"], steps: ["click a"] });
+    const b = tc({ id: "tc-2", technique: "exploratory", type: "Positive", elementRefs: ["e2", "e3"], steps: ["click b totally different"] });
+    const { merged, flagged } = dedupCases([a, b]);
+    expect(merged).toHaveLength(2);
+    expect(flagged.some((g) => g.reason === "flagged")).toBe(true);
+  });
+  it("leaves distinct cases untouched; 0/1 case is a no-op", () => {
+    expect(dedupCases([]).merged).toHaveLength(0);
+    const a = tc({ technique: "boundary-value", elementRefs: ["e1"] });
+    expect(dedupCases([a]).merged).toHaveLength(1);
+    const b = tc({ technique: "state-transition", elementRefs: ["e9"] });
+    expect(dedupCases([a, b]).merged).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/dedup.test.ts`
+Expected: FAIL — `Cannot find module '../../src/design/dedup.js'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/design/dedup.ts`:
+
+```ts
+import type { TestCase } from "./schema.js";
+
+export interface DuplicateGroup {
+  representative: TestCase;
+  duplicates: TestCase[];
+  reason: "merged" | "flagged";
+}
+
+const PRIORITY_RANK: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
+
+const norm = (s: string): string => s.toLowerCase().trim().replace(/\s+/g, " ");
+const stepSet = (steps: string[]): Set<string> => new Set(steps.map(norm));
+const refsKey = (refs: string[]): string => [...refs].sort().join("|");
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  let inter = 0;
+  for (const x of a) if (b.has(x)) inter += 1;
+  const union = a.size + b.size - inter;
+  return union === 0 ? 1 : inter / union;
+}
+
+/** Single source of truth for "near-duplicate". Shared by dedupCases and the case_redundancy scorer. */
+export function caseSimilarity(a: TestCase, b: TestCase): "merge" | "flag" | "distinct" {
+  if (a.technique !== b.technique || a.type !== b.type) return "distinct";
+  const sameRefs = refsKey(a.elementRefs) === refsKey(b.elementRefs);
+  if (sameRefs && jaccard(stepSet(a.steps), stepSet(b.steps)) >= 0.9) return "merge";
+  const aSet = new Set(a.elementRefs);
+  const overlap = b.elementRefs.some((r) => aSet.has(r));
+  if ((overlap && !sameRefs) || (norm(a.title) === norm(b.title) && !sameRefs)) return "flag";
+  return "distinct";
+}
+
+/** Better representative: higher priority, then more steps, then the earlier one (a). */
+function better(a: TestCase, b: TestCase): TestCase {
+  const pa = PRIORITY_RANK[a.priority] ?? 0;
+  const pb = PRIORITY_RANK[b.priority] ?? 0;
+  if (pa !== pb) return pa > pb ? a : b;
+  if (a.steps.length !== b.steps.length) return a.steps.length > b.steps.length ? a : b;
+  return a;
+}
+
+/** Tiered dedup: merge high-confidence dups (keep best rep), flag borderline (kept, counted). */
+export function dedupCases(cases: TestCase[]): { merged: TestCase[]; flagged: DuplicateGroup[] } {
+  const reps: TestCase[] = [];
+  const flagged: DuplicateGroup[] = [];
+  for (const c of cases) {
+    let mergedIn = false;
+    for (let k = 0; k < reps.length; k += 1) {
+      if (caseSimilarity(reps[k]!, c) === "merge") {
+        const winner = better(reps[k]!, c);
+        const loser = winner === reps[k]! ? c : reps[k]!;
+        flagged.push({ representative: winner, duplicates: [loser], reason: "merged" });
+        reps[k] = winner;
+        mergedIn = true;
+        break;
+      }
+    }
+    if (!mergedIn) {
+      for (const r of reps) {
+        if (caseSimilarity(r, c) === "flag") flagged.push({ representative: r, duplicates: [c], reason: "flagged" });
+      }
+      reps.push(c);
+    }
+  }
+  return { merged: reps, flagged };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/dedup.test.ts`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Run the gate and commit**
+
+Run: `npm run typecheck && npm run lint && npm test && npm run build`
+
+```bash
+git add src/design/dedup.ts tests/unit/dedup.test.ts
+git commit -m "feat(design): deterministic tiered case dedup + caseSimilarity (#58)"
+```
+
+---
+
+### Task 2: Apply dedup inside `designTestCases`
+
+**Files:**
+- Modify: `src/design/index.ts`
+- Test: `tests/unit/design.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `dedupCases` (Task 1).
+- Produces: `designTestCases` now returns the DEDUPED `TestCase[]` (signature unchanged).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/design.test.ts` (inside the existing `describe`):
+
+```ts
+  it("merges near-duplicate cases the LLM emits (#58)", async () => {
+    const dup = {
+      title: "Boundary 0", technique: "boundary-value", type: "Positive", kind: "active",
+      execution: "auto", preconditions: [], steps: ["Enter 0 into Email", "Submit"],
+      expected: "rejected", priority: "high", elementRefs: ["e3", "e6"],
+    };
+    const fakeInvoke: StructuredInvoke = async (schema) =>
+      schema.parse({ testCases: [dup, { ...dup, title: "Boundary 0 again" }] });
+    const cases = await designTestCases(
+      { study, pageSemantics: "x" },
+      { invoke: fakeInvoke, prompts: new PromptRegistry() },
+    );
+    expect(cases).toHaveLength(1); // two identical-modulo-title cases → merged
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/design.test.ts`
+Expected: FAIL — `expected length 2 to be 1` (no dedup yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/design/index.ts`, add the import near the others:
+
+```ts
+import { dedupCases } from "./dedup.js";
+```
+
+Then change the final `return` of `designTestCases` from:
+
+```ts
+  const known = new Set(els.map((e) => e.ref));
+  return result.testCases.map((c, i) => ({
+    ...c,
+    id: `tc-${i + 1}`,
+    elementRefs: c.elementRefs.filter((r) => known.has(r)),
+  }));
+```
+
+to:
+
+```ts
+  const known = new Set(els.map((e) => e.ref));
+  const grounded = result.testCases.map((c, i) => ({
+    ...c,
+    id: `tc-${i + 1}`,
+    elementRefs: c.elementRefs.filter((r) => known.has(r)),
+  }));
+  return dedupCases(grounded).merged; // #58: merge high-confidence near-duplicates (reduced count is the report)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/design.test.ts`
+Expected: PASS (the 2 original tests + the new one; the originals are unaffected — 1 case stays 1, [] stays []).
+
+- [ ] **Step 5: Run the gate and commit**
+
+Run: `npm run typecheck && npm run lint && npm test && npm run build`
+
+```bash
+git add src/design/index.ts tests/unit/design.test.ts
+git commit -m "feat(design): dedup near-duplicate cases in designTestCases (#58)"
+```
+
+---
+
+### Task 3: `technique_coverage` + `case_redundancy` scorers
+
+**Files:**
+- Modify: `src/eval/scorers.ts`
+- Test: `tests/unit/scorers.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `ScoreInput.testCases` (existing); `caseSimilarity` from `../design/dedup.js` (Task 1).
+- Produces: two new `Score`s — `technique_coverage` (distinct techniques / 6) and `case_redundancy`
+  (cases in ≥1 non-distinct pair / total).
+
+- [ ] **Step 1: Write the failing test**
+
+Append a new `it` to `tests/unit/scorers.test.ts` (inside the existing `describe`):
+
+```ts
+  it("technique_coverage and case_redundancy (#58)", () => {
+    const mk = (over: Partial<(typeof testCases)[number]>) => ({
+      id: "x", title: "t", technique: "boundary-value", type: "Positive",
+      preconditions: [], steps: ["enter 0"], expected: "e", priority: "high", elementRefs: ["e1"],
+      ...over,
+    });
+    const cases = [
+      mk({ id: "1" }),
+      mk({ id: "2" }), // near-dup of 1
+      mk({ id: "3", technique: "equivalence-partitioning", elementRefs: ["e9"], steps: ["other"] }),
+    ];
+    const scores = deterministicScores({ study, verified, testCases: cases as never, suite: undefined, validation: undefined });
+    expect(byName(scores, "technique_coverage")).toBeCloseTo(2 / 6, 5); // boundary-value + equivalence-partitioning
+    expect(byName(scores, "case_redundancy")).toBeCloseTo(2 / 3, 5); // cases 1 & 2 near-dup → 2 of 3
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/scorers.test.ts`
+Expected: FAIL — both scores `undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/eval/scorers.ts`, add the import near the top:
+
+```ts
+import { caseSimilarity } from "../design/dedup.js";
+```
+
+Then, inside `deterministicScores`, immediately before `return scores;`, add:
+
+```ts
+  // technique_coverage (#58): breadth across the 6 ISO/IEC/IEEE 29119-4 techniques.
+  if (input.testCases.length > 0) {
+    const techniques = new Set(input.testCases.map((c) => c.technique));
+    scores.push({ name: "technique_coverage", value: techniques.size / 6 });
+  }
+  // case_redundancy (#58): share of cases in >=1 near-duplicate pair (shared caseSimilarity — DRY).
+  if (input.testCases.length > 1) {
+    const involved = new Set<number>();
+    for (let i = 0; i < input.testCases.length; i += 1) {
+      for (let j = i + 1; j < input.testCases.length; j += 1) {
+        if (caseSimilarity(input.testCases[i]!, input.testCases[j]!) !== "distinct") {
+          involved.add(i);
+          involved.add(j);
+        }
+      }
+    }
+    scores.push({ name: "case_redundancy", value: involved.size / input.testCases.length });
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/scorers.test.ts`
+Expected: PASS (existing scorer tests + the new one).
+
+- [ ] **Step 5: Run the gate and commit**
+
+Run: `npm run typecheck && npm run lint && npm test && npm run build`
+
+```bash
+git add src/eval/scorers.ts tests/unit/scorers.test.ts
+git commit -m "feat(eval): technique_coverage + case_redundancy scores (#58)"
+```
+
+---
+
+### Task 4: Prompt nudge — technique breadth
+
+**Files:**
+- Modify: `src/prompts/local/qa-testcase-from-ui.ts`
+- Modify: `docs/prompts/qa-testcase-from-ui.md` (doc parity, if present; gitignored → local-only)
+- Test: `tests/unit/case-quality-prompt.test.ts` (new)
+
+**Interfaces:**
+- Consumes: the exported `QA_TESTCASE_FROM_UI` string.
+- Produces: the prompt now names the 29119-4 techniques and asks for breadth + non-redundancy.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/case-quality-prompt.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { QA_TESTCASE_FROM_UI } from "../../src/prompts/local/qa-testcase-from-ui.js";
+
+describe("qa-testcase-from-ui prompt (case-quality #58)", () => {
+  it("nudges technique breadth by naming specific 29119-4 techniques", () => {
+    expect(QA_TESTCASE_FROM_UI).toMatch(/boundary-value/);
+    expect(QA_TESTCASE_FROM_UI).toMatch(/equivalence-partitioning/);
+    expect(QA_TESTCASE_FROM_UI).toMatch(/variety|breadth|diversif/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/case-quality-prompt.test.ts`
+Expected: FAIL — the prompt doesn't name the techniques yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/prompts/local/qa-testcase-from-ui.ts`, change the line:
+
+```ts
+Cover happy path AND negative/edge scenarios. No duplicates or trivialities.
+```
+
+to:
+
+```ts
+Cover happy path AND negative/edge scenarios. No duplicates or trivialities (no two cases with the same technique + same elements + same steps).
+TECHNIQUE BREADTH: apply a VARIETY of 29119-4 techniques where the page allows — equivalence-partitioning, boundary-value, decision-table, state-transition, error-guessing — not just exploratory.
+```
+
+Then add the same two lines to `docs/prompts/qa-testcase-from-ui.md` if it exists (it is gitignored, so this edit is local-only — the `.ts` is the committed source of truth).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/case-quality-prompt.test.ts`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Run the gate and commit**
+
+Run: `npm run typecheck && npm run lint && npm test && npm run build`
+
+```bash
+git add src/prompts/local/qa-testcase-from-ui.ts tests/unit/case-quality-prompt.test.ts
+git commit -m "feat(prompts): nudge 29119-4 technique breadth in case design (#58)"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] Full gate: `npm run typecheck && npm run lint && npm test && npm run build`
+- [ ] Packaging smoke (if present): `npm run smoke:pack`
+- [ ] Grep guard — confirm the invariants:
+  - No `src/agent/graph.ts` change in `git diff main...feat/58-case-quality`.
+  - `designTestCases` still returns `Promise<TestCase[]>` (signature unchanged).
+  - "near-duplicate" is defined ONCE: `caseSimilarity` is the only place; `scorers.ts` imports it, does not restate it.
+
+## Self-Review (run by the author)
+
+**1. Spec coverage:**
+- Component 1 `dedupCases`/`caseSimilarity` → Task 1. Component 2 (apply in designTestCases) → Task 2.
+  Component 3 (technique_coverage + case_redundancy) → Task 3. Component 4 (prompt nudge) → Task 4. ✓
+- AC1 (technique coverage) → Task 3. AC2 (redundancy reported) → Task 3 score (see refinement: via the
+  score, not a new onProgress line). AC3 (high-conf merged) → Tasks 1+2. AC4 (borderline flagged not
+  dropped) → Task 1 (dedupCases keeps reps, records flagged). AC5 (diversity protected) → Task 1 tests
+  (different technique/type/refs → distinct). AC6 (no regression) → per-task gate + final grep guard. ✓
+
+**2. Placeholder scan:** every code/test step has complete code + an exact command + expected output. No TBD/TODO. ✓
+
+**3. Type consistency:** `caseSimilarity(a,b): "merge"|"flag"|"distinct"` and `dedupCases(): { merged, flagged }`
+(Task 1) match their use in Task 2 (`dedupCases(grounded).merged`) and Task 3 (`caseSimilarity(...) !== "distinct"`).
+`TestCase` fields used (`technique`, `type`, `elementRefs`, `steps`, `priority`, `title`, `id`) match
+`src/design/schema.ts`. ✓

--- a/docs/superpowers/specs/2026-06-19-case-quality-design.md
+++ b/docs/superpowers/specs/2026-06-19-case-quality-design.md
@@ -1,0 +1,141 @@
+---
+title: "#58 Case-quality guardrails — dedup + technique coverage"
+issue: "plune-ai/cairn#58 (L2-06, epic L2 #47)"
+date: 2026-06-19
+status: approved (design) — pending implementation plan
+branch: feat/58-case-quality (off main 0ae46a1 — independent PR, NOT stacked on #57/PR #74)
+related:
+  - "#57 (PR #74) — flaky-hardening; established the deterministic-detector + sibling-scorer pattern reused here"
+  - "Refactor (drop LangGraph) — sequenced AFTER this; #58 adds no graph.ts stage to avoid collision"
+---
+
+# #58 Case-quality guardrails — design
+
+## 1. Problem & goal
+
+Generated suites can be padded with near-duplicate cases and skew to one or two techniques — "50
+redundant clicks" instead of a meaningful suite. Add two deterministic guardrails: **dedup**
+near-identical cases (merge the obvious, flag the borderline) and **report technique coverage** across
+the ISO/IEC/IEEE 29119-4 techniques.
+
+**Behavior contract:** generated cases get better (deduped, technique-diverse); CLI surface, run
+artifacts (`runs/<id>/…`), and config are unchanged. Everything stays behind the seams
+(`StructuredInvoke`, `onProgress`). **No new stage in `agent/graph.ts`; no design-retry loop.**
+
+## 2. Current state (grounded in code, 2026-06-19)
+
+- **`src/design/index.ts`** `designTestCases` is prompt-driven (`qa-manual-test-designer` +
+  `qa-testcase-from-ui` → `DesignResultSchema` → `TestCase[]`), grounds `elementRefs` to known refs.
+  It is a **single LLM call** — there is no design-side repair loop (unlike codegen's `runRepairLoop`).
+  **No dedup, no coverage enforcement.**
+- **`src/design/schema.ts`** `TestCase` already carries `technique` (enum of 6: `equivalence-partitioning`,
+  `boundary-value`, `decision-table`, `state-transition`, `exploratory`, `error-guessing`), plus
+  `type` (Positive/Negative), `kind` (static/active), `execution` (auto/manual), `priority`, `steps`,
+  `elementRefs`.
+- **`qa-testcase-from-ui` prompt** already says "No duplicates or trivialities" — it asks, but does not
+  guarantee. (Same shape as #57, where the prompt already banned css and the real gap was waits.)
+- **`src/eval/scorers.ts`** has no technique-coverage or redundancy score (it gained `locator_robustness`
+  in #57). `checklist_coverage` is a different thing (checklist items, not 29119-4 techniques).
+
+## 3. Design decisions
+
+- **Q1 — scope:** two **deterministic** guardrails (`dedupCases` + `technique_coverage`); "meaningfulness"
+  is the emergent result (no redundant filler + technique breadth), NOT a separate subjective/LLM score.
+  An LLM-judge `case_meaningfulness` may be added later as a sibling if the deterministic proxies prove
+  insufficient.
+- **Q2 — dedup behavior:** **tiered** — deterministically MERGE only high-confidence duplicates, FLAG
+  borderline ones (kept in the output, counted in the report). Merge runs **inside** `designTestCases`
+  → zero `graph.ts` change.
+- **Q3 — technique coverage:** **measure + nudge**, not hard-enforce. A `technique_coverage` score every
+  run + a prompt nudge to diversify techniques. NO coverage-gated design-retry (that would build a second
+  repair loop in the very stage the later refactor rewrites — deferred to Stage 2+).
+
+## 4. Components
+
+| # | Change | File | Nature |
+|---|--------|------|--------|
+| 1 | `dedupCases(cases): { merged: TestCase[]; flagged: DuplicateGroup[] }` + exported `caseSimilarity(a, b): "merge" \| "flag" \| "distinct"` (the tier verdict for one pair) | `src/design/dedup.ts` *(new)* | pure, deterministic, never throws |
+| 2 | apply dedup at the end of `designTestCases` (return `merged`; emit a dedup `onProgress` line) | `src/design/index.ts` | output quality ↑, signature unchanged |
+| 3 | `technique_coverage` + `case_redundancy` scores | `src/eval/scorers.ts` | new, siblings to `locator_robustness` |
+| 4 | technique-diversity nudge (+ reinforce "no duplicates") | `qa-testcase-from-ui` prompt (`prompts/local/*.ts`) + doc | proactive |
+
+## 5. Data flow
+
+- **Proactive:** the prompt nudge → the LLM emits more diverse, less redundant cases on the first pass.
+- **Deterministic safety net:** `dedupCases` merges residual high-confidence duplicates inside
+  `designTestCases`, which returns the merged `TestCase[]` (same signature; downstream unaffected).
+- **Measurement:** `technique_coverage` + `case_redundancy` scores every run, plus an `onProgress` line
+  (`designTestCases — dedup: merged N, flagged M borderline`).
+
+## 6. Dedup rules (conservative — protect technique diversity)
+
+`DuplicateGroup = { representative: TestCase; duplicates: TestCase[]; reason: "merged" | "flagged" }`.
+
+| Tier | Condition | Action |
+|------|-----------|--------|
+| **merge** (high-confidence) | same `technique` AND same `type` AND identical `elementRefs` set AND normalized-`steps` Jaccard ≥ 0.9 | keep ONE representative (by `priority` critical>high>medium>low; tie → more steps; tie → earliest), drop the rest |
+| **flag** (borderline) | same `(technique, type)` AND `elementRefs` overlap > 0 but NOT identical, OR identical normalized `title` with differing `elementRefs` | keep in output; count in the report (NOT dropped) |
+| keep | different `technique` OR `type`, or no `elementRefs` overlap | unchanged |
+
+- The merge key includes **`type`** so a Positive and a Negative case are never merged.
+- Normalization (in `caseSimilarity`): lowercase, trim, collapse whitespace; steps compared as a set
+  (Jaccard over normalized step strings). `elementRefs` compared as sorted sets.
+- Threshold is deliberately high (whole triple + Jaccard 0.9) — a `boundary-value` case and an
+  `equivalence-partitioning` case on the same field must both survive.
+
+## 7. Scorers (DRY — one definition of "near-duplicate")
+
+- **`technique_coverage`** = distinct `technique` values present / 6. Value 0–1. (Measure; Q3.)
+- **`case_redundancy`** = (cases involved in ≥1 borderline-flag pair) / total cases, on the FINAL
+  (post-dedup) set. Value 0–1, lower is better. It reuses the SAME
+  `caseSimilarity(a, b): "merge" | "flag" | "distinct"` helper that `dedupCases` uses, exported from
+  `design/dedup.ts` (eval already imports design types → importing the helper is legal) — one source of
+  truth for "near-duplicate", avoiding the lint↔scorer asymmetry #57's final review flagged. On the
+  post-dedup set no pair is `"merge"` (those were already removed), so this effectively counts `"flag"`
+  pairs.
+
+## 8. Behavior-preserving guarantees
+
+- `dedupCases` is pure and never throws; 0 or 1 case → returned as-is.
+- Conservative merge (whole triple must match) → minimal coverage-loss risk; diversity protected by §6.
+- `designTestCases` signature is unchanged (returns `TestCase[]`); the merge changes only the case COUNT
+  (the intended improvement, analogous to #57's prompt changing generated code). Grounding/`elementRefs`
+  filtering is untouched.
+- **Unchanged:** CLI, config, `runs/<id>/` artifacts, `graph.ts`; no design-retry loop.
+
+## 9. Testing (all deterministic — no browser; the LLM is mocked)
+
+- `tests/unit/dedup.test.ts` *(new)* — high-confidence dups merged (count drops, representative kept by
+  priority); borderline flagged but NOT dropped; a `boundary-value` vs `equivalence-partitioning` case on
+  the same field is NOT merged (diversity protected); a Positive vs Negative pair is NOT merged.
+- `tests/unit/scorers.test.ts` — `technique_coverage` (distinct/6) and `case_redundancy` (near-dup pairs/total).
+- `tests/unit/design.test.ts` — with a mocked `invoke` returning duplicate cases, `designTestCases`
+  returns the deduped set.
+- A prompt test (extend/new) — `qa-testcase-from-ui` nudges technique diversity.
+
+## 10. Out of scope (non-goals)
+
+- A subjective/LLM-judge `case_meaningfulness` score (deferred; deterministic proxies first).
+- Hard coverage enforcement / a coverage-gated design-retry loop (would add a second repair loop to the
+  design stage the later refactor rewrites — deferred to Stage 2+).
+- Surfacing flagged groups as a new artifact field (kept to a score + progress line to preserve the
+  artifact format).
+- Cross-run learning of redundant patterns (MEM territory).
+
+## 11. Acceptance criteria (maps to the board DoD)
+
+- AC1 — technique coverage reported: every run emits a `technique_coverage` score = distinct techniques / 6.
+- AC2 — redundancy reported: every run emits a `case_redundancy` score + an `onProgress` dedup line.
+- AC3 — high-confidence duplicates merged: `dedupCases` drops cases matching the whole merge key, keeping
+  the highest-priority representative; `designTestCases` returns the merged set.
+- AC4 — borderline flagged, not dropped: borderline-similar cases remain in the output and are counted.
+- AC5 — diversity protected: cases differing in `technique` OR `type` OR `elementRefs` are never merged.
+- AC6 — no regression: full gate green (`typecheck + lint + test + build`); CLI/config/artifacts/`graph.ts`
+  and the `designTestCases` signature unchanged.
+
+## 12. Sequencing note
+
+Stage 1b of the workflow (`#57 → #58 → refactor`). On `feat/58-case-quality` off `main` (independent of
+PR #74) — expect a small, resolvable `scorers.ts` conflict at merge (both #57 and #58 add a score before
+`return scores`). Keeping all changes inside `design/` + `eval/` and out of `graph.ts` is the discipline
+that prevents a collision with the later LangGraph-drop refactor.

--- a/src/design/dedup.ts
+++ b/src/design/dedup.ts
@@ -1,0 +1,67 @@
+import type { TestCase } from "./schema.js";
+
+export interface DuplicateGroup {
+  representative: TestCase;
+  duplicates: TestCase[];
+  reason: "merged" | "flagged";
+}
+
+const PRIORITY_RANK: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
+
+const norm = (s: string): string => s.toLowerCase().trim().replace(/\s+/g, " ");
+const stepSet = (steps: string[]): Set<string> => new Set(steps.map(norm));
+const refsKey = (refs: string[]): string => [...refs].sort().join("|");
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  let inter = 0;
+  for (const x of a) if (b.has(x)) inter += 1;
+  const union = a.size + b.size - inter;
+  return union === 0 ? 1 : inter / union;
+}
+
+/** Single source of truth for "near-duplicate". Shared by dedupCases and the case_redundancy scorer. */
+export function caseSimilarity(a: TestCase, b: TestCase): "merge" | "flag" | "distinct" {
+  if (a.technique !== b.technique || a.type !== b.type) return "distinct";
+  const sameRefs = refsKey(a.elementRefs) === refsKey(b.elementRefs);
+  if (sameRefs && jaccard(stepSet(a.steps), stepSet(b.steps)) >= 0.9) return "merge";
+  const aSet = new Set(a.elementRefs);
+  const overlap = b.elementRefs.some((r) => aSet.has(r));
+  if ((overlap && !sameRefs) || (norm(a.title) === norm(b.title) && !sameRefs)) return "flag";
+  return "distinct";
+}
+
+/** Better representative: higher priority, then more steps, then the earlier one (a). */
+function better(a: TestCase, b: TestCase): TestCase {
+  const pa = PRIORITY_RANK[a.priority] ?? 0;
+  const pb = PRIORITY_RANK[b.priority] ?? 0;
+  if (pa !== pb) return pa > pb ? a : b;
+  if (a.steps.length !== b.steps.length) return a.steps.length > b.steps.length ? a : b;
+  return a;
+}
+
+/** Tiered dedup: merge high-confidence dups (keep best rep), flag borderline (kept, counted). */
+export function dedupCases(cases: TestCase[]): { merged: TestCase[]; flagged: DuplicateGroup[] } {
+  const reps: TestCase[] = [];
+  const flagged: DuplicateGroup[] = [];
+  for (const c of cases) {
+    let mergedIn = false;
+    for (let k = 0; k < reps.length; k += 1) {
+      if (caseSimilarity(reps[k]!, c) === "merge") {
+        const winner = better(reps[k]!, c);
+        const loser = winner === reps[k]! ? c : reps[k]!;
+        flagged.push({ representative: winner, duplicates: [loser], reason: "merged" });
+        reps[k] = winner;
+        mergedIn = true;
+        break;
+      }
+    }
+    if (!mergedIn) {
+      for (const r of reps) {
+        if (caseSimilarity(r, c) === "flag") flagged.push({ representative: r, duplicates: [c], reason: "flagged" });
+      }
+      reps.push(c);
+    }
+  }
+  return { merged: reps, flagged };
+}

--- a/src/design/index.ts
+++ b/src/design/index.ts
@@ -5,6 +5,7 @@ import type { PageStudy } from "../observe/index.js";
 import type { VerifiedElement } from "../browser/types.js";
 import { formatTransitions, type Transition } from "../probe/index.js";
 import { DesignResultSchema, type TestCase } from "./schema.js";
+import { dedupCases } from "./dedup.js";
 
 export type { TestCase, DesignedCase } from "./schema.js";
 export {
@@ -69,9 +70,10 @@ export async function designTestCases(input: DesignInput, deps: DesignDeps): Pro
   const result = await deps.invoke(DesignResultSchema, [new HumanMessage(prompt.text)]);
 
   const known = new Set(els.map((e) => e.ref));
-  return result.testCases.map((c, i) => ({
+  const grounded = result.testCases.map((c, i) => ({
     ...c,
     id: `tc-${i + 1}`,
     elementRefs: c.elementRefs.filter((r) => known.has(r)),
   }));
+  return dedupCases(grounded).merged; // #58: merge high-confidence near-duplicates (reduced count is the report)
 }

--- a/src/eval/scorers.ts
+++ b/src/eval/scorers.ts
@@ -3,6 +3,7 @@ import type { TestCase } from "../design/index.js";
 import type { GeneratedSuite } from "../codegen/index.js";
 import type { ValidationReport } from "../validate/index.js";
 import type { VerifiedElement } from "../browser/types.js";
+import { caseSimilarity } from "../design/dedup.js";
 
 export interface Score {
   name: string;
@@ -57,6 +58,25 @@ export function deterministicScores(input: ScoreInput): Score[] {
     const fragile = (code.match(/\.locator\(|getByTestId|page\.\$/g) ?? []).length;
     const total = userFacing + fragile;
     if (total > 0) scores.push({ name: "locator_quality", value: userFacing / total });
+  }
+
+  // technique_coverage (#58): breadth across the 6 ISO/IEC/IEEE 29119-4 techniques.
+  if (input.testCases.length > 0) {
+    const techniques = new Set(input.testCases.map((c) => c.technique));
+    scores.push({ name: "technique_coverage", value: techniques.size / 6 });
+  }
+  // case_redundancy (#58): share of cases in >=1 near-duplicate pair (shared caseSimilarity — DRY).
+  if (input.testCases.length > 1) {
+    const involved = new Set<number>();
+    for (let i = 0; i < input.testCases.length; i += 1) {
+      for (let j = i + 1; j < input.testCases.length; j += 1) {
+        if (caseSimilarity(input.testCases[i]!, input.testCases[j]!) !== "distinct") {
+          involved.add(i);
+          involved.add(j);
+        }
+      }
+    }
+    scores.push({ name: "case_redundancy", value: involved.size / input.testCases.length });
   }
 
   return scores;

--- a/src/prompts/local/qa-testcase-from-ui.ts
+++ b/src/prompts/local/qa-testcase-from-ui.ts
@@ -46,6 +46,7 @@ STABILITY (CRITICAL):
 - Each case is INDEPENDENT and starts from a CLEAN page. Do NOT assume state left by another case.
 - Do NOT generate contradictory cases (e.g. one expects toggle=on, another toggle=off from a fresh start). For a toggle take EXACTLY ONE transition from the "Observed state transitions" (before→after).
 
-Cover happy path AND negative/edge scenarios. No duplicates or trivialities.
+Cover happy path AND negative/edge scenarios. No duplicates or trivialities (no two cases with the same technique + same elements + same steps).
+TECHNIQUE BREADTH: apply a VARIETY of 29119-4 techniques where the page allows — equivalence-partitioning, boundary-value, decision-table, state-transition, error-guessing — not just exploratory.
 
 FULL CHECKLIST COVERAGE: do NOT skip checklist items. If an item cannot be reliably automated (full generation/submit flow, security/XSS, UI-UX/visual/responsiveness, irreversible actions) — STILL create a case, but set execution="manual" (it will not be automated, but it is documented for manual testing). Every checklist item → at least one case (auto or manual).`;

--- a/tests/unit/case-quality-prompt.test.ts
+++ b/tests/unit/case-quality-prompt.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { QA_TESTCASE_FROM_UI } from "../../src/prompts/local/qa-testcase-from-ui.js";
+
+describe("qa-testcase-from-ui prompt (case-quality #58)", () => {
+  it("nudges technique breadth by naming specific 29119-4 techniques", () => {
+    expect(QA_TESTCASE_FROM_UI).toMatch(/boundary-value/);
+    expect(QA_TESTCASE_FROM_UI).toMatch(/equivalence-partitioning/);
+    expect(QA_TESTCASE_FROM_UI).toMatch(/variety|breadth|diversif/i);
+  });
+});

--- a/tests/unit/dedup.test.ts
+++ b/tests/unit/dedup.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { caseSimilarity, dedupCases } from "../../src/design/dedup.js";
+import type { TestCase } from "../../src/design/schema.js";
+
+const tc = (over: Partial<TestCase>): TestCase => ({
+  id: "x", title: "t", technique: "exploratory", type: "Positive", kind: "active",
+  execution: "auto", preconditions: [], steps: ["a"], expected: "e", priority: "medium",
+  elementRefs: [], ...over,
+});
+
+describe("caseSimilarity", () => {
+  it("merge: same technique+type, identical refs, near-identical steps", () => {
+    const a = tc({ technique: "boundary-value", type: "Positive", elementRefs: ["e1"], steps: ["enter 0"] });
+    const b = tc({ technique: "boundary-value", type: "Positive", elementRefs: ["e1"], steps: ["enter 0"] });
+    expect(caseSimilarity(a, b)).toBe("merge");
+  });
+  it("distinct: different technique on the same field (diversity protected)", () => {
+    const a = tc({ technique: "boundary-value", type: "Positive", elementRefs: ["e1"], steps: ["enter 0"] });
+    const b = tc({ technique: "equivalence-partitioning", type: "Positive", elementRefs: ["e1"], steps: ["enter 0"] });
+    expect(caseSimilarity(a, b)).toBe("distinct");
+  });
+  it("distinct: Positive vs Negative never merge", () => {
+    const a = tc({ technique: "boundary-value", type: "Positive", elementRefs: ["e1"], steps: ["enter 0"] });
+    const b = tc({ technique: "boundary-value", type: "Negative", elementRefs: ["e1"], steps: ["enter 0"] });
+    expect(caseSimilarity(a, b)).toBe("distinct");
+  });
+  it("flag: same technique+type, overlapping but not identical refs, different steps", () => {
+    const a = tc({ technique: "exploratory", type: "Positive", elementRefs: ["e1", "e2"], steps: ["click a"] });
+    const b = tc({ technique: "exploratory", type: "Positive", elementRefs: ["e2", "e3"], steps: ["click b totally different"] });
+    expect(caseSimilarity(a, b)).toBe("flag");
+  });
+});
+
+describe("dedupCases", () => {
+  it("merges high-confidence dups, keeping the higher-priority representative", () => {
+    const a = tc({ id: "tc-1", priority: "low", technique: "boundary-value", type: "Positive", elementRefs: ["e1"], steps: ["click x"] });
+    const b = tc({ id: "tc-2", priority: "critical", technique: "boundary-value", type: "Positive", elementRefs: ["e1"], steps: ["click x"] });
+    const { merged, flagged } = dedupCases([a, b]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.id).toBe("tc-2"); // critical beats low
+    expect(flagged.some((g) => g.reason === "merged")).toBe(true);
+  });
+  it("keeps borderline pairs (flagged, not dropped)", () => {
+    const a = tc({ id: "tc-1", technique: "exploratory", type: "Positive", elementRefs: ["e1", "e2"], steps: ["click a"] });
+    const b = tc({ id: "tc-2", technique: "exploratory", type: "Positive", elementRefs: ["e2", "e3"], steps: ["click b totally different"] });
+    const { merged, flagged } = dedupCases([a, b]);
+    expect(merged).toHaveLength(2);
+    expect(flagged.some((g) => g.reason === "flagged")).toBe(true);
+  });
+  it("leaves distinct cases untouched; 0/1 case is a no-op", () => {
+    expect(dedupCases([]).merged).toHaveLength(0);
+    const a = tc({ technique: "boundary-value", elementRefs: ["e1"] });
+    expect(dedupCases([a]).merged).toHaveLength(1);
+    const b = tc({ technique: "state-transition", elementRefs: ["e9"] });
+    expect(dedupCases([a, b]).merged).toHaveLength(2);
+  });
+});

--- a/tests/unit/design.test.ts
+++ b/tests/unit/design.test.ts
@@ -58,4 +58,19 @@ describe("designTestCases", () => {
     );
     expect(cases).toEqual([]);
   });
+
+  it("merges near-duplicate cases the LLM emits (#58)", async () => {
+    const dup = {
+      title: "Boundary 0", technique: "boundary-value", type: "Positive", kind: "active",
+      execution: "auto", preconditions: [], steps: ["Enter 0 into Email", "Submit"],
+      expected: "rejected", priority: "high", elementRefs: ["e3", "e6"],
+    };
+    const fakeInvoke: StructuredInvoke = async (schema) =>
+      schema.parse({ testCases: [dup, { ...dup, title: "Boundary 0 again" }] });
+    const cases = await designTestCases(
+      { study, pageSemantics: "x" },
+      { invoke: fakeInvoke, prompts: new PromptRegistry() },
+    );
+    expect(cases).toHaveLength(1); // two identical-modulo-title cases → merged
+  });
 });

--- a/tests/unit/scorers.test.ts
+++ b/tests/unit/scorers.test.ts
@@ -55,4 +55,20 @@ describe("deterministicScores", () => {
     expect(byName(scores, "runs_green")).toBeUndefined();
     expect(byName(scores, "grounding")).toBe(0.5);
   });
+
+  it("technique_coverage and case_redundancy (#58)", () => {
+    const mk = (over: Partial<(typeof testCases)[number]>) => ({
+      id: "x", title: "t", technique: "boundary-value", type: "Positive",
+      preconditions: [], steps: ["enter 0"], expected: "e", priority: "high", elementRefs: ["e1"],
+      ...over,
+    });
+    const cases = [
+      mk({ id: "1" }),
+      mk({ id: "2" }), // near-dup of 1
+      mk({ id: "3", technique: "equivalence-partitioning", elementRefs: ["e9"], steps: ["other"] }),
+    ];
+    const scores = deterministicScores({ study, verified, testCases: cases as never, suite: undefined, validation: undefined });
+    expect(byName(scores, "technique_coverage")).toBeCloseTo(2 / 6, 5); // boundary-value + equivalence-partitioning
+    expect(byName(scores, "case_redundancy")).toBeCloseTo(2 / 3, 5); // cases 1 & 2 near-dup → 2 of 3
+  });
 });


### PR DESCRIPTION
## What & why

**#58** (L2-06, epic L2 #47). Quality over quantity: dedup near-identical test cases and report ISO 29119-4 technique coverage — a meaningful suite, not 50 redundant clicks.

Closes #58.

## Changes (all in `design/` + `eval/`; **zero `agent/graph.ts` change; no design-retry loop**)

- **`src/design/dedup.ts`** *(new)* — `caseSimilarity(a,b): "merge" | "flag" | "distinct"` (the SINGLE source of truth for "near-duplicate") + tiered `dedupCases`: MERGE high-confidence dups (keep the highest-priority representative), FLAG borderline (kept, counted).
- **`src/design/index.ts`** — `designTestCases` applies `dedupCases(grounded).merged` at the end (grounding→dedup; signature unchanged).
- **`src/eval/scorers.ts`** — new `technique_coverage` (distinct techniques / 6) + `case_redundancy` (cases in ≥1 near-dup pair / total), both **reusing the imported `caseSimilarity`** — one definition of "near-duplicate", no restatement.
- **`qa-testcase-from-ui` prompt** — names the 29119-4 techniques and asks for breadth + non-redundancy.

## Behavior-preserving

- Conservative merge key: same `technique` AND `type` AND identical `elementRefs` AND steps Jaccard ≥ 0.9 → Positive/Negative never merge; different techniques on the same field survive (diversity protected).
- `designTestCases` keeps its signature (`Promise<TestCase[]>`); only the case COUNT changes (the intended improvement).
- The two new scores flow generically through every consumer (cli / explore / scores-table / report / experiment) — no consumer hardcodes a score list, so CLI/artifacts are unchanged.
- **Unchanged:** CLI, config, `runs/<id>/` artifacts, `graph.ts`.

## Verification

- TDD per task; two-stage review (spec + quality) per task; final whole-branch review = **Ready to merge: Yes**.
- Gate green: `typecheck` · `lint` · **400 tests** · `build`.
- DRY confirmed by the final review: "near-duplicate defined once, scorers imports it — zero restated logic" — closes the lint↔scorer asymmetry #57's review flagged.

## Design docs

- Spec: `docs/superpowers/specs/2026-06-19-case-quality-design.md`
- Plan: `docs/superpowers/plans/2026-06-19-case-quality.md`

> Branched off `main`, independent of #57 (PR #74). Expect a small, resolvable `scorers.ts` conflict at merge (both PRs add a score before `return scores`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
