### PR TITLE
feat: --fresh flag — ignore prior-run experience for clean A/B runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`--fresh` flag on `cairn design` and `cairn explore`** (and a matching TUI toggle) — ignore
+  prior-run experience for a URL. By default a 2nd+ run on the same URL reuses its *previously stable*
+  cases as design-prompt context and generates only the **delta** (new cases); `--fresh` skips that
+  disk read entirely (`collectPriorRuns`) and generates a **full set** every time, for clean A/B
+  comparisons. The gate is shared by both flows via `experienceForUrl()` in `src/eval/collect.ts`.
+  Behavior is unchanged when the flag is absent — no generated artifact differs. (See ADR-0006.)
+
 ## [0.4.0] - 2026-06-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ cairn explore --url https://app.example.com/page --session myapp --checklist pla
 The `--checklist` file steers **what** the bot tests (and is scored as coverage). Copy
 [`examples/plan.md`](examples/plan.md) — a ready-to-run checklist for `https://plune.ai/cairn` — as a starting point.
 
+Add `--fresh` (on `design` and `explore`) to **ignore prior runs of the same URL**. By default a 2nd+
+run on a URL reuses its *previously stable* cases as context and generates only the **delta** (new
+cases), so re-runs get smaller. `--fresh` skips that and generates a **full set** every time — useful
+for clean A/B comparisons. In the TUI it's the "Ignore prior-run experience for this URL?" toggle (default **no**).
+
 New here? Read the **[Getting started guide](docs/getting-started.md)** — it walks the whole cycle with explanations.
 
 ## Authenticated targets
@@ -154,7 +159,7 @@ Then:
 cairn          # launches the terminal UI (requires the Ink packages above)
 ```
 
-Pick a command (explore / design / automate), fill parameters (URL, session, checklist, style) via a
+Pick a command (explore / design / automate), fill parameters (URL, session, checklist, style, fresh) via a
 guided form, watch a **live dashboard** of the pipeline stages as the run progresses, read the result summary
 (scores, green %, Pilot verdict, test cases), and **browse past runs** in `./runs` — opening any run to
 read its test cases, report and logs.
@@ -169,10 +174,10 @@ no arguments also falls back to printing help.
 |---|---|
 | `cairn session capture --url <loginUrl> --name <s>` | Capture a login session once → `.auth/` (`cairn login` is a shorthand; `session ls` / `session rm`) |
 | `cairn observe --url <u> [--session <s>]` | ARIA snapshot + interactive elements + screenshot |
-| `cairn design --url <u> --session <s> [--checklist <f>] [--style <s>]` | Test cases only (ATC/MTC `.md` + selectors), no code |
+| `cairn design --url <u> --session <s> [--checklist <f>] [--style <s>] [--fresh]` | Test cases only (ATC/MTC `.md` + selectors), no code |
 | `cairn automate --run <dir> [--validate --session <s>]` | `@playwright/test` from `ATC-*` cases |
 | `cairn promote --run <dir> --cases <ids> [--session <s>]` | Promote manual MTC case(s) to ATC (.md only; then `automate`) |
-| `cairn explore --url <u> --session <s> [--checklist <f>]` | Full pipeline (cases → code → validate → repair → Pilot) |
+| `cairn explore --url <u> --session <s> [--checklist <f>] [--fresh]` | Full pipeline (cases → code → validate → repair → Pilot) |
 | `cairn experiment --dataset <d> --candidate name=file` | Compare prompt versions on a dataset |
 
 > `lex-bot <command>` still runs every command above (deprecated alias — prints a notice, then runs `cairn`).

--- a/docs/adr/0006-observability-langfuse-v5-otel.md
+++ b/docs/adr/0006-observability-langfuse-v5-otel.md
@@ -24,6 +24,7 @@ with integration into the LangChain-core LLM layer. **The user already has their
 
 ## Consequences
 
+- (+) The experience few-shot (prior STABLE cases of a URL → design prompt, the RESULTS-level self-improvement) is **skippable per run** via `--fresh` on `design`/`explore` — generate a full set for clean A/B comparisons instead of only the delta. Gate: `experienceForUrl()` in `src/eval/collect.ts`.
 - (+) The whole improvement loop (trace→score→dataset→experiment→promote) runs on your server; data doesn't go to the cloud.
 - (+) SDK-side judges → provider-agnostic (Anthropic or OpenRouter, ADR-0002) and independent of Langfuse EE features.
 - (−) **v5 is OTel-first, a new API** → confirmed by **Spike S5** (Sprint 0), including against the self-hosted instance.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -15,7 +15,7 @@ import { lintSuite, lintHint } from "../codegen/lint.js";
 import { deterministicScores, type Score } from "../eval/scorers.js";
 import { judgeTestCases, judgeChecklistCoverage } from "../eval/judge.js";
 import { pilotReview, type PilotVerdict } from "../eval/pilot.js";
-import { collectPriorRuns, unionPassedTitles, formatExperience } from "../eval/collect.js";
+import { collectPriorRuns, unionPassedTitles, experienceForUrl } from "../eval/collect.js";
 import { ingestChecklist, formatChecklist, coverageScore, styleDirective } from "../checklist/index.js";
 import { loadKnowledge } from "../knowledge/index.js";
 import { validateSuite, type ValidationReport } from "../validate/index.js";
@@ -57,6 +57,8 @@ export interface ExploreInput {
   headed?: boolean;
   /** Live per-node progress (CLI prints to stderr). */
   onProgress?: (event: string) => void;
+  /** Ignore prior-run experience for this URL (collectPriorRuns is skipped). */
+  fresh?: boolean;
 }
 
 export interface ExploreResult {
@@ -152,13 +154,14 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
   const checklistItems = input.checklistText ? ingestChecklist(input.checklistText) : [];
   const checklistFormatted = formatChecklist(checklistItems);
   const knowledgeText = await loadKnowledge(resolve(input.knowledgeDir ?? "knowledge"), input.url);
-  const experienceText = formatExperience(
-    unionPassedTitles(
-      (
-        await collectPriorRuns(resolve(input.runsBaseDir ?? resolve(process.cwd(), "runs")), input.url)
-      ).filter((r) => r.runId !== runId),
-    ),
-  );
+  // `--fresh` skips this disk read entirely → no "previously STABLE cases" dedup block, so the run
+  // generates a full set (clean A/B comparison) instead of only the delta vs. past runs of this URL.
+  const experienceText = await experienceForUrl({
+    runsBaseDir: resolve(input.runsBaseDir ?? resolve(process.cwd(), "runs")),
+    url: input.url,
+    currentRunId: runId,
+    fresh: input.fresh,
+  });
   const styleText = styleDirective(input.style ?? "all");
   const languageText = input.language ?? cfg.testCaseLanguage;
 
@@ -484,13 +487,14 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
 
   const checklistItems = input.checklistText ? ingestChecklist(input.checklistText) : [];
   const knowledgeText = await loadKnowledge(resolve(input.knowledgeDir ?? "knowledge"), input.url);
-  const experienceText = formatExperience(
-    unionPassedTitles(
-      (
-        await collectPriorRuns(resolve(input.runsBaseDir ?? resolve(process.cwd(), "runs")), input.url)
-      ).filter((r) => r.runId !== runId),
-    ),
-  );
+  // `--fresh` skips this disk read entirely → no "previously STABLE cases" dedup block, so the run
+  // generates a full set (clean A/B comparison) instead of only the delta vs. past runs of this URL.
+  const experienceText = await experienceForUrl({
+    runsBaseDir: resolve(input.runsBaseDir ?? resolve(process.cwd(), "runs")),
+    url: input.url,
+    currentRunId: runId,
+    fresh: input.fresh,
+  });
   const styleText = styleDirective(input.style ?? "all");
   const languageText = input.language ?? cfg.testCaseLanguage;
   // L1-01: resolve per-role tiers (override ?? profile tier), then build metered invokers.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -108,6 +108,7 @@ export function buildProgram(): Command {
     .option("--headed", "visible browser (debug)")
     .option("--checklist <file>", "checklist file (md/text) — guides what to test")
     .option("--style <s>", "planning style: happy | negative | coverage | all")
+    .option("--fresh", "ignore prior runs for this URL — generate a full set, don't dedupe against past cases")
     .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
     .action(async (opts: Record<string, unknown>) => {
       await runModality("explore", opts);
@@ -215,6 +216,7 @@ export function buildProgram(): Command {
     .option("--channel <channel>", "system browser channel, e.g. chrome — drives your installed Chrome (no bundled-Chromium download; helps OAuth)")
     .option("--checklist <file>", "checklist file — guides what to test")
     .option("--style <s>", "planning style: happy | negative | coverage | all")
+    .option("--fresh", "ignore prior runs for this URL — generate a full set, don't dedupe against past cases")
     .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
     .option("--headed", "visible browser (debug)")
     .action(
@@ -227,6 +229,7 @@ export function buildProgram(): Command {
         style?: string;
         headed?: boolean;
         routing?: string;
+        fresh?: boolean;
       }) => {
         const config = resolveConfig({ routing: opts.routing, channel: opts.channel });
         const checklistText = opts.checklist ? await readFile(opts.checklist, "utf8") : undefined;
@@ -244,6 +247,7 @@ export function buildProgram(): Command {
           checklistText,
           style: opts.style,
           headed: opts.headed,
+          fresh: opts.fresh,
           onProgress: progress.event,
         }).finally(() => progress.stop());
 

--- a/src/core/modalities/explore.ts
+++ b/src/core/modalities/explore.ts
@@ -24,6 +24,7 @@ interface ExploreFlags {
   checklist?: string;
   style?: string;
   routing?: string;
+  fresh?: boolean;
 }
 
 export const exploreModality: Modality = {
@@ -49,6 +50,7 @@ export const exploreModality: Modality = {
       headed: opts.headed,
       checklistText,
       style: opts.style,
+      fresh: opts.fresh,
       onProgress: progress.event,
     }).finally(() => progress.stop());
 

--- a/src/eval/collect.ts
+++ b/src/eval/collect.ts
@@ -63,3 +63,25 @@ export function formatExperience(titles: string[]): string {
     titles.map((t) => `- ${t}`).join("\n")
   );
 }
+
+/**
+ * The gated experience block injected into the design prompt: STABLE cases from prior runs of this
+ * URL so a 2nd+ run generates only the delta (collectPriorRuns → unionPassedTitles → formatExperience).
+ * The current run is excluded so a run never dedupes against itself.
+ *
+ * `fresh` skips the disk read entirely and returns "" → a clean, full-set run for A/B comparisons
+ * (no dedup against the past). Shared by runExploration and runDesign so the gate is defined once.
+ */
+export async function experienceForUrl(opts: {
+  runsBaseDir: string;
+  url: string;
+  currentRunId: string;
+  /** Ignore prior-run experience for this URL — collectPriorRuns is skipped. */
+  fresh?: boolean;
+}): Promise<string> {
+  if (opts.fresh) return "";
+  const priors = (await collectPriorRuns(opts.runsBaseDir, opts.url)).filter(
+    (r) => r.runId !== opts.currentRunId,
+  );
+  return formatExperience(unionPassedTitles(priors));
+}

--- a/src/tui/hooks/use-runner.ts
+++ b/src/tui/hooks/use-runner.ts
@@ -108,6 +108,7 @@ export function useRunner() {
             checklistText,
             style: values.style,
             headed: values.headed,
+            fresh: values.fresh,
             onProgress,
           });
         } else {
@@ -119,6 +120,7 @@ export function useRunner() {
             checklistText,
             style: values.style,
             headed: values.headed,
+            fresh: values.fresh,
             onProgress,
           });
         }

--- a/src/tui/screens/form-screen.tsx
+++ b/src/tui/screens/form-screen.tsx
@@ -13,6 +13,7 @@ type StepKey =
   | "session"
   | "checklist"
   | "style"
+  | "fresh"
   | "headed"
   | "validate"
   | "backend"
@@ -25,7 +26,8 @@ function stepsFor(command: Command): StepKey[] {
   // observe runs no LLM, so it omits routing. "(default)" on any of them leaves the env untouched.
   if (command === "automate") return ["runDir", "session", "validate", "backend", "channel", "routing", "submit"];
   if (command === "observe") return ["url", "session", "headed", "backend", "channel", "submit"];
-  return ["url", "session", "checklist", "style", "headed", "backend", "channel", "routing", "submit"]; // explore / design
+  // explore / design — `fresh` mirrors the CLI --fresh flag (skip dedup against prior runs of this URL).
+  return ["url", "session", "checklist", "style", "fresh", "headed", "backend", "channel", "routing", "submit"];
 }
 
 const STYLE_ITEMS = [
@@ -58,7 +60,7 @@ const ROUTING_ITEMS = [
 /** Sequential wizard: one field per step, ⏎ advances, last step runs the command. */
 export function FormScreen({ command, initial }: { command: Command; initial?: Partial<FormValues> }) {
   const { navigate, setInTextField, setBackHandler } = useRouter();
-  const [values, setValues] = useState<FormValues>({ url: "", style: "all", headed: false, ...initial });
+  const [values, setValues] = useState<FormValues>({ url: "", style: "all", headed: false, fresh: false, ...initial });
   const [stepIndex, setStepIndex] = useState(0);
 
   const steps = stepsFor(command);
@@ -144,6 +146,19 @@ export function FormScreen({ command, initial }: { command: Command; initial?: P
               items={STYLE_ITEMS}
               onSelect={(it) => {
                 set("style", it.value as PlanningStyle);
+                advance();
+              }}
+            />
+          </Box>
+        );
+      case "fresh":
+        return (
+          <Box flexDirection="column">
+            <Text>Ignore prior-run experience for this URL?</Text>
+            <SelectInput
+              items={YESNO}
+              onSelect={(it) => {
+                set("fresh", it.value === "yes");
                 advance();
               }}
             />
@@ -247,6 +262,7 @@ function FormSummary({ values, command }: { values: FormValues; command: Command
     if (command !== "observe") {
       if (values.checklist) rows.push(`checklist: ${values.checklist}`);
       rows.push(`style: ${values.style}`);
+      if (values.fresh) rows.push("fresh: yes (ignore prior runs)");
     }
   }
   if (values.session) rows.push(`session: ${values.session}`);

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -20,6 +20,8 @@ export interface FormValues {
   checklist?: string;
   style: PlanningStyle;
   headed: boolean;
+  /** Ignore prior-run experience for this URL (skip the dedup-against-past block). */
+  fresh?: boolean;
   // Browser/LLM config — parity with the CLI flags --backend/--channel/--routing.
   // undefined = leave the env/default untouched (resolveConfig only overrides a SET flag).
   backend?: "lib" | "cli";

--- a/tests/unit/__snapshots__/cli-modalities.test.ts.snap
+++ b/tests/unit/__snapshots__/cli-modalities.test.ts.snap
@@ -58,6 +58,8 @@ Options:
   --headed               visible browser (debug)
   --checklist <file>     checklist file (md/text) — guides what to test
   --style <s>            planning style: happy | negative | coverage | all
+  --fresh                ignore prior runs for this URL — generate a full set,
+                         don't dedupe against past cases
   --routing <preset>     role-routing preset: fast (Groq worker) | volume
                          (OpenRouter worker) (sets LLM_ROUTING)
   -h, --help             display help for command

--- a/tests/unit/cli-modalities.test.ts
+++ b/tests/unit/cli-modalities.test.ts
@@ -110,11 +110,12 @@ describe("explore parity (C1-02)", () => {
       "--headed",
       "--checklist",
       "--style",
+      "--fresh",
       "--routing",
     ]) {
       expect(longs, `explore should accept ${f}`).toContain(f);
     }
-    expect(longs).toHaveLength(9); // 0.3.3: + --channel (drive system Chrome / coexist with host Playwright)
+    expect(longs).toHaveLength(10); // + --fresh (ignore prior-run experience for a clean A/B run)
   });
 
   it("maps flags to runExploration the same way as before the refactor", async () => {
@@ -146,6 +147,15 @@ describe("explore parity (C1-02)", () => {
     // --backend / --routing flow through resolveConfig into the AppConfig
     expect(arg.config.browser.backend).toBe("cli");
     expect(arg.config.roles?.worker?.provider).toBe("openrouter");
+  });
+
+  it("--fresh flows through to runExploration as fresh:true (and is falsy when absent)", async () => {
+    await buildProgram().parseAsync(["node", "cairn", "explore", "--url", "https://app.test", "--fresh"]);
+    expect(runExploration.mock.calls[0][0].fresh).toBe(true);
+
+    runExploration.mockClear();
+    await buildProgram().parseAsync(["node", "cairn", "explore", "--url", "https://app.test"]);
+    expect(runExploration.mock.calls[0][0].fresh).toBeFalsy(); // default: dedupe against prior runs (unchanged)
   });
 
   it("prints the same exploration / metrics / cost / summary structure", async () => {

--- a/tests/unit/collect.test.ts
+++ b/tests/unit/collect.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { collectPriorRuns, unionPassedTitles, formatExperience } from "../../src/eval/collect.js";
+import { collectPriorRuns, unionPassedTitles, formatExperience, experienceForUrl } from "../../src/eval/collect.js";
 
 async function writeRun(
   base: string,
@@ -48,5 +48,44 @@ describe("collectPriorRuns / unionPassedTitles", () => {
     const txt = formatExperience(["Кейс A", "Кейс B"]);
     expect(txt).toContain("Кейс A");
     expect(txt).toContain("STABLE");
+  });
+});
+
+describe("experienceForUrl (the --fresh gate)", () => {
+  it("default (no fresh): injects the STABLE-cases dedup block from prior runs of the URL", async () => {
+    const base = await mkdtemp(join(tmpdir(), "qa-exp-"));
+    try {
+      await writeRun(base, "r1", "http://x", 0.8, [{ test: "Login works", status: "passed" }]);
+
+      const txt = await experienceForUrl({ runsBaseDir: base, url: "http://x", currentRunId: "current" });
+      expect(txt).toContain("Login works");
+      expect(txt).toContain("STABLE");
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("fresh: true → '' even when prior runs exist on disk (clean A/B run, no dedup)", async () => {
+    const base = await mkdtemp(join(tmpdir(), "qa-exp-"));
+    try {
+      await writeRun(base, "r1", "http://x", 0.8, [{ test: "Login works", status: "passed" }]);
+
+      const txt = await experienceForUrl({ runsBaseDir: base, url: "http://x", currentRunId: "current", fresh: true });
+      expect(txt).toBe("");
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("excludes the current run id (a run never dedupes against itself)", async () => {
+    const base = await mkdtemp(join(tmpdir(), "qa-exp-"));
+    try {
+      await writeRun(base, "self", "http://x", 1.0, [{ test: "Only my own case", status: "passed" }]);
+
+      const txt = await experienceForUrl({ runsBaseDir: base, url: "http://x", currentRunId: "self" });
+      expect(txt).toBe("");
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/tui/form-screen.test.tsx
+++ b/tests/unit/tui/form-screen.test.tsx
@@ -44,7 +44,7 @@ describe("FormScreen", () => {
       </RouterProvider>,
     );
     await delay(40);
-    // design steps: url → session → checklist → style → headed → backend → channel → routing → submit
+    // design steps: url → session → checklist → style → fresh → headed → backend → channel → routing → submit
     stdin.write("https://app.test");
     await delay(20);
     stdin.write("\r"); // url → session
@@ -53,7 +53,9 @@ describe("FormScreen", () => {
     await delay(50);
     stdin.write("\r"); // checklist: empty → style
     await delay(50);
-    stdin.write("\r"); // style: highlighted "all" → headed
+    stdin.write("\r"); // style: highlighted "all" → fresh
+    await delay(50);
+    stdin.write("\r"); // fresh: highlighted "no" → headed
     await delay(50);
     stdin.write("\r"); // headed: highlighted "no" → backend
     await delay(50);


### PR DESCRIPTION
## Why

`runExploration`/`runDesign` compute an `experienceText` from `collectPriorRuns(runs/, url)` → `unionPassedTitles` → `formatExperience`, which injects a *"Previously STABLE cases … do NOT duplicate"* block into the design prompt. So 2nd+ runs on the **same URL** intentionally generate only the **delta** (fewer new cases). This adds an opt-in `--fresh` flag to skip that, for clean comparisons.

## What

- **`--fresh` on `cairn design` and `cairn explore`** (+ a matching TUI yes/no toggle, default **no**): ignore prior-run experience for the URL and generate a **full set** every time.
- The gate is shared by both flows via a new **`experienceForUrl()`** helper in `src/eval/collect.ts`, which also removes the verbatim-duplicated experience block that used to live in both `runExploration` and `runDesign`. When `fresh` is set it skips the `collectPriorRuns` disk read entirely and returns `""`.
- **Behavior-preserving when the flag is absent** — the gate is `if (opts.fresh)`, so an unset flag yields the exact same experience text as before. No generated artifact changes.
- The Phase-4 prior-runs **reporting** block in `runExploration` (read-only `history` in `report.json`) is left untouched.

## Surface

| Layer | Change |
|---|---|
| `src/agent/index.ts` | `ExploreInput.fresh?`; both flows call `experienceForUrl({…, fresh})` |
| `src/eval/collect.ts` | new `experienceForUrl()` (shared gate) |
| `src/cli/index.ts` | `--fresh` option on `explore` + `design`; `design` threads `fresh` to `runDesign` |
| `src/core/modalities/explore.ts` | `ExploreFlags.fresh?`; passes `fresh` to `runExploration` |
| `src/tui/*` | `FormValues.fresh?`, a "fresh" wizard step, summary row, wired into both runners |

## Tests

- `tests/unit/collect.test.ts` — unit-level (temp `runs/` dir, no browser/LLM): `fresh:false` injects the STABLE block, `fresh:true` → `""`, current run excluded.
- `tests/unit/cli-modalities.test.ts` — `--fresh` flows to `runExploration` as `fresh:true` (falsy when absent); flag-surface lock 9 → 10; refreshed `explore --help` snapshot.
- `tests/unit/tui/form-screen.test.tsx` — walkthrough updated for the new step.

## Gates

`npm run typecheck && npm run lint && npm test && npm run build` — all green (**420 passed** | 2 skipped). Verified `--fresh` shows in the built `explore --help` and `design --help`.

## Docs

README (flag note + command table + TUI mention), CHANGELOG (`Unreleased`), ADR-0006 (experience few-shot now skippable per run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)