### PR TITLE
fix: robust --run/--from-run path resolution on Windows/Git-Bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ cairn explore --url https://app.example.com/page --session myapp --checklist pla
 The `--checklist` file steers **what** the bot tests (and is scored as coverage). Copy
 [`examples/plan.md`](examples/plan.md) — a ready-to-run checklist for `https://plune.ai/cairn` — as a starting point.
 
+> **Run id / Windows tip:** `--run` (and `--from-run`) accept just the run id — `--run <id>` — in addition to
+> `runs/<id>` or an absolute path. In **Git Bash (MINGW64)** quote the path or use forward slashes
+> (`--run 'runs/<id>'`), because an unquoted `\` is eaten by the shell *before* Cairn sees it (so `runs\<id>`
+> would otherwise arrive as `runs<id>`). The bare-id form sidesteps the issue entirely.
+
 Add `--fresh` (on `design` and `explore`) to **ignore prior runs of the same URL**. By default a 2nd+
 run on a URL reuses its *previously stable* cases as context and generates only the **delta** (new
 cases), so re-runs get smaller. `--fresh` skips that and generates a **full set** every time — useful

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,6 +97,10 @@ Promote renames the file to the next free `ATC-*` number, flips it to automatabl
 from the run's data. It does **not** generate code — that's the next step. (If a case has no usable selectors,
 add `--session <name>` so it can verify locators live in a browser.)
 
+> **Tip — run id & Git Bash:** `--run` (and `dataset-add --from-run`) accept the bare run id (`--run <id>`)
+> as well as `runs/<id>` or an absolute path. In **Git Bash (MINGW64)** quote the path or use forward slashes —
+> an unquoted `\` is eaten by the shell, so `runs\<id>` would arrive as `runs<id>`. The bare-id form avoids the trap.
+
 ## Step 6 — Automate and validate
 
 Generate `@playwright/test` code from the approved `ATC` cases, and run them:

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -20,11 +20,12 @@ import { ingestChecklist, formatChecklist, coverageScore, styleDirective } from 
 import { loadKnowledge } from "../knowledge/index.js";
 import { validateSuite, type ValidationReport } from "../validate/index.js";
 import { SessionStore } from "../session/index.js";
+import { resolveRunDir, defaultRunsBaseDir } from "../fs/run-dir.js";
 import { runExploreGraph } from "./graph.js";
 import { finalizeFailure } from "./finalize.js";
 import { runRepairLoop } from "./repair-loop.js";
 import { buildTestCaseDocs } from "./testcase-docs.js";
-import type { BudgetReport } from "./summary.js";
+import { displayPath, type BudgetReport } from "./summary.js";
 import type { AppConfig } from "../config/index.js";
 import type { StorageState } from "../browser/index.js";
 import type { PageStudy } from "../observe/index.js";
@@ -144,7 +145,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
     headless: !input.headed,
   });
   const prompts = new PromptRegistry();
-  const artifacts = new ArtifactStore(resolve(input.runsBaseDir ?? resolve(process.cwd(), "runs")));
+  const artifacts = new ArtifactStore(resolve(input.runsBaseDir ?? defaultRunsBaseDir()));
   const runId = randomUUID();
   const runWriter = await artifacts.openRun(runId);
   // #38: now that the run dir exists, flush run.log on every progress event (best-effort).
@@ -157,7 +158,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
   // `--fresh` skips this disk read entirely → no "previously STABLE cases" dedup block, so the run
   // generates a full set (clean A/B comparison) instead of only the delta vs. past runs of this URL.
   const experienceText = await experienceForUrl({
-    runsBaseDir: resolve(input.runsBaseDir ?? resolve(process.cwd(), "runs")),
+    runsBaseDir: resolve(input.runsBaseDir ?? defaultRunsBaseDir()),
     url: input.url,
     currentRunId: runId,
     fresh: input.fresh,
@@ -231,7 +232,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
         if (out.bestSuite) await runWriter.writeSuite(out.bestSuite); // restore the best code on disk
 
         // Phase 4: study prior runs of this URL + collect the best (collect-best).
-        const runsBase = resolve(input.runsBaseDir ?? resolve(process.cwd(), "runs"));
+        const runsBase = resolve(input.runsBaseDir ?? defaultRunsBaseDir());
         const priorRuns = (await collectPriorRuns(runsBase, out.study.url)).filter((r) => r.runId !== runId);
         const currentPassed = (validation?.results ?? [])
           .filter((r) => r.status === "passed")
@@ -479,7 +480,7 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
     headless: !input.headed,
   });
   const prompts = new PromptRegistry();
-  const artifacts = new ArtifactStore(resolve(input.runsBaseDir ?? resolve(process.cwd(), "runs")));
+  const artifacts = new ArtifactStore(resolve(input.runsBaseDir ?? defaultRunsBaseDir()));
   const runId = randomUUID();
   const runWriter = await artifacts.openRun(runId);
   // #38: now that the run dir exists, flush run.log on every progress event (best-effort).
@@ -490,7 +491,7 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
   // `--fresh` skips this disk read entirely → no "previously STABLE cases" dedup block, so the run
   // generates a full set (clean A/B comparison) instead of only the delta vs. past runs of this URL.
   const experienceText = await experienceForUrl({
-    runsBaseDir: resolve(input.runsBaseDir ?? resolve(process.cwd(), "runs")),
+    runsBaseDir: resolve(input.runsBaseDir ?? defaultRunsBaseDir()),
     url: input.url,
     currentRunId: runId,
     fresh: input.fresh,
@@ -672,6 +673,8 @@ export interface AutomateResult {
 export async function runAutomate(input: {
   runDir: string;
   config: AppConfig;
+  /** Base directory for runs/ (default ./runs) — used to resolve a bare run id passed as runDir. */
+  runsBaseDir?: string;
   sessionName?: string;
   sessionFile?: string;
   sessionsDir?: string;
@@ -691,7 +694,7 @@ export async function runAutomate(input: {
     }
   };
   const router = new RoleRouter(cfg, keys, budget, undefined, undefined, onCharge); // L1-01 routing + ledger
-  const runDir = resolve(input.runDir);
+  const runDir = await resolveRunDir(input.runDir, { runsBaseDir: resolve(input.runsBaseDir ?? defaultRunsBaseDir()) });
 
   const rep = JSON.parse(await readFile(join(runDir, "report.json"), "utf8")) as {
     url?: string;
@@ -707,7 +710,7 @@ export async function runAutomate(input: {
   // Only auto/ATC — manual/MTC cases are NOT automated (they are manual).
   const cases = allCases.filter((c) => c.execution !== "manual" && !c.id.startsWith("MTC"));
   const skipped = allCases.length - cases.length;
-  onProgress(`automate — ${cases.length} auto cases (skipped manual/MTC: ${skipped}) from ${tcDir}`);
+  onProgress(`automate — ${cases.length} auto cases (skipped manual/MTC: ${skipped}) from ${displayPath(tcDir)}`);
 
   const invoke = router.invoke("worker", router.tierFor("worker", cfg.models.bulk));
   const prompts = new PromptRegistry();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,6 +20,7 @@ import { SessionStore, captureSession } from "../session/index.js";
 import { loadConfig } from "../config/index.js";
 import { runDesign, runAutomate } from "../agent/index.js";
 import { renderRunSummary, displayPath } from "../agent/summary.js";
+import { resolveRunDir, defaultRunsBaseDir, readInputFile } from "../fs/run-dir.js";
 import { promoteCase, locatorFor } from "../promote/index.js";
 import type { PromoteDeps } from "../promote/index.js";
 import { makeModel, structuredMethodFor } from "../llm/index.js";
@@ -118,13 +119,14 @@ export function buildProgram(): Command {
   program
     .command("dataset-add")
     .description("Add a run (study.json) to an experiment dataset")
-    .requiredOption("--from-run <dir>", "runs/<id> folder")
+    .requiredOption("--from-run <dir>", "run folder: runs/<id> or a bare <id>")
     .requiredOption("--to <file>", "dataset file (JSON)")
     .action(async (opts: { fromRun: string; to: string }) => {
-      const study = JSON.parse(await readFile(join(opts.fromRun, "study.json"), "utf8")) as PageStudy;
+      const fromRun = await resolveRunDir(opts.fromRun, { runsBaseDir: defaultRunsBaseDir() });
+      const study = JSON.parse(await readFile(join(fromRun, "study.json"), "utf8")) as PageStudy;
       let pageSemantics = "";
       try {
-        const rep = JSON.parse(await readFile(join(opts.fromRun, "report.json"), "utf8")) as {
+        const rep = JSON.parse(await readFile(join(fromRun, "report.json"), "utf8")) as {
           pageSemantics?: string;
         };
         pageSemantics = rep.pageSemantics ?? "";
@@ -157,13 +159,13 @@ export function buildProgram(): Command {
         openrouterApiKey: config.openrouterApiKey,
         groqApiKey: config.groqApiKey,
       };
-      const ds = JSON.parse(await readFile(opts.dataset, "utf8")) as { items: DatasetItem[] };
+      const ds = JSON.parse(await readInputFile(opts.dataset, "Dataset")) as { items: DatasetItem[] };
 
       const variants: Variant[] = [{ label: "production", prompts: new PromptRegistry() }];
       if (opts.candidate) {
         const eq = opts.candidate.indexOf("=");
         const name = opts.candidate.slice(0, eq);
-        const text = await readFile(opts.candidate.slice(eq + 1), "utf8");
+        const text = await readInputFile(opts.candidate.slice(eq + 1), "Candidate prompt");
         variants.push({
           label: "candidate",
           prompts: new PromptRegistry({ local: { ...LOCAL_PROMPTS, [name]: text } }),
@@ -233,7 +235,7 @@ export function buildProgram(): Command {
         fresh?: boolean;
       }) => {
         const config = resolveConfig({ routing: opts.routing, channel: opts.channel });
-        const checklistText = opts.checklist ? await readFile(opts.checklist, "utf8") : undefined;
+        const checklistText = opts.checklist ? await readInputFile(opts.checklist, "Checklist") : undefined;
         process.stderr.write(`▸ Designing test cases for ${opts.url}${opts.session ? ` (session: ${opts.session})` : ""}…\n`);
         const progress = makeCliProgress({
           write: (s) => void process.stderr.write(s),
@@ -274,7 +276,7 @@ export function buildProgram(): Command {
   program
     .command("automate")
     .description("Generate @playwright/test from ready cases (runs/<id>/testcases/*.md)")
-    .requiredOption("--run <dir>", "design run folder (runs/<id>)")
+    .requiredOption("--run <dir>", "run folder: runs/<id>, a bare <id>, or an absolute path (Git Bash: quote or use /)")
     .option("--validate", "run the generated tests (a session is required)")
     .option("--session <name>", "session name for validation")
     .option("--session-file <path>", "path to storageState for validation")
@@ -283,7 +285,7 @@ export function buildProgram(): Command {
     .action(
       async (opts: { run: string; validate?: boolean; session?: string; sessionFile?: string; channel?: string; routing?: string }) => {
         const config = resolveConfig({ routing: opts.routing, channel: opts.channel });
-        process.stderr.write(`▸ Automating cases from ${opts.run}…\n`);
+        process.stderr.write(`▸ Automating cases from ${displayPath(opts.run)}…\n`);
         const progress = makeCliProgress({
           write: (s) => void process.stderr.write(s),
           isTTY: Boolean(process.stderr.isTTY),
@@ -348,14 +350,14 @@ export function buildProgram(): Command {
   program
     .command("promote")
     .description("Promote manual MTC case(s) to automatable ATC (.md only; run `automate` to generate code)")
-    .requiredOption("--run <dir>", "run folder (runs/<id>)")
+    .requiredOption("--run <dir>", "run folder: runs/<id>, a bare <id>, or an absolute path (Git Bash: quote or use /)")
     .requiredOption("--cases <ids>", "comma-separated MTC ids, e.g. MTC-DEMO-001,MTC-DEMO-003")
     .option("--session <name>", "session for the live selector fallback")
     .option("--session-file <path>", "storageState path for the live selector fallback")
     .action(
       async (opts: { run: string; cases: string; session?: string; sessionFile?: string }) => {
         const config = loadConfig(process.env);
-        const runDir = resolve(opts.run);
+        const runDir = await resolveRunDir(opts.run, { runsBaseDir: defaultRunsBaseDir() });
         const ids = opts.cases.split(",").map((s) => s.trim()).filter(Boolean);
 
         // Live fallback only when a session is provided (best-effort — see note).
@@ -378,12 +380,12 @@ export function buildProgram(): Command {
           };
         }
 
-        process.stderr.write(`▸ Promoting ${String(ids.length)} case(s) from ${opts.run}…\n`);
+        process.stderr.write(`▸ Promoting ${String(ids.length)} case(s) from ${displayPath(opts.run)}…\n`);
         for (const id of ids) {
           const res = await promoteCase(runDir, id, { collectLive });
           process.stdout.write(`${res.oldId} → ${res.newId}${res.warning ? ` (⚠ ${res.warning})` : ""}\n`);
         }
-        process.stdout.write(`\nDone. Run \`cairn automate --run ${opts.run}\` to generate code for the new ATC case(s).\n`);
+        process.stdout.write(`\nDone. Run \`cairn automate --run ${displayPath(runDir)}\` to generate code for the new ATC case(s).\n`);
       },
     );
 

--- a/src/core/modalities/explore.ts
+++ b/src/core/modalities/explore.ts
@@ -5,7 +5,7 @@
  * printCost + renderRunSummary). The CLI `explore` command is now a thin delegate to this `run`,
  * so its output is identical to the pre-extraction inline action (locked by the C1-02 parity test).
  */
-import { readFile } from "node:fs/promises";
+import { readInputFile } from "../../fs/run-dir.js";
 import { runExploration } from "../../agent/index.js";
 import { renderRunSummary, displayPath } from "../../agent/summary.js";
 import { resolveConfig } from "../config.js";
@@ -36,7 +36,7 @@ export const exploreModality: Modality = {
     // commander hands the action untyped options; the command's option defs guarantee this shape.
     const opts = ctx.flags as unknown as ExploreFlags;
     const config = resolveConfig({ backend: opts.backend, routing: opts.routing, channel: opts.channel });
-    const checklistText = opts.checklist ? await readFile(opts.checklist, "utf8") : undefined;
+    const checklistText = opts.checklist ? await readInputFile(opts.checklist, "Checklist") : undefined;
     ctx.err(
       `▸ Exploring ${opts.url}${opts.session ? ` (session: ${opts.session})` : ""}${opts.checklist ? ` (checklist: ${opts.checklist})` : ""}…\n`,
     );

--- a/src/fs/run-dir.ts
+++ b/src/fs/run-dir.ts
@@ -1,0 +1,132 @@
+/**
+ * Robust resolution of user-supplied run-directory arguments (`--run` / `--from-run`).
+ *
+ * The Windows/Git-Bash trap: in MINGW64 an unquoted backslash is a shell ESCAPE, so
+ * `--run runs\<id>` reaches the process as the glued string `runs<id>` (the separator is
+ * eaten) BEFORE Node ever runs. We cannot un-eat it at display time — the fix lives at the
+ * INPUT layer: accept a bare run id, recover the glued form, and otherwise fail with an
+ * actionable message instead of a raw ENOENT.
+ *
+ * `src/fs/` is a dependency-free leaf — it must NOT import from `src/agent/` (a higher layer),
+ * so the display normalization below is a small local copy of agent/summary.displayPath().
+ */
+import { resolve, isAbsolute, basename } from "node:path";
+import { stat, readdir, readFile } from "node:fs/promises";
+
+/** Forward-slash a path for DISPLAY only (POSIX slashes are valid on all three platforms). */
+function toPosix(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+/** Escape a string for safe use as a literal inside a RegExp. */
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Single source of truth for the default runs base dir (was duplicated across agent/index.ts). */
+export function defaultRunsBaseDir(): string {
+  return resolve(process.cwd(), "runs");
+}
+
+async function dirExists(p: string): Promise<boolean> {
+  try {
+    return (await stat(p)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function listRunDirs(base: string): Promise<string[]> {
+  try {
+    const entries = await readdir(base, { withFileTypes: true });
+    return entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+export interface ResolveRunDirOptions {
+  /** Where bare run ids live. Default: defaultRunsBaseDir(). */
+  runsBaseDir?: string;
+  /** Injectable for tests: does this absolute path point at an existing directory? */
+  isDir?: (p: string) => Promise<boolean>;
+  /** Injectable for tests: list the run-dir names under the base. */
+  listRuns?: (base: string) => Promise<string[]>;
+}
+
+/** Build the actionable "run dir not found" message: what we tried, what's available, and how to avoid the trap. */
+export function runDirNotFoundMessage(value: string, runsBaseDir: string, available: string[]): string {
+  const lines = [`Run directory not found for "${value}".`, `  Tried: ${toPosix(resolve(value))} (does not exist).`, ""];
+  if (available.length > 0) {
+    lines.push(`Available runs in ${toPosix(runsBaseDir)}:`);
+    for (const name of available.slice(0, 12)) lines.push(`  - ${name}`);
+    if (available.length > 12) lines.push(`  …and ${available.length - 12} more`);
+  } else {
+    lines.push(
+      `No runs found in ${toPosix(runsBaseDir)} (none yet — run \`cairn design --url <u>\` or \`cairn explore\` first).`,
+    );
+  }
+  lines.push(
+    "",
+    "Tip: pass just the run id (e.g. --run <id>) or an absolute path.",
+    "In Git Bash (MINGW64) an unquoted \\ is eaten by the shell — quote the path or use forward slashes: --run 'runs/<id>'.",
+  );
+  return lines.join("\n");
+}
+
+/**
+ * Resolve a `--run`/`--from-run` value to an EXISTING run directory (absolute). See the module header.
+ * Order (first hit wins):
+ *   (a) literal path exists      → resolve(value)              [runs/<id>, ./runs/<id>, absolute, PowerShell `\`]
+ *   (b) bare id under the base   → resolve(runsBaseDir, value) [`--run <uuid>`]
+ *   (c) glued `<base><id>`       → resolve(runsBaseDir, captured) [Git-Bash eaten-separator recovery]
+ *   (d) nothing matched          → throw runDirNotFoundMessage(...)
+ * A non-existent ABSOLUTE path falls straight through to (d) — it is never re-joined under the base.
+ */
+export async function resolveRunDir(value: string, opts: ResolveRunDirOptions = {}): Promise<string> {
+  const runsBaseDir = resolve(opts.runsBaseDir ?? defaultRunsBaseDir());
+  const isDir = opts.isDir ?? dirExists;
+  const listRuns = opts.listRuns ?? listRunDirs;
+
+  // (a) literal path (relative/absolute/PowerShell `\`) — returned verbatim if it exists.
+  const direct = resolve(value);
+  if (await isDir(direct)) return direct;
+
+  if (!isAbsolute(value)) {
+    // (b) a bare run id living under the runs base dir.
+    const inBase = resolve(runsBaseDir, value);
+    if (await isDir(inBase)) return inBase;
+
+    // (c) Git-Bash glued case: `<base-name><id>` with the separator eaten. Prefix is the base dir name.
+    const captured = new RegExp(`^${escapeRe(basename(runsBaseDir))}(.+)$`, "i").exec(value)?.[1];
+    if (captured) {
+      const recovered = resolve(runsBaseDir, captured);
+      if (await isDir(recovered)) return recovered;
+    }
+  }
+
+  // (d) nothing matched — fail with an actionable message instead of a downstream ENOENT.
+  throw new Error(runDirNotFoundMessage(value, runsBaseDir, await listRuns(runsBaseDir)));
+}
+
+/**
+ * readFile, but a missing file becomes a friendly, actionable error (with the Git-Bash separator tip)
+ * instead of a raw ENOENT. For arbitrary file flags (`--checklist`/`--dataset`/`--candidate`) where the
+ * glued-path recovery used by resolveRunDir is impossible (no base+id convention to reconstruct from).
+ */
+export async function readInputFile(value: string, label: string): Promise<string> {
+  try {
+    return await readFile(value, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+      throw new Error(
+        `${label} not found: ${toPosix(resolve(value))}.\n` +
+          "In Git Bash (MINGW64) an unquoted \\ is eaten by the shell — quote the path or use forward slashes.",
+      );
+    }
+    throw err;
+  }
+}

--- a/tests/unit/fs/run-dir.test.ts
+++ b/tests/unit/fs/run-dir.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  resolveRunDir,
+  defaultRunsBaseDir,
+  runDirNotFoundMessage,
+  readInputFile,
+} from "../../../src/fs/run-dir.js";
+
+const UUID = "2ecb594f-021d-4077-b341-f1bd8ae25a0d";
+
+describe("resolveRunDir", () => {
+  let parent: string; // temp parent so the runs base dir is literally named "runs"
+  let base: string; // <parent>/runs  (basename === "runs", as in production)
+  let runDir: string; // <base>/<UUID>
+  beforeEach(async () => {
+    parent = await mkdtemp(join(tmpdir(), "cairn-resolve-"));
+    base = join(parent, "runs");
+    runDir = join(base, UUID);
+    await mkdir(runDir, { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(parent, { recursive: true, force: true });
+  });
+
+  it("(a) returns an existing absolute path verbatim", async () => {
+    expect(await resolveRunDir(runDir, { runsBaseDir: base })).toBe(resolve(runDir));
+  });
+
+  it("(b) resolves a bare run id under the runs base dir", async () => {
+    expect(await resolveRunDir(UUID, { runsBaseDir: base })).toBe(resolve(base, UUID));
+  });
+
+  it("(c) recovers the Git-Bash glued `runs<id>` case (eaten separator)", async () => {
+    // This is the exact regression: `--run runs\<id>` arrives as `runs<id>` after the shell eats `\`.
+    expect(await resolveRunDir(`runs${UUID}`, { runsBaseDir: base })).toBe(resolve(base, UUID));
+  });
+
+  it("(a) takes precedence over glued recovery when the literal path exists", async () => {
+    const value = `runs${UUID}`;
+    const literal = resolve(value);
+    // isDir says the literal `runs<id>` dir exists in cwd → (a) must win, no stripping.
+    const isDir = async (p: string): Promise<boolean> => p === literal;
+    expect(await resolveRunDir(value, { runsBaseDir: base, isDir })).toBe(literal);
+  });
+
+  it("(d) throws an actionable error when nothing matches", async () => {
+    await expect(resolveRunDir("nope-no-such-run", { runsBaseDir: base })).rejects.toThrow(
+      /Run directory not found/,
+    );
+  });
+
+  it("does not silently map a non-existent ABSOLUTE path to a same-named run (isAbsolute guard)", async () => {
+    // base/<UUID> exists, but this different absolute path ending in <UUID> does NOT — must throw, not map.
+    const otherAbs = resolve(parent, "not-the-base", UUID);
+    await expect(resolveRunDir(otherAbs, { runsBaseDir: base })).rejects.toThrow(/not found/i);
+  });
+});
+
+describe("defaultRunsBaseDir", () => {
+  it("is <cwd>/runs", () => {
+    expect(defaultRunsBaseDir()).toBe(resolve(process.cwd(), "runs"));
+  });
+});
+
+describe("runDirNotFoundMessage", () => {
+  it("lists available runs and carries the bare-id + Git-Bash tips", () => {
+    const msg = runDirNotFoundMessage(`runs${UUID}`, "/proj/runs", [UUID, "9af10000-0000-0000-0000-000000000000"]);
+    expect(msg).toMatch(/not found/i);
+    expect(msg).toContain(UUID); // available list
+    expect(msg).toMatch(/--run <id>|bare|run id/i); // bare-id tip
+    expect(msg).toMatch(/Git Bash|forward slash|quote/i); // shell-trap tip
+    // The path it tried is shown POSIX-style (the literal `\` in the human tip is intentional).
+    const triedLine = msg.split("\n").find((l) => l.includes("Tried:")) ?? "";
+    expect(triedLine).not.toContain("\\");
+  });
+
+  it("degrades gracefully when there are no runs yet", () => {
+    const msg = runDirNotFoundMessage("x", "/proj/runs", []);
+    expect(msg).toMatch(/none yet|no runs/i);
+  });
+});
+
+describe("readInputFile", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "cairn-input-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns the file contents when present", async () => {
+    const f = join(dir, "checklist.md");
+    await writeFile(f, "- test the thing\n");
+    expect(await readInputFile(f, "Checklist")).toBe("- test the thing\n");
+  });
+
+  it("throws a friendly error (label + Git-Bash tip) when the file is missing", async () => {
+    const missing = join(dir, "nope.md");
+    await expect(readInputFile(missing, "Checklist")).rejects.toThrow(/Checklist not found/);
+    await expect(readInputFile(missing, "Checklist")).rejects.toThrow(/Git Bash|forward slash|quote/i);
+  });
+});


### PR DESCRIPTION
## Problem

In Git Bash (MINGW64) an unquoted `\` is a shell escape, so `cairn promote --run runs\<id> …` reaches the process as the glued `runs<id>` (the separator is eaten) **before Node runs** → `ENOENT … runs<id>\testcases\<case>.md`. This recurred (raised before); `displayPath()` is display-only and cannot fix an input that is already corrupted — the fix must be at the **input** layer.

## Fix

New leaf module `src/fs/run-dir.ts`:
- **`resolveRunDir(value, {runsBaseDir})`** — accepts `runs/<id>`, an absolute path, a **bare `<id>`**, and **recovers** the glued `runs<id>` case (prefix derived from the runs-dir basename); otherwise throws an actionable error listing available runs + bare-id/Git-Bash tips. Never mangles an absolute path.
- **`readInputFile(value, label)`** — friendly ENOENT (+ Git-Bash tip) for arbitrary file flags (`--checklist`/`--dataset`/`--candidate`) where glued recovery is impossible (no base+id convention).
- **`defaultRunsBaseDir()`** — single source for the runs base dir (was duplicated 5× in `agent/index.ts`).

Wired into `promote` / `automate` (via `runAutomate`, so library callers benefit too) / `dataset-add`, plus the checklist/dataset/candidate read sites. Raw path log lines now go through `displayPath()`. Help text + README + getting-started document the bare-id form and the forward-slash/quote tip. `src/fs/` is kept a dependency-free leaf (no import from `src/agent/`).

## Verification

- `npm run build` ✅ · `npm run lint` ✅ · `npm test` **436 passed** (+11 new in `tests/unit/fs/run-dir.test.ts`, incl. the glued-recovery regression).
- Reproduced & verified on **real Git Bash**:
  - `--run runs\<id>` (shell eats `\`) → recovered → promote succeeds (was ENOENT)
  - `--run <id>` (bare) ✅ · `--run runs/<id>` ✅
  - not-found → friendly error with available runs + tips
  - `dataset-add --from-run runs\<id>` → recovered
  - `design --checklist nope\plan.md` → "Checklist not found …" + tip (no raw ENOENT)

## Usage going forward

Simplest: pass the bare run id — `cairn promote --run <id> --cases …` (no prefix). The habitual `--run runs\<id>` now works too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
