### PR TITLE
feat: --critique — design-time self-critique pass (prune + technique top-up) (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--critique` flag on `cairn design` and `cairn explore` (#82)** — an opt-in design-time
+  self-critique pass that runs once AFTER the first design set and BEFORE finalization. On the cheap
+  **worker** role (`CAIRN_ROLE_WORKER`) it (a) prunes trivial / contradictory / unverifiable cases and
+  (b) tops up techniques under-represented across the 6 × ISO/IEC/IEEE 29119-4 set — feeding quality
+  signal back into generation instead of only scoring it post-hoc. The prune/top-up delta (cases
+  pruned, techniques added, technique-coverage before→after) is recorded in `report.json` under
+  `critique`, next to the existing `technique_coverage` / `case_redundancy` metrics. Bounded to a
+  **single** worker-tier LLM call; conservative default (**off** unless `--critique` is passed). The
+  methodology and assertion-safety rules are unchanged — the pass only prunes and fills gaps, and
+  top-up refs are grounded against real elements like the main design step. Behavior is identical to
+  before when the flag is absent.
+
 - **`--fresh` flag on `cairn design` and `cairn explore`** (and a matching TUI toggle) — ignore
   prior-run experience for a URL. By default a 2nd+ run on the same URL reuses its *previously stable*
   cases as design-prompt context and generates only the **delta** (new cases); `--fresh` skips that

--- a/src/agent/graph.ts
+++ b/src/agent/graph.ts
@@ -2,6 +2,7 @@ import { capture, type PageStudy } from "../observe/index.js";
 import { parseAriaSnapshot } from "../observe/parse-aria.js";
 import { analyzePage, type PageAnalysis } from "../analyze/index.js";
 import { designTestCases, type TestCase } from "../design/index.js";
+import { critiqueCases, type CritiqueDelta } from "../design/critique.js";
 import { generateSuite, type GeneratedSuite } from "../codegen/index.js";
 import { probeTransitions, type Transition } from "../probe/index.js";
 import { looksLikeLoginPage, expiredSessionMessage } from "../session/index.js";
@@ -20,6 +21,10 @@ export interface ExploreDeps {
   analyzeInvoke: StructuredInvoke;
   designInvoke: StructuredInvoke;
   codegenInvoke: StructuredInvoke;
+  /** #82: worker-tier invoker for the design-time self-critique pass. Absent → pass is skipped. */
+  critiqueInvoke?: StructuredInvoke;
+  /** #82: run the self-critique pass (prune + technique top-up). Conservative default: off. */
+  critique?: boolean;
   useVision: boolean;
   checklistText?: string;
   knowledgeText?: string;
@@ -69,6 +74,8 @@ export interface ExploreOutcome {
   stoppedEarly: boolean;
   /** Repair attempts actually run (0 = green on the first try, or maxRepair=0 or codeless). */
   attempts: number;
+  /** #82: before/after delta of the self-critique pass (undefined when the pass didn't run). */
+  critique?: CritiqueDelta;
 }
 
 /** Sprint 3: observe → identify → design → generateCode → validate ⇄ repair (bounded by maxRepair). */
@@ -190,7 +197,7 @@ export async function runExploreGraph(
 
   // ── designTestCases ───────────────────────────────────────────────────────
   deps.onProgress?.("designTestCases — designing cases (LLM reasoning, may take ~a minute)…");
-  const testCases = await designTestCases(
+  let testCases = await designTestCases(
     {
       study,
       pageSemantics: analysis.pageSemantics,
@@ -205,6 +212,33 @@ export async function runExploreGraph(
     { invoke: deps.designInvoke, prompts: deps.prompts },
   );
   deps.onProgress?.(`designTestCases — generated ${testCases.length} cases`);
+
+  // ── critique (opt-in, #82) ────────────────────────────────────────────────
+  // One cheap worker-tier pass that prunes weak cases + tops up under-represented techniques.
+  // Best-effort: a critique failure must never sink a run that already has a valid design set.
+  let critique: CritiqueDelta | undefined;
+  if (deps.critique && deps.critiqueInvoke && testCases.length > 0) {
+    deps.onProgress?.("critique — pruning weak cases + topping up technique gaps (worker)…");
+    try {
+      const out = await critiqueCases(
+        {
+          testCases,
+          pageSemantics: analysis.pageSemantics,
+          knownRefs: verified.filter((v) => v.count >= 1).map((v) => v.ref),
+          language: deps.languageText,
+        },
+        { invoke: deps.critiqueInvoke, prompts: deps.prompts },
+      );
+      testCases = out.cases;
+      critique = out.delta;
+      deps.onProgress?.(
+        `critique — pruned ${critique.pruned}, topped up ${critique.toppedUp}; ` +
+          `technique coverage ${critique.techniqueCoverageBefore.toFixed(2)}→${critique.techniqueCoverageAfter.toFixed(2)}`,
+      );
+    } catch {
+      // critique is best-effort — keep the original design set on any failure.
+    }
+  }
   // Durability: persist the cases NOW (best-effort), mirroring onStudy (#38) — a kill during the later
   // codegen/validate phase (minutes for explore) must not lose what we already designed.
   try {
@@ -215,7 +249,7 @@ export async function runExploreGraph(
 
   // ── codeless short-circuit ────────────────────────────────────────────────
   if (deps.codeless) {
-    return { study, analysis, verified, transitions, testCases, stoppedEarly: false, attempts: 0 };
+    return { study, analysis, verified, transitions, testCases, stoppedEarly: false, attempts: 0, critique };
   }
 
   // ── generate → validate → repair (reuse runRepairLoop) ───────────────────
@@ -263,5 +297,6 @@ export async function runExploreGraph(
     bestValidation,
     stoppedEarly,
     attempts,
+    critique,
   };
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -60,6 +60,8 @@ export interface ExploreInput {
   onProgress?: (event: string) => void;
   /** Ignore prior-run experience for this URL (collectPriorRuns is skipped). */
   fresh?: boolean;
+  /** #82: run the design-time self-critique pass (prune + technique top-up) on the worker tier. Default off. */
+  critique?: boolean;
 }
 
 export interface ExploreResult {
@@ -177,6 +179,9 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
     analyzeInvoke: router.invoke("worker", analyzeTier),
     designInvoke: router.invoke("reasoner", designTier),
     codegenInvoke: router.invoke("worker", codegenTier),
+    // #82: self-critique runs on the worker tier (CAIRN_ROLE_WORKER) to bound cost; built only when opted in.
+    critiqueInvoke: input.critique ? router.invoke("worker", codegenTier) : undefined,
+    critique: input.critique,
     useVision: analyzeTier.supportsVision,
     checklistText: checklistFormatted,
     knowledgeText,
@@ -348,6 +353,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
           cost,
           budget: budgetReport,
           stoppedEarly,
+          critique: out.critique, // #82: prune/top-up delta (undefined when the pass didn't run)
           history: {
             priorRuns: priorRuns.length,
             bestPriorGreen: bestPriorGreen ?? null,
@@ -510,6 +516,9 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
     analyzeInvoke: router.invoke("worker", analyzeTier),
     designInvoke: router.invoke("reasoner", designTier),
     codegenInvoke: router.invoke("worker", codegenTier),
+    // #82: self-critique runs on the worker tier (CAIRN_ROLE_WORKER) to bound cost; built only when opted in.
+    critiqueInvoke: input.critique ? router.invoke("worker", codegenTier) : undefined,
+    critique: input.critique,
     useVision: analyzeTier.supportsVision,
     checklistText: formatChecklist(checklistItems),
     knowledgeText,
@@ -616,6 +625,7 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
           testCaseFiles,
           scores,
           cost,
+          critique: out.critique, // #82: prune/top-up delta (undefined when the pass didn't run)
         });
         await runWriter.writeLog(
           [...logLines, "", `summary: mode=design testCases=${out.testCases.length} suite=${suite} runId=${runId}`].join("\n"),

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -112,6 +112,7 @@ export function buildProgram(): Command {
     .option("--style <s>", "planning style: happy | negative | coverage | all")
     .option("--fresh", "ignore prior runs for this URL — generate a full set, don't dedupe against past cases")
     .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
+    .option("--critique", "self-critique pass after design: prune weak cases + top up technique gaps (1 extra worker-tier LLM call)")
     .action(async (opts: Record<string, unknown>) => {
       await runModality("explore", opts);
     });
@@ -221,6 +222,7 @@ export function buildProgram(): Command {
     .option("--style <s>", "planning style: happy | negative | coverage | all")
     .option("--fresh", "ignore prior runs for this URL — generate a full set, don't dedupe against past cases")
     .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
+    .option("--critique", "self-critique pass after design: prune weak cases + top up technique gaps (1 extra worker-tier LLM call)")
     .option("--headed", "visible browser (debug)")
     .action(
       async (opts: {
@@ -233,6 +235,7 @@ export function buildProgram(): Command {
         headed?: boolean;
         routing?: string;
         fresh?: boolean;
+        critique?: boolean;
       }) => {
         const config = resolveConfig({ routing: opts.routing, channel: opts.channel });
         const checklistText = opts.checklist ? await readInputFile(opts.checklist, "Checklist") : undefined;
@@ -251,6 +254,7 @@ export function buildProgram(): Command {
           style: opts.style,
           headed: opts.headed,
           fresh: opts.fresh,
+          critique: opts.critique,
           onProgress: progress.event,
         }).finally(() => progress.stop());
 

--- a/src/core/modalities/explore.ts
+++ b/src/core/modalities/explore.ts
@@ -26,6 +26,7 @@ interface ExploreFlags {
   style?: string;
   routing?: string;
   fresh?: boolean;
+  critique?: boolean;
 }
 
 export const exploreModality: Modality = {
@@ -52,6 +53,7 @@ export const exploreModality: Modality = {
       checklistText,
       style: opts.style,
       fresh: opts.fresh,
+      critique: opts.critique,
       onProgress: progress.event,
     }).finally(() => progress.stop());
 

--- a/src/design/critique.ts
+++ b/src/design/critique.ts
@@ -1,0 +1,110 @@
+import { HumanMessage } from "@langchain/core/messages";
+import { z } from "zod";
+import type { StructuredInvoke } from "../llm/structured.js";
+import type { PromptRegistry } from "../prompts/index.js";
+import { DesignedCaseSchema, TestTechniqueSchema, type TestCase } from "./schema.js";
+import { dedupCases } from "./dedup.js";
+
+/** The 6 × ISO/IEC/IEEE 29119-4 techniques (single source: the schema enum). */
+const ALL_TECHNIQUES = TestTechniqueSchema.options;
+
+/** What the critique pass changed — recorded in report.json next to technique_coverage / case_redundancy. */
+export interface CritiqueDelta {
+  /** Case count before the pass. */
+  before: number;
+  /** Case count after the pass (prune + top-up + re-dedup). */
+  after: number;
+  /** Cases dropped as trivial / contradictory / unverifiable. */
+  pruned: number;
+  /** Titles of the dropped cases (so the report shows WHAT was pruned). */
+  prunedTitles: string[];
+  /** New cases the top-up proposed (grounded against real refs). */
+  toppedUp: number;
+  /** technique_coverage (distinct/6) before the pass. */
+  techniqueCoverageBefore: number;
+  /** technique_coverage (distinct/6) after the pass. */
+  techniqueCoverageAfter: number;
+  /** Techniques newly covered by the top-up. */
+  techniquesAdded: string[];
+}
+
+export interface CritiqueInput {
+  testCases: TestCase[];
+  pageSemantics: string;
+  /** Real element refs (count≥1) — top-up cases are grounded against these (anti-hallucination). */
+  knownRefs: string[];
+  /** Case language (default "English"). */
+  language?: string;
+}
+
+export interface CritiqueDeps {
+  invoke: StructuredInvoke;
+  prompts: PromptRegistry;
+}
+
+/** What the worker returns: which cases to drop + which new cases to add. */
+const CritiqueResultSchema = z.object({
+  drop: z.array(z.object({ id: z.string(), reason: z.string() })).default([]),
+  add: z.array(DesignedCaseSchema).default([]),
+});
+
+const distinctTechniques = (cases: TestCase[]): Set<string> => new Set(cases.map((c) => c.technique));
+
+/**
+ * #82 — design-time self-critique: ONE cheap worker-tier pass AFTER the first design set and BEFORE
+ * finalization. It (a) prunes trivial / contradictory / unverifiable cases and (b) tops up techniques
+ * under-represented across the 6 × 29119-4 set. Methodology and assertion-safety rules are unchanged —
+ * this only prunes and fills gaps. Top-up refs are grounded exactly like {@link designTestCases}.
+ */
+export async function critiqueCases(
+  input: CritiqueInput,
+  deps: CritiqueDeps,
+): Promise<{ cases: TestCase[]; delta: CritiqueDelta }> {
+  const before = input.testCases;
+  const techBefore = distinctTechniques(before);
+  const underrepresented = ALL_TECHNIQUES.filter((t) => !techBefore.has(t));
+
+  const casesList = before
+    .map((c) => `- ${c.id} [${c.technique}/${c.type}] ${c.title} → expected: ${c.expected}`)
+    .join("\n");
+  const prompt = await deps.prompts.getPrompt("qa-case-critique", {
+    cases: casesList,
+    underrepresented: underrepresented.join(", ") || "(none — all 6 techniques already covered)",
+    elements: input.knownRefs.join(", "),
+    language: input.language ?? "English",
+  });
+  const result = await deps.invoke(CritiqueResultSchema, [new HumanMessage(prompt.text)]);
+
+  const dropIds = new Set(result.drop.map((d) => d.id));
+  const prunedTitles = before.filter((c) => dropIds.has(c.id)).map((c) => c.title);
+  const kept = before.filter((c) => !dropIds.has(c.id));
+
+  // Ground top-up refs against real elements (same anti-hallucination rule as designTestCases).
+  const known = new Set(input.knownRefs);
+  const toppedUpCases = result.add.map((c) => ({
+    ...c,
+    id: "tc-pending",
+    elementRefs: c.elementRefs.filter((r) => known.has(r)),
+  }));
+
+  // Re-id + re-dedup the combined set, mirroring designTestCases' tail (one source of truth for dedup).
+  const combined = [...kept, ...toppedUpCases].map((c, i) => ({ ...c, id: `tc-${i + 1}` }));
+  const after = dedupCases(combined).merged;
+
+  const techAfter = distinctTechniques(after);
+  const techniquesAdded = [...techAfter].filter((t) => !techBefore.has(t));
+
+  return {
+    cases: after,
+    delta: {
+      before: before.length,
+      after: after.length,
+      pruned: prunedTitles.length,
+      prunedTitles,
+      toppedUp: toppedUpCases.length,
+      techniqueCoverageBefore: techBefore.size / ALL_TECHNIQUES.length,
+      techniqueCoverageAfter: techAfter.size / ALL_TECHNIQUES.length,
+      techniquesAdded,
+    },
+  };
+}

--- a/src/prompts/local/index.ts
+++ b/src/prompts/local/index.ts
@@ -1,5 +1,6 @@
 import { QA_TESTCASE_FROM_UI } from "./qa-testcase-from-ui.js";
 import { QA_MANUAL_TEST_DESIGNER } from "./qa-manual-test-designer.js";
+import { QA_CASE_CRITIQUE } from "./qa-case-critique.js";
 import { QA_PLAYWRIGHT_TS_WRITER } from "./qa-playwright-ts-writer.js";
 import { IDENTIFY_ELEMENTS } from "./identify-elements.js";
 import { JUDGE_TEST_CASES } from "./judge-test-cases.js";
@@ -10,6 +11,7 @@ import { PILOT_REVIEW } from "./pilot-review.js";
 export const LOCAL_PROMPTS: Record<string, string> = {
   "qa-testcase-from-ui": QA_TESTCASE_FROM_UI,
   "qa-manual-test-designer": QA_MANUAL_TEST_DESIGNER,
+  "qa-case-critique": QA_CASE_CRITIQUE,
   "qa-playwright-ts-writer": QA_PLAYWRIGHT_TS_WRITER,
   "identify-elements": IDENTIFY_ELEMENTS,
   "judge-test-cases": JUDGE_TEST_CASES,

--- a/src/prompts/local/qa-case-critique.ts
+++ b/src/prompts/local/qa-case-critique.ts
@@ -1,0 +1,33 @@
+/**
+ * #82 — design-time self-critique prompt. A SEPARATE, cheap worker-tier pass that reviews the
+ * first design set: it PRUNES weak cases and TOPS UP under-represented techniques. It does NOT
+ * redesign and does NOT touch the methodology / assertion-safety rules — those live in
+ * `qa-testcase-from-ui` and `qa-manual-test-designer` and stay fixed.
+ */
+export const QA_CASE_CRITIQUE = `You are a senior QA reviewer doing a SECOND pass over an already-designed set of UI test cases.
+Write everything (titles, steps, expected) in {{language}} — do not mix languages.
+
+Current test cases (id · [technique/type] · title → expected):
+{{cases}}
+
+Under-represented 29119-4 techniques on this page (cover these if the page genuinely supports them — do NOT invent cases the page can't back):
+{{underrepresented}}
+
+Real element refs you may reference (use ONLY these — never invent refs):
+{{elements}}
+
+Do TWO things:
+1. PRUNE — list the ids of cases to DROP, each with a one-line reason. Drop a case ONLY if it is:
+   - trivial (asserts nothing meaningful, e.g. "page loads"),
+   - contradictory with another case (e.g. two cases expect opposite states of the same toggle from a clean start), or
+   - not verifiable (its "expected" cannot be objectively checked).
+   When in doubt, KEEP the case — pruning is conservative.
+2. TOP UP — add NEW cases ONLY for the under-represented techniques above, where the page supports them.
+   Each new case follows the SAME rules as the original design:
+   - one logical check (one expected), independent, starting from a clean page;
+   - read-only by default — for destructive/irreversible controls only check visibility, never perform the action;
+   - real element labels in steps; elementRefs taken ONLY from the refs listed above.
+   Add nothing if the techniques cannot be honestly covered — an empty top-up is a valid answer.
+
+Each new case has: title, technique (one of the under-represented ones), kind ("static"|"active"),
+type ("Positive"|"Negative"), execution ("auto"|"manual"), preconditions, steps, expected, priority, elementRefs.`;

--- a/tests/unit/__snapshots__/cli-modalities.test.ts.snap
+++ b/tests/unit/__snapshots__/cli-modalities.test.ts.snap
@@ -62,6 +62,8 @@ Options:
                          don't dedupe against past cases
   --routing <preset>     role-routing preset: fast (Groq worker) | volume
                          (OpenRouter worker) (sets LLM_ROUTING)
+  --critique             self-critique pass after design: prune weak cases + top
+                         up technique gaps (1 extra worker-tier LLM call)
   -h, --help             display help for command
 "
 `;

--- a/tests/unit/cli-modalities.test.ts
+++ b/tests/unit/cli-modalities.test.ts
@@ -112,10 +112,11 @@ describe("explore parity (C1-02)", () => {
       "--style",
       "--fresh",
       "--routing",
+      "--critique",
     ]) {
       expect(longs, `explore should accept ${f}`).toContain(f);
     }
-    expect(longs).toHaveLength(10); // + --fresh (ignore prior-run experience for a clean A/B run)
+    expect(longs).toHaveLength(11); // + --critique (opt-in design-time self-critique pass, #82)
   });
 
   it("maps flags to runExploration the same way as before the refactor", async () => {

--- a/tests/unit/critique.test.ts
+++ b/tests/unit/critique.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { critiqueCases } from "../../src/design/critique.js";
+import { PromptRegistry } from "../../src/prompts/index.js";
+import type { StructuredInvoke } from "../../src/llm/structured.js";
+import type { TestCase } from "../../src/design/schema.js";
+
+const tc = (over: Partial<TestCase>): TestCase => ({
+  id: "tc-1",
+  title: "t",
+  technique: "equivalence-partitioning",
+  kind: "static",
+  type: "Positive",
+  execution: "auto",
+  preconditions: [],
+  steps: ["s"],
+  expected: "e",
+  priority: "medium",
+  elementRefs: [],
+  ...over,
+});
+
+describe("critiqueCases (#82)", () => {
+  it("prunes the cases the critique drops (by id) and records the delta", async () => {
+    const cases = [tc({ id: "tc-1" }), tc({ id: "tc-2", title: "trivial dup" })];
+    const fake: StructuredInvoke = async (schema) =>
+      schema.parse({ drop: [{ id: "tc-2", reason: "trivial" }], add: [] });
+
+    const { cases: out, delta } = await critiqueCases(
+      { testCases: cases, pageSemantics: "x", knownRefs: [] },
+      { invoke: fake, prompts: new PromptRegistry() },
+    );
+
+    expect(out).toHaveLength(1);
+    expect(out[0]?.title).toBe("t");
+    expect(delta.before).toBe(2);
+    expect(delta.after).toBe(1);
+    expect(delta.pruned).toBe(1);
+    expect(delta.prunedTitles).toEqual(["trivial dup"]);
+  });
+
+  it("tops up an under-represented technique and grounds the new refs", async () => {
+    const cases = [tc({ id: "tc-1", technique: "equivalence-partitioning", elementRefs: ["e1"] })];
+    const fake: StructuredInvoke = async (schema) =>
+      schema.parse({
+        drop: [],
+        add: [
+          {
+            title: "Boundary",
+            technique: "boundary-value",
+            kind: "static",
+            type: "Positive",
+            execution: "auto",
+            preconditions: [],
+            steps: ["enter min"],
+            expected: "accepted",
+            priority: "low",
+            elementRefs: ["e1", "eGHOST"],
+          },
+        ],
+      });
+
+    const { cases: out, delta } = await critiqueCases(
+      { testCases: cases, pageSemantics: "x", knownRefs: ["e1"] },
+      { invoke: fake, prompts: new PromptRegistry() },
+    );
+
+    expect(out).toHaveLength(2);
+    const boundary = out.find((c) => c.technique === "boundary-value");
+    expect(boundary?.elementRefs).toEqual(["e1"]); // eGHOST grounded out (anti-hallucination)
+    expect(delta.toppedUp).toBe(1);
+    expect(delta.techniquesAdded).toContain("boundary-value");
+    expect(delta.techniqueCoverageAfter).toBeGreaterThan(delta.techniqueCoverageBefore);
+  });
+
+  it("surfaces the missing techniques + current cases to the model", async () => {
+    let captured = "";
+    const fake: StructuredInvoke = async (schema, messages) => {
+      captured = JSON.stringify(messages);
+      return schema.parse({ drop: [], add: [] });
+    };
+
+    await critiqueCases(
+      { testCases: [tc({ id: "tc-1", technique: "equivalence-partitioning" })], pageSemantics: "Login form", knownRefs: ["e1"] },
+      { invoke: fake, prompts: new PromptRegistry() },
+    );
+
+    expect(captured).toContain("boundary-value"); // an under-represented technique is offered for top-up
+    expect(captured).toContain("tc-1"); // the existing case is shown for the prune decision
+  });
+
+  it("is a no-op when the critique neither drops nor adds", async () => {
+    const cases = [tc({ id: "tc-1" })];
+    const fake: StructuredInvoke = async (schema) => schema.parse({ drop: [], add: [] });
+    const { cases: out, delta } = await critiqueCases(
+      { testCases: cases, pageSemantics: "x", knownRefs: [] },
+      { invoke: fake, prompts: new PromptRegistry() },
+    );
+    expect(out).toHaveLength(1);
+    expect(delta.pruned).toBe(0);
+    expect(delta.toppedUp).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Adds an **opt-in** design-time self-critique pass (`--critique`) on `cairn design` and
`cairn explore`. Today the judge only scores cases *post-hoc* and dedup only merges
near-duplicates; this closes the loop by feeding quality signal **back into generation**.

The pass runs **once**, after the first design set and before finalization:

1. **Prune** — drops trivial / contradictory / unverifiable cases (conservative: keep on doubt).
2. **Top up** — adds cases only for techniques **under-represented** across the 6 × ISO/IEC/IEEE
   29119-4 set, where the page genuinely supports them.

## How

- New `src/design/critique.ts` (`critiqueCases`) + a separate `qa-case-critique` prompt. The
  methodology and assertion-safety rules (in `qa-testcase-from-ui` / `qa-manual-test-designer`)
  are **untouched** — the pass only prunes and fills gaps. Top-up refs are grounded against real
  elements exactly like the main design step, and the combined set is re-deduped via the existing
  `dedupCases` (one source of truth).
- Wired into `runExploreGraph` right after `designTestCases`, gated by `deps.critique` +
  `deps.critiqueInvoke`. The invoker is built on the **worker** role
  (`router.invoke("worker", …)` → `CAIRN_ROLE_WORKER`) to bound cost — **a single LLM call**.
- Conservative default: **off** unless `--critique` is passed. Best-effort — a critique failure
  keeps the original design set.
- The prune/top-up delta (cases pruned + titles, techniques added, technique-coverage
  before→after) is recorded in `report.json` under `critique`, next to the existing
  `technique_coverage` / `case_redundancy` metrics.

## Back-compat

No generated artifact differs when the flag is absent. The `explore` CLI surface-lock tests
(C1-02) are updated for the new opt-in flag (all prior flags unchanged).

## Tests

`tests/unit/critique.test.ts` (mocked LLM): prune by id, top-up + ref grounding, delta
computation, and the no-op case. `npm run build`, `npm run lint`, `npm test` (440 passed, 2
skipped) all green.

Closes #82