### PR TITLE
feat: externalize prompts + house-style packs (--style packs) (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **First-class prompt overrides + house-style packs (#80).** A committed `prompts/` scaffold now
+  ships in the repo: a `prompts/README.md` documenting the override precedence (Langfuse →
+  `prompts/<name>.md` → built-in constant) and `prompts/qa-testcase-from-ui.md` — the built-in design
+  prompt **verbatim** — so you can see exactly what is overridable (a drift guard keeps it in sync).
+  `--style <value>` is promoted to a dual resolver: a **style pack** (`prompts/styles/<value>.md` or an
+  explicit `.md` path) is loaded into the prompt's `{{style}}` slot, otherwise it falls back to the
+  existing inline hint (`happy` / `negative` / `coverage`). Three built-in packs ship —
+  `concise`, `gherkin`, `detailed-manual`. Style affects **only** naming / format / language / tone;
+  it never changes technique coverage or assertion safety (the methodology stays fixed). Back-compat:
+  the short `--style happy|negative|coverage|all` behavior is unchanged.
+
 - **`--critique` flag on `cairn design` and `cairn explore` (#82)** — an opt-in design-time
   self-critique pass that runs once AFTER the first design set and BEFORE finalization. On the cheap
   **worker** role (`CAIRN_ROLE_WORKER`) it (a) prunes trivial / contradictory / unverifiable cases and

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,40 @@
+# Prompt overrides
+
+Drop a `<name>.md` file in this folder to override a built-in Cairn prompt **without rebuilding**.
+This folder ships committed so you can see exactly what is overridable and edit it in place.
+
+## Precedence (highest first)
+
+1. **Langfuse** — when `LANGFUSE_*` is configured and the prompt exists there (versioned, labelled).
+2. **`prompts/<name>.md`** — this folder. What you edit locally wins over the built-in default.
+3. **Built-in constant** — `src/prompts/local/<name>.ts`, the offline default that always works.
+
+`{{var}}` placeholders are interpolated at run time; a missing variable becomes empty.
+
+## Methodology vs house-style — important
+
+`qa-testcase-from-ui.md` here is the built-in design prompt **verbatim**, so you can see what you
+may tune. ⚠ It becomes the live prompt the moment you change it. Keep the **METHODOLOGY**,
+**ASSERTION SAFETY**, and **STABILITY** sections intact — those are what make the generated cases
+correct, safe, and runnable.
+
+If you only want to change **naming / format / language / tone** (not which techniques are covered
+or how assertions are written), do **not** edit the methodology — use a **style pack** instead:
+
+```bash
+cairn design --url <u> --session <s> --style concise
+```
+
+`--style <value>` resolves in order:
+
+1. a **style pack** — `prompts/styles/<value>.md` (built-in or yours), or an explicit `.md` path —
+   whose text is loaded into the prompt's `{{style}}` slot;
+2. otherwise a built-in **inline hint** — `happy` / `negative` / `coverage` (focus directives),
+   or `all` / anything else → balanced (no directive).
+
+Built-in packs live in [`styles/`](styles/): `concise`, `gherkin`, `detailed-manual`.
+
+## Prompt names
+
+`qa-testcase-from-ui` · `qa-manual-test-designer` · `qa-case-critique` · `qa-playwright-ts-writer` ·
+`identify-elements` · `judge-test-cases` · `judge-checklist-coverage` · `pilot-review`

--- a/prompts/qa-testcase-from-ui.md
+++ b/prompts/qa-testcase-from-ui.md
@@ -1,0 +1,48 @@
+You are an experienced QA engineer. Based on the explored page, generate UI test cases.
+IMPORTANT: write all title, steps, expected in {{language}} — do not mix languages (even if the checklist/page is in another language).
+
+Page purpose:
+{{pageSemantics}}
+
+Interactive elements (ref · role · name; ×N = repeated, several identical on the page — e.g. list rows). All REALLY present. In elementRefs use ONLY these refs — do not invent or change them:
+{{elements}}
+
+Observed state transitions (act→observe). GROUND state-transition assertions ON THESE — do not invent consequences:
+{{transitions}}
+
+Domain knowledge (credentials, validation rules, nuances — account for these in the cases):
+{{knowledge}}
+
+{{experience}}
+
+{{style}}
+
+{{methodology}}
+
+{{checklist}}
+
+Generate clear, verifiable test cases. For each:
+- title — concise title;
+- technique — applied 29119-4 technique;
+- kind — "static" (visibility/state check only, no actions) or "active" (with actions: click/fill/navigation);
+- type — "Positive" (valid scenario) or "Negative" (invalid/erroneous input);
+- execution — "auto" (can be RELIABLY automated: read-only checks on verified locators) or "manual" (full generation/submit, security/XSS, UI-UX/visual/responsiveness, irreversible actions — the bot does NOT automate these);
+- preconditions — preconditions (e.g. "user is logged in", "page X is open");
+- steps — DETAILED unambiguous steps with REAL element labels (e.g. 'Click "Generate CV"', 'Enter text into the "Vacancy text" field');
+- expected — verifiable expected result;
+- priority — critical | high | medium | low;
+- elementRefs — real refs from the list above that the case touches.
+
+ASSERTION SAFETY:
+- Read-only by default: check visibility/state (toBeVisible/toBeEnabled/toBeChecked), not the consequences of actions.
+- For destructive/irreversible controls (Delete, Remove, Submit, Convert, Log out, Add — anything that writes data or signs out) — only check that the element is VISIBLE; do NOT click or perform the action.
+
+STABILITY (CRITICAL):
+- One case = ONE logical check (one expected). Do NOT combine many assertions in one case — a mega-test fails entirely if any single part is off.
+- Each case is INDEPENDENT and starts from a CLEAN page. Do NOT assume state left by another case.
+- Do NOT generate contradictory cases (e.g. one expects toggle=on, another toggle=off from a fresh start). For a toggle take EXACTLY ONE transition from the "Observed state transitions" (before→after).
+
+Cover happy path AND negative/edge scenarios. No duplicates or trivialities (no two cases with the same technique + same elements + same steps).
+TECHNIQUE BREADTH: apply a VARIETY of 29119-4 techniques where the page allows — equivalence-partitioning, boundary-value, decision-table, state-transition, error-guessing — not just exploratory.
+
+FULL CHECKLIST COVERAGE: do NOT skip checklist items. If an item cannot be reliably automated (full generation/submit flow, security/XSS, UI-UX/visual/responsiveness, irreversible actions) — STILL create a case, but set execution="manual" (it will not be automated, but it is documented for manual testing). Every checklist item → at least one case (auto or manual).

--- a/prompts/styles/concise.md
+++ b/prompts/styles/concise.md
@@ -1,0 +1,9 @@
+STYLE FOR THIS RUN — CONCISE HOUSE STYLE.
+This affects ONLY naming, format, language, and tone. It does NOT change which 29119-4 techniques
+are applied, how many cases are produced, or the assertion-safety / stability rules.
+
+- Titles: short and specific (≤ 8 words). Drop filler prefixes like "Verify that" / "Check that".
+- Steps: terse imperative lines, one action per line; no restating the obvious.
+- Expected: a single concrete, checkable outcome — no prose, no hedging.
+
+Keep the same set of cases and the same technique coverage; only tighten the wording.

--- a/prompts/styles/detailed-manual.md
+++ b/prompts/styles/detailed-manual.md
@@ -1,0 +1,10 @@
+STYLE FOR THIS RUN — DETAILED MANUAL.
+This affects ONLY naming, format, language, and tone. It does NOT change which 29119-4 techniques
+are applied, how many cases are produced, or the assertion-safety / stability rules.
+
+- Preconditions: explicit and exhaustive — environment, test data, auth state, entry point.
+- Steps: numbered and fully spelled out — exact element labels, exact input values, nothing implied.
+- Expected: a precise observable result, including WHERE to look (which element / region).
+- Write so a human tester with no prior context can follow the case end to end.
+
+Keep the same set of cases and the same technique coverage; only expand the detail and explicitness.

--- a/prompts/styles/gherkin.md
+++ b/prompts/styles/gherkin.md
@@ -1,0 +1,12 @@
+STYLE FOR THIS RUN — GHERKIN STEP FORMAT.
+This affects ONLY naming, format, language, and tone. It does NOT change which 29119-4 techniques
+are applied, how many cases are produced, or the assertion-safety / stability rules.
+
+- Write the steps in Given / When / Then form:
+  - **Given** … — preconditions / starting state (a clean page).
+  - **When** … — the single action under test.
+  - **Then** … — the observable, checkable outcome.
+- One **When** per case (one logical action); fold any setup into **Given** and the assertion into **Then**.
+- Titles stay plain prose (not Gherkin).
+
+Keep the same set of cases and the same technique coverage; only reshape the step phrasing.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -52,6 +52,8 @@ export interface ExploreInput {
   knowledgeDir?: string;
   /** Planning style: happy | negative | coverage | all (default all). */
   style?: string;
+  /** #80: pre-resolved text for the prompt's {{style}} slot (a house-style pack). Wins over `style`. */
+  styleText?: string;
   /** Test-case language (override; otherwise cfg.testCaseLanguage / env QA_TESTCASE_LANG / "English"). */
   language?: string;
   /** Visible browser (debug). */
@@ -165,7 +167,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
     currentRunId: runId,
     fresh: input.fresh,
   });
-  const styleText = styleDirective(input.style ?? "all");
+  const styleText = input.styleText ?? styleDirective(input.style ?? "all");
   const languageText = input.language ?? cfg.testCaseLanguage;
 
   // L1-01: resolve per-role tiers (override ?? profile tier), then build metered invokers.
@@ -502,7 +504,7 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
     currentRunId: runId,
     fresh: input.fresh,
   });
-  const styleText = styleDirective(input.style ?? "all");
+  const styleText = input.styleText ?? styleDirective(input.style ?? "all");
   const languageText = input.language ?? cfg.testCaseLanguage;
   // L1-01: resolve per-role tiers (override ?? profile tier), then build metered invokers.
   const visionTier = cfg.models.vision ?? cfg.models.reasoning;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,6 +21,7 @@ import { loadConfig } from "../config/index.js";
 import { runDesign, runAutomate } from "../agent/index.js";
 import { renderRunSummary, displayPath } from "../agent/summary.js";
 import { resolveRunDir, defaultRunsBaseDir, readInputFile } from "../fs/run-dir.js";
+import { resolveStyleText } from "../design/style.js";
 import { promoteCase, locatorFor } from "../promote/index.js";
 import type { PromoteDeps } from "../promote/index.js";
 import { makeModel, structuredMethodFor } from "../llm/index.js";
@@ -239,6 +240,9 @@ export function buildProgram(): Command {
       }) => {
         const config = resolveConfig({ routing: opts.routing, channel: opts.channel });
         const checklistText = opts.checklist ? await readInputFile(opts.checklist, "Checklist") : undefined;
+        // #80: --style resolves to a house-style pack file (prompts/styles/<v>.md or a path) → {{style}} slot,
+        // else the built-in inline hint (happy/negative/coverage). Methodology is never touched.
+        const styleText = await resolveStyleText(opts.style);
         process.stderr.write(`▸ Designing test cases for ${opts.url}${opts.session ? ` (session: ${opts.session})` : ""}…\n`);
         const progress = makeCliProgress({
           write: (s) => void process.stderr.write(s),
@@ -252,6 +256,7 @@ export function buildProgram(): Command {
           sessionFile: opts.sessionFile,
           checklistText,
           style: opts.style,
+          styleText,
           headed: opts.headed,
           fresh: opts.fresh,
           critique: opts.critique,

--- a/src/core/modalities/explore.ts
+++ b/src/core/modalities/explore.ts
@@ -7,6 +7,7 @@
  */
 import { readInputFile } from "../../fs/run-dir.js";
 import { runExploration } from "../../agent/index.js";
+import { resolveStyleText } from "../../design/style.js";
 import { renderRunSummary, displayPath } from "../../agent/summary.js";
 import { resolveConfig } from "../config.js";
 import { printCost } from "../reporting.js";
@@ -38,6 +39,9 @@ export const exploreModality: Modality = {
     const opts = ctx.flags as unknown as ExploreFlags;
     const config = resolveConfig({ backend: opts.backend, routing: opts.routing, channel: opts.channel });
     const checklistText = opts.checklist ? await readInputFile(opts.checklist, "Checklist") : undefined;
+    // #80: --style resolves to a house-style pack (prompts/styles/<v>.md or a path) → {{style}} slot,
+    // else the built-in inline hint. Methodology / assertion-safety are never touched.
+    const styleText = await resolveStyleText(opts.style);
     ctx.err(
       `▸ Exploring ${opts.url}${opts.session ? ` (session: ${opts.session})` : ""}${opts.checklist ? ` (checklist: ${opts.checklist})` : ""}…\n`,
     );
@@ -52,6 +56,7 @@ export const exploreModality: Modality = {
       headed: opts.headed,
       checklistText,
       style: opts.style,
+      styleText,
       fresh: opts.fresh,
       critique: opts.critique,
       onProgress: progress.event,

--- a/src/design/style.ts
+++ b/src/design/style.ts
@@ -1,0 +1,39 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { styleDirective } from "../checklist/index.js";
+
+export interface ResolveStyleOptions {
+  /** Directory of built-in / user style packs (default ./prompts/styles). */
+  stylesDir?: string;
+}
+
+/**
+ * #80 — resolve `--style <value>` into the text for the design prompt's {{style}} slot.
+ *
+ * Dual behavior, in order:
+ *  1. a house-style PACK — `<stylesDir>/<value>.md` (a built-in or user pack), or an explicit
+ *     `.md` path — loads that file's text verbatim into the slot;
+ *  2. otherwise the built-in inline HINT — `happy` / `negative` / `coverage` (via
+ *     {@link styleDirective}); anything else (incl. `all` / unset) → "" (balanced).
+ *
+ * Style only fills the {{style}} slot — it never touches the methodology or assertion-safety
+ * rules baked into the design prompt.
+ */
+export async function resolveStyleText(
+  value: string | undefined,
+  opts: ResolveStyleOptions = {},
+): Promise<string> {
+  if (!value) return styleDirective("all"); // "" — balanced
+  const stylesDir = opts.stylesDir ?? join("prompts", "styles");
+  // a named pack first (the common case), then an explicit path the user passed directly.
+  const candidates = [join(stylesDir, `${value}.md`), value];
+  for (const p of candidates) {
+    try {
+      const text = await readFile(p, "utf8");
+      if (text.trim()) return text;
+    } catch {
+      // not a readable file → try the next candidate
+    }
+  }
+  return styleDirective(value); // inline-hint fallback (happy/negative/coverage), else ""
+}

--- a/tests/unit/experiment.test.ts
+++ b/tests/unit/experiment.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { runExperiment } from "../../src/eval/experiment.js";
 import { PromptRegistry } from "../../src/prompts/index.js";
 import type { StructuredInvoke } from "../../src/llm/structured.js";
 import type { PageStudy } from "../../src/observe/index.js";
+
+// Isolate from the repo's committed prompts/ overrides (#80): these variants test LOCAL prompts,
+// so point overridesDir at a non-existent dir or the real prompts/qa-testcase-from-ui.md would win.
+const noOverrides = join(tmpdir(), "cairn-exp-no-overrides-xyz");
 
 const study: PageStudy = {
   url: "http://x",
@@ -15,9 +21,11 @@ const study: PageStudy = {
 // Baseline and candidate prompts differ by a marker; the fake invoke returns different cases based on it.
 const baseline = new PromptRegistry({
   local: { "qa-manual-test-designer": "M", "qa-testcase-from-ui": "BASE {{elements}}" },
+  overridesDir: noOverrides,
 });
 const candidate = new PromptRegistry({
   local: { "qa-manual-test-designer": "M", "qa-testcase-from-ui": "CANDIDATE {{elements}}" },
+  overridesDir: noOverrides,
 });
 
 const designInvoke: StructuredInvoke = async (schema, messages) => {

--- a/tests/unit/prompts-scaffold.test.ts
+++ b/tests/unit/prompts-scaffold.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { QA_TESTCASE_FROM_UI } from "../../src/prompts/local/qa-testcase-from-ui.js";
+
+/** Newlines normalized: the committed .md may be checked out CRLF on Windows (git autocrlf). */
+const lf = (s: string): string => s.replace(/\r\n/g, "\n");
+
+describe("committed prompts/ scaffold (#80)", () => {
+  it("prompts/qa-testcase-from-ui.md is the built-in design prompt VERBATIM (drift guard)", async () => {
+    const file = await readFile(join("prompts", "qa-testcase-from-ui.md"), "utf8");
+    expect(lf(file)).toBe(lf(QA_TESTCASE_FROM_UI));
+  });
+
+  it("ships the documented built-in style packs", async () => {
+    for (const name of ["concise", "gherkin", "detailed-manual"]) {
+      const text = await readFile(join("prompts", "styles", `${name}.md`), "utf8");
+      expect(text.trim().length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/unit/style.test.ts
+++ b/tests/unit/style.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveStyleText } from "../../src/design/style.js";
+
+const noDir = join(tmpdir(), "cairn-no-styles-xyz");
+
+describe("resolveStyleText (#80)", () => {
+  it("resolves a named style pack to the file's text (loaded into the {{style}} slot)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "cairn-styles-"));
+    try {
+      await writeFile(join(dir, "concise.md"), "STYLE: terse titles, short steps.");
+      const text = await resolveStyleText("concise", { stylesDir: dir });
+      expect(text).toBe("STYLE: terse titles, short steps.");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the inline hint for a built-in style name (no pack file)", async () => {
+    const text = await resolveStyleText("happy", { stylesDir: noDir });
+    expect(text).toContain("happy-path"); // styleDirective("happy")
+  });
+
+  it("unknown style with no file → empty (balanced, unchanged behavior)", async () => {
+    const text = await resolveStyleText("nonexistent-style", { stylesDir: noDir });
+    expect(text).toBe("");
+  });
+
+  it("undefined → empty", async () => {
+    const text = await resolveStyleText(undefined, { stylesDir: noDir });
+    expect(text).toBe("");
+  });
+
+  it("an explicit .md path → its text", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "cairn-styles-"));
+    try {
+      const p = join(dir, "house.md");
+      await writeFile(p, "HOUSE STYLE BODY");
+      const text = await resolveStyleText(p, { stylesDir: noDir });
+      expect(text).toBe("HOUSE STYLE BODY");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What

Ships the prompt-override capability as a **documented, first-class feature**, and promotes
`--style` so it can load a **house-style pack** into the design prompt's `{{style}}` slot —
**without touching the methodology**.

## How

**Committed `prompts/` scaffold** (so users see exactly what is overridable):
- `prompts/README.md` — documents the override precedence: Langfuse → `prompts/<name>.md` → built-in constant.
- `prompts/qa-testcase-from-ui.md` — the built-in design prompt **verbatim**, picked up by the default
  `overridesDir: "prompts"`. A drift-guard test (`prompts-scaffold.test.ts`) keeps it byte-identical to
  the `QA_TESTCASE_FROM_UI` constant, so the documented example can't silently rot.
- `prompts/styles/` — three built-in packs: `concise`, `gherkin`, `detailed-manual`.

**`--style` dual resolution** (`src/design/style.ts` → `resolveStyleText`):
1. a **pack** — `prompts/styles/<value>.md` (built-in or yours) or an explicit `.md` path → loaded into `{{style}}`;
2. otherwise the existing inline **hint** — `happy` / `negative` / `coverage` (via `styleDirective`), else balanced.

Wired through both `design` and `explore` via a new `styleText` input that wins over the inline `style`
(library callers can still pass `style` directly). Style only fills the `{{style}}` slot — it never
changes which 29119-4 techniques are covered or how assertions are written. Each built-in pack says so explicitly.

## Back-compat

- The short `--style happy|negative|coverage|all` behavior is unchanged (it's the fallback path).
- `prompts/` is a repo scaffold/example; `package.json` `files` is still `["dist"]`, so the npm package
  is unchanged and embedded library callers fall back to the built-in constant when they have no `prompts/`.
- The methodology / assertion-safety / stability sections of the design prompt are untouched.

## Tests

`style.test.ts` (pack resolution, inline-hint fallback, explicit path, undefined) and
`prompts-scaffold.test.ts` (verbatim drift guard + packs present). `experiment.test.ts` is now isolated
from the repo's committed overrides. `npm run build` / `npm run lint` / `npm test` (447 passed, 2 skipped) green.

> Note: `docs/prompts-and-styles.md` (the user-facing deep-dive) is added in the follow-up README-slimming PR (#81), which depends on this scaffold.

Closes #80