### PR TITLE
feat: multi-page / flow exploration — journeys across pages (--flow) (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-page / flow exploration — `--flow` / `--max-pages N` (#59).** Opt-in, Cairn now follows
+  in-app navigation from the start page to build a **page/flow graph** (nodes = studied pages, edges =
+  observed transitions), reusing the captured `--session` storageState across pages, and designs
+  **multi-page USER JOURNEY cases** (ordered steps that cross page boundaries) in **addition** to the
+  per-page cases. The crawl is pure browser mechanics (no LLM), bounded by `--max-pages` (default 3),
+  stays in-origin, dedupes revisits, and **never follows destructive links** (log out / delete) — so
+  the session and read-only safety hold across the whole walk. Journey steps are grounded **per page**
+  (a step only references elements that exist on its own page), and only journeys spanning ≥2 distinct
+  pages are kept. The graph + journeys are persisted in `report.json` (`flow`) and rendered in
+  `report.md`. Without `--flow`, single-page behavior is byte-for-byte unchanged. The design
+  methodology / assertion-safety rules are untouched.
+
 - **First-class prompt overrides + house-style packs (#80).** A committed `prompts/` scaffold now
   ships in the repo: a `prompts/README.md` documenting the override precedence (Langfuse →
   `prompts/<name>.md` → built-in constant) and `prompts/qa-testcase-from-ui.md` — the built-in design

--- a/src/agent/graph.ts
+++ b/src/agent/graph.ts
@@ -3,6 +3,9 @@ import { parseAriaSnapshot } from "../observe/parse-aria.js";
 import { analyzePage, type PageAnalysis } from "../analyze/index.js";
 import { designTestCases, type TestCase } from "../design/index.js";
 import { critiqueCases, type CritiqueDelta } from "../design/critique.js";
+import { crawlFlow, type FlowGraph } from "../flow/crawl.js";
+import { designJourneys } from "../flow/journey.js";
+import type { JourneyCase } from "../design/schema.js";
 import { generateSuite, type GeneratedSuite } from "../codegen/index.js";
 import { probeTransitions, type Transition } from "../probe/index.js";
 import { looksLikeLoginPage, expiredSessionMessage } from "../session/index.js";
@@ -25,6 +28,10 @@ export interface ExploreDeps {
   critiqueInvoke?: StructuredInvoke;
   /** #82: run the self-critique pass (prune + technique top-up). Conservative default: off. */
   critique?: boolean;
+  /** #59: follow in-app navigation, build a page/flow graph, design multi-page journey cases. Opt-in. */
+  flow?: boolean;
+  /** #59: max pages to crawl when `flow` is on (page cap — cost guardrail). Default 1 (single page). */
+  maxPages?: number;
   useVision: boolean;
   checklistText?: string;
   knowledgeText?: string;
@@ -76,6 +83,10 @@ export interface ExploreOutcome {
   attempts: number;
   /** #82: before/after delta of the self-critique pass (undefined when the pass didn't run). */
   critique?: CritiqueDelta;
+  /** #59: the page/flow graph crawled when `flow` is on (undefined for single-page runs). */
+  flowGraph?: FlowGraph;
+  /** #59: multi-page journey cases designed from the graph (undefined for single-page runs). */
+  journeys?: JourneyCase[];
 }
 
 /** Sprint 3: observe → identify → design → generateCode → validate ⇄ repair (bounded by maxRepair). */
@@ -247,9 +258,31 @@ export async function runExploreGraph(
     // durability is best-effort — never let it break the run.
   }
 
+  // ── flow exploration (opt-in, #59) ────────────────────────────────────────
+  // Crawl in-app navigation → page/flow graph → multi-page journey cases. Runs AFTER per-page design
+  // so single-page output is unchanged; best-effort so a crawl failure can't sink the per-page cases.
+  let flowGraph: FlowGraph | undefined;
+  let journeys: JourneyCase[] | undefined;
+  if (deps.flow && (deps.maxPages ?? 1) > 1) {
+    deps.onProgress?.(`flow — crawling up to ${deps.maxPages} pages (reusing the session)…`);
+    try {
+      const startNode = { url: study.url, study, verified: verified.filter((v) => v.count >= 1), transitions };
+      flowGraph = await crawlFlow(startNode, { gateway: deps.gateway, onProgress: deps.onProgress }, { maxPages: deps.maxPages ?? 1 });
+      deps.onProgress?.(`flow — graph: ${flowGraph.nodes.length} pages, ${flowGraph.edges.length} transitions`);
+      journeys = await designJourneys(
+        { graph: flowGraph, language: deps.languageText },
+        { invoke: deps.designInvoke, prompts: deps.prompts },
+      );
+      deps.onProgress?.(`flow — ${journeys.length} journey case(s) spanning ≥2 pages`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message.split("\n")[0] : String(e);
+      deps.onProgress?.(`flow — skipped (${msg})`); // best-effort: keep the per-page cases
+    }
+  }
+
   // ── codeless short-circuit ────────────────────────────────────────────────
   if (deps.codeless) {
-    return { study, analysis, verified, transitions, testCases, stoppedEarly: false, attempts: 0, critique };
+    return { study, analysis, verified, transitions, testCases, stoppedEarly: false, attempts: 0, critique, flowGraph, journeys };
   }
 
   // ── generate → validate → repair (reuse runRepairLoop) ───────────────────
@@ -298,5 +331,7 @@ export async function runExploreGraph(
     stoppedEarly,
     attempts,
     critique,
+    flowGraph,
+    journeys,
   };
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -22,6 +22,7 @@ import { validateSuite, type ValidationReport } from "../validate/index.js";
 import { SessionStore } from "../session/index.js";
 import { resolveRunDir, defaultRunsBaseDir } from "../fs/run-dir.js";
 import { runExploreGraph } from "./graph.js";
+import { flowReportPayload } from "../flow/crawl.js";
 import { finalizeFailure } from "./finalize.js";
 import { runRepairLoop } from "./repair-loop.js";
 import { buildTestCaseDocs } from "./testcase-docs.js";
@@ -64,6 +65,10 @@ export interface ExploreInput {
   fresh?: boolean;
   /** #82: run the design-time self-critique pass (prune + technique top-up) on the worker tier. Default off. */
   critique?: boolean;
+  /** #59: follow in-app navigation and design multi-page journey cases. Default off (single page). */
+  flow?: boolean;
+  /** #59: max pages to crawl when `flow` is on (page cap — cost guardrail). */
+  maxPages?: number;
 }
 
 export interface ExploreResult {
@@ -184,6 +189,8 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
     // #82: self-critique runs on the worker tier (CAIRN_ROLE_WORKER) to bound cost; built only when opted in.
     critiqueInvoke: input.critique ? router.invoke("worker", codegenTier) : undefined,
     critique: input.critique,
+    flow: input.flow,
+    maxPages: input.maxPages,
     useVision: analyzeTier.supportsVision,
     checklistText: checklistFormatted,
     knowledgeText,
@@ -331,6 +338,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
         const cost = router.ledger.report(); // L1-01: per-role cost + tokens for this run
         const budgetReport: BudgetReport = { used: budget.spent, max: budget.max }; // L1-04 (Box 3)
         const stoppedEarly = Boolean(out.stoppedEarly); // L1-04 (Box 2)
+        const flowReport = flowReportPayload(out.flowGraph, out.journeys); // #59: compact graph + journeys (no screenshots)
 
         // #39: also emit ATC/MTC case docs (.md) — explore now produces the human-readable cases like
         // design, so manual MTC cases are visible deliverables (not just buried inside report.md).
@@ -356,6 +364,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
           budget: budgetReport,
           stoppedEarly,
           critique: out.critique, // #82: prune/top-up delta (undefined when the pass didn't run)
+          flow: flowReport, // #59: page/flow graph + journey cases (undefined for single-page runs)
           history: {
             priorRuns: priorRuns.length,
             bestPriorGreen: bestPriorGreen ?? null,
@@ -377,6 +386,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
             cost,
             budget: budgetReport,
             stoppedEarly,
+            journeys: out.journeys,
           }),
         );
         const green = validation ? `${Math.round(validation.greenRatio * 100)}%` : "—";
@@ -521,6 +531,8 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
     // #82: self-critique runs on the worker tier (CAIRN_ROLE_WORKER) to bound cost; built only when opted in.
     critiqueInvoke: input.critique ? router.invoke("worker", codegenTier) : undefined,
     critique: input.critique,
+    flow: input.flow,
+    maxPages: input.maxPages,
     useVision: analyzeTier.supportsVision,
     checklistText: formatChecklist(checklistItems),
     knowledgeText,
@@ -628,6 +640,7 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
           scores,
           cost,
           critique: out.critique, // #82: prune/top-up delta (undefined when the pass didn't run)
+          flow: flowReportPayload(out.flowGraph, out.journeys), // #59: graph + journeys (undefined single-page)
         });
         await runWriter.writeLog(
           [...logLines, "", `summary: mode=design testCases=${out.testCases.length} suite=${suite} runId=${runId}`].join("\n"),

--- a/src/artifacts/report.ts
+++ b/src/artifacts/report.ts
@@ -1,5 +1,6 @@
 import type { ElementRef } from "../browser/types.js";
 import type { TestCase } from "../design/index.js";
+import type { JourneyCase } from "../design/schema.js";
 import type { ValidationReport } from "../validate/index.js";
 import type { Score } from "../eval/scorers.js";
 import { METRIC_LEGEND, dirGlyph } from "../eval/legend.js";
@@ -28,6 +29,8 @@ export interface ReportInput {
   budget?: { used: number; max: number };
   /** The repair loop bailed early because it stopped making progress (L1-04, Box 2). */
   stoppedEarly?: boolean;
+  /** #59: multi-page journey cases (rendered as a section when present). */
+  journeys?: JourneyCase[];
 }
 
 function mark(status: string): string {
@@ -113,6 +116,20 @@ export function renderReportMd(r: ReportInput): string {
     lines.push(`- ⇒ ${tc.expected}`);
     if (tc.elementRefs.length) lines.push(`- refs: ${tc.elementRefs.join(", ")}`);
     lines.push("");
+  }
+
+  // #59: multi-page user journeys (only present on a --flow run).
+  if (r.journeys && r.journeys.length > 0) {
+    lines.push(`## User journeys (${r.journeys.length}) — multi-page`, "");
+    for (const j of r.journeys) {
+      lines.push(`### ${j.id} · [${j.priority} · ${j.technique}] ${j.title}`);
+      if (j.preconditions.length) lines.push(`- Preconditions: ${j.preconditions.join("; ")}`);
+      for (const s of j.steps) {
+        const refs = s.elementRefs.length ? ` [refs: ${s.elementRefs.join(", ")}]` : "";
+        lines.push(`- (${s.page}) ${s.action}${refs}`);
+      }
+      lines.push(`- ⇒ ${j.expected}`, "");
+    }
   }
   return lines.join("\n");
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -114,6 +114,8 @@ export function buildProgram(): Command {
     .option("--fresh", "ignore prior runs for this URL — generate a full set, don't dedupe against past cases")
     .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
     .option("--critique", "self-critique pass after design: prune weak cases + top up technique gaps (1 extra worker-tier LLM call)")
+    .option("--flow", "follow in-app navigation across pages and design multi-page journey cases (opt-in)")
+    .option("--max-pages <n>", "max pages to crawl with --flow (page cap; default 3)")
     .action(async (opts: Record<string, unknown>) => {
       await runModality("explore", opts);
     });
@@ -224,6 +226,8 @@ export function buildProgram(): Command {
     .option("--fresh", "ignore prior runs for this URL — generate a full set, don't dedupe against past cases")
     .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
     .option("--critique", "self-critique pass after design: prune weak cases + top up technique gaps (1 extra worker-tier LLM call)")
+    .option("--flow", "follow in-app navigation across pages and design multi-page journey cases (opt-in)")
+    .option("--max-pages <n>", "max pages to crawl with --flow (page cap; default 3)")
     .option("--headed", "visible browser (debug)")
     .action(
       async (opts: {
@@ -237,6 +241,8 @@ export function buildProgram(): Command {
         routing?: string;
         fresh?: boolean;
         critique?: boolean;
+        flow?: boolean;
+        maxPages?: string;
       }) => {
         const config = resolveConfig({ routing: opts.routing, channel: opts.channel });
         const checklistText = opts.checklist ? await readInputFile(opts.checklist, "Checklist") : undefined;
@@ -260,6 +266,8 @@ export function buildProgram(): Command {
           headed: opts.headed,
           fresh: opts.fresh,
           critique: opts.critique,
+          flow: opts.flow,
+          maxPages: opts.flow ? Number(opts.maxPages) || 3 : undefined,
           onProgress: progress.event,
         }).finally(() => progress.stop());
 

--- a/src/core/modalities/explore.ts
+++ b/src/core/modalities/explore.ts
@@ -28,6 +28,8 @@ interface ExploreFlags {
   routing?: string;
   fresh?: boolean;
   critique?: boolean;
+  flow?: boolean;
+  maxPages?: string;
 }
 
 export const exploreModality: Modality = {
@@ -59,6 +61,8 @@ export const exploreModality: Modality = {
       styleText,
       fresh: opts.fresh,
       critique: opts.critique,
+      flow: opts.flow,
+      maxPages: opts.flow ? Number(opts.maxPages) || 3 : undefined,
       onProgress: progress.event,
     }).finally(() => progress.stop());
 

--- a/src/design/schema.ts
+++ b/src/design/schema.ts
@@ -45,3 +45,35 @@ export const DesignResultSchema = z.object({ testCases: z.array(DesignedCaseSche
 export interface TestCase extends DesignedCase {
   id: string;
 }
+
+/**
+ * One step of a multi-page journey (#59): which page it runs on, the action, and the element refs it
+ * touches. Refs are grounded PER PAGE (a step only references elements that exist on its own page).
+ */
+export const JourneyStepSchema = z.object({
+  /** URL of the page this step runs on (must be one of the graph's node URLs). */
+  page: z.string(),
+  /** Human-readable step (real element labels). */
+  action: z.string(),
+  elementRefs: z.array(z.string()).default([]),
+});
+export type JourneyStep = z.infer<typeof JourneyStepSchema>;
+
+/** A user journey that spans ≥2 pages — an ordered list of cross-page steps (#59). */
+export const DesignedJourneySchema = z.object({
+  title: z.string(),
+  technique: TestTechniqueSchema,
+  type: TestTypeSchema.default("Positive"),
+  preconditions: z.array(z.string()).default([]),
+  steps: z.array(JourneyStepSchema),
+  expected: z.string(),
+  priority: TestPrioritySchema,
+});
+export type DesignedJourney = z.infer<typeof DesignedJourneySchema>;
+
+export const JourneyResultSchema = z.object({ journeys: z.array(DesignedJourneySchema) });
+
+/** Final journey case with an assigned id. */
+export interface JourneyCase extends DesignedJourney {
+  id: string;
+}

--- a/src/flow/crawl.ts
+++ b/src/flow/crawl.ts
@@ -1,0 +1,147 @@
+import type { BrowserGateway } from "../browser/gateway.js";
+import type { VerifiedElement } from "../browser/types.js";
+import { parseAriaSnapshot } from "../observe/parse-aria.js";
+import type { PageStudy } from "../observe/index.js";
+import type { Transition } from "../probe/index.js";
+import type { JourneyCase } from "../design/schema.js";
+
+/** One studied page in the flow graph. */
+export interface FlowNode {
+  url: string;
+  study: PageStudy;
+  verified: VerifiedElement[];
+  /** Observed safe transitions on this page (empty for crawled nodes — kept lean for cost). */
+  transitions: Transition[];
+}
+
+/** An observed navigation between two pages (a link click that changed the URL). */
+export interface FlowEdge {
+  from: string;
+  to: string;
+  via: { ref: string; role: string; name?: string };
+}
+
+/** The app's page/flow graph: studied pages + observed transitions between them. */
+export interface FlowGraph {
+  nodes: FlowNode[];
+  edges: FlowEdge[];
+}
+
+export interface CrawlDeps {
+  gateway: BrowserGateway;
+  onProgress?: (event: string) => void;
+}
+
+/**
+ * Destructive / session-ending link names — NEVER followed during a crawl (would log us out or
+ * mutate data mid-walk, breaking both session reuse and read-only safety).
+ */
+const DESTRUCTIVE = /\b(log\s?out|sign\s?out|logout|signout|delete|remove|deactivate|close account)\b/i;
+
+/** Same-origin check — the crawl stays inside the app under test, never wanders to external sites. */
+function sameOrigin(a: string, b: string): boolean {
+  try {
+    return new URL(a).origin === new URL(b).origin;
+  } catch {
+    return false;
+  }
+}
+
+/** Normalize a URL for the visited set: drop the hash + a trailing slash (same page, different anchor). */
+function norm(u: string): string {
+  try {
+    const url = new URL(u);
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return u.replace(/#.*$/, "").replace(/\/$/, "");
+  }
+}
+
+/**
+ * #59 — follow in-app navigation from a start page to build the page/flow graph (nodes = studied
+ * pages, edges = observed transitions). No LLM — pure browser mechanics over the gateway, reusing the
+ * gateway's storageState across pages. Bounded by `maxPages`; destructive/external links are skipped.
+ *
+ * Per link: re-observe the source page (so its refs are valid again), click the link, observe where it
+ * lands. A new in-app URL becomes a node (studied + verified); a revisit only records the edge.
+ */
+export async function crawlFlow(
+  start: FlowNode,
+  deps: CrawlDeps,
+  opts: { maxPages: number },
+): Promise<FlowGraph> {
+  const { gateway } = deps;
+  const nodes: FlowNode[] = [start];
+  const edges: FlowEdge[] = [];
+  const visited = new Set<string>([norm(start.url)]);
+  const queue: FlowNode[] = [start];
+
+  while (queue.length > 0 && nodes.length < opts.maxPages) {
+    const node = queue.shift()!;
+    const links = node.study.elements.filter(
+      (e) => e.role === "link" && e.interactive && !DESTRUCTIVE.test(e.name ?? ""),
+    );
+
+    for (const link of links) {
+      if (nodes.length >= opts.maxPages) break;
+
+      // Reset to the source page so its synthesized refs resolve, then follow the link.
+      await gateway.observe({ url: node.url });
+      const clicked = await gateway.act({ kind: "click", ref: link.ref });
+      if (!clicked.ok) continue;
+      const obs = await gateway.observe({});
+
+      // Stay in-app; never leave the origin under test.
+      if (!sameOrigin(start.url, obs.url)) continue;
+
+      edges.push({ from: node.url, to: obs.url, via: { ref: link.ref, role: link.role, name: link.name } });
+
+      const key = norm(obs.url);
+      if (visited.has(key)) continue; // revisit → edge only, no new node
+      visited.add(key);
+
+      const elements = parseAriaSnapshot(obs.ariaSnapshot);
+      const study: PageStudy = {
+        url: obs.url,
+        screenshotB64: obs.screenshotB64,
+        ariaYaml: obs.ariaSnapshot,
+        capturedBy: obs.capturedBy,
+        elements,
+        consoleErrors: obs.consoleErrors,
+      };
+      let verified: VerifiedElement[];
+      try {
+        verified = await gateway.verify(elements);
+      } catch {
+        verified = elements.map((e) => ({ ...e, count: -1, verified: false }));
+      }
+      const next: FlowNode = { url: obs.url, study, verified, transitions: [] };
+      nodes.push(next);
+      queue.push(next);
+      deps.onProgress?.(`flow — visited ${obs.url} (${nodes.length}/${opts.maxPages})`);
+    }
+  }
+
+  return { nodes, edges };
+}
+
+/** Compact flow payload for report.json — pages + edges + journeys, WITHOUT page screenshots/ARIA. */
+export interface FlowReport {
+  pages: { url: string; interactive: number }[];
+  edges: FlowEdge[];
+  journeys: JourneyCase[];
+}
+
+/** Build the report.json `flow` block (undefined when no crawl happened). Pure — unit-testable. */
+export function flowReportPayload(graph?: FlowGraph, journeys?: JourneyCase[]): FlowReport | undefined {
+  if (!graph) return undefined;
+  return {
+    pages: graph.nodes.map((n) => ({
+      url: n.url,
+      interactive: n.verified.filter((v) => v.interactive && v.count >= 1).length,
+    })),
+    edges: graph.edges,
+    journeys: journeys ?? [],
+  };
+}

--- a/src/flow/journey.ts
+++ b/src/flow/journey.ts
@@ -1,0 +1,73 @@
+import { HumanMessage } from "@langchain/core/messages";
+import type { StructuredInvoke } from "../llm/structured.js";
+import type { PromptRegistry } from "../prompts/index.js";
+import { JourneyResultSchema, type DesignedJourney, type JourneyCase } from "../design/schema.js";
+import type { FlowGraph } from "./crawl.js";
+
+/** Distinct page URLs the journey's steps touch. */
+const distinctPages = (j: DesignedJourney): number => new Set(j.steps.map((s) => s.page)).size;
+
+/**
+ * Per-page grounding (anti-hallucination): each step keeps only the refs that actually exist on
+ * THAT step's page. Mirrors `designTestCases` ref filtering, but page-aware for journeys.
+ */
+export function groundJourney(j: DesignedJourney, refsByPage: Map<string, Set<string>>): DesignedJourney {
+  return {
+    ...j,
+    steps: j.steps.map((s) => ({
+      ...s,
+      elementRefs: s.elementRefs.filter((r) => (refsByPage.get(s.page) ?? new Set<string>()).has(r)),
+    })),
+  };
+}
+
+export interface JourneyInput {
+  graph: FlowGraph;
+  /** Case language (default "English"). */
+  language?: string;
+}
+
+export interface JourneyDeps {
+  invoke: StructuredInvoke;
+  prompts: PromptRegistry;
+}
+
+/**
+ * #59 — design multi-page journey cases from the flow graph (reasoner tier). Refs are grounded
+ * per page; only journeys that span ≥2 distinct pages survive. Returns [] for a single-node graph
+ * (no journey is possible) without calling the LLM.
+ */
+export async function designJourneys(input: JourneyInput, deps: JourneyDeps): Promise<JourneyCase[]> {
+  const { graph } = input;
+  if (graph.nodes.length < 2) return []; // a journey needs ≥2 pages
+
+  const refsByPage = new Map(
+    graph.nodes.map((n) => [n.url, new Set(n.verified.filter((v) => v.count >= 1).map((v) => v.ref))]),
+  );
+
+  const pages = graph.nodes
+    .map((n) => {
+      const els = n.verified
+        .filter((v) => v.interactive && v.count >= 1)
+        .map((v) => `  ${v.ref} · ${v.role}${v.name ? ` "${v.name}"` : ""}`)
+        .join("\n");
+      return `PAGE ${n.url}\n${els || "  (no interactive elements)"}`;
+    })
+    .join("\n\n");
+  const edges =
+    graph.edges
+      .map((e) => `- ${e.from} --(${e.via.role}${e.via.name ? ` "${e.via.name}"` : ""})--> ${e.to}`)
+      .join("\n") || "(no observed transitions)";
+
+  const prompt = await deps.prompts.getPrompt("qa-journey-from-flow", {
+    pages,
+    edges,
+    language: input.language ?? "English",
+  });
+  const result = await deps.invoke(JourneyResultSchema, [new HumanMessage(prompt.text)]);
+
+  return result.journeys
+    .map((j) => groundJourney(j, refsByPage))
+    .filter((j) => distinctPages(j) >= 2) // enforce the cross-page invariant
+    .map((j, i) => ({ ...j, id: `journey-${i + 1}` }));
+}

--- a/src/prompts/local/index.ts
+++ b/src/prompts/local/index.ts
@@ -1,6 +1,7 @@
 import { QA_TESTCASE_FROM_UI } from "./qa-testcase-from-ui.js";
 import { QA_MANUAL_TEST_DESIGNER } from "./qa-manual-test-designer.js";
 import { QA_CASE_CRITIQUE } from "./qa-case-critique.js";
+import { QA_JOURNEY_FROM_FLOW } from "./qa-journey-from-flow.js";
 import { QA_PLAYWRIGHT_TS_WRITER } from "./qa-playwright-ts-writer.js";
 import { IDENTIFY_ELEMENTS } from "./identify-elements.js";
 import { JUDGE_TEST_CASES } from "./judge-test-cases.js";
@@ -12,6 +13,7 @@ export const LOCAL_PROMPTS: Record<string, string> = {
   "qa-testcase-from-ui": QA_TESTCASE_FROM_UI,
   "qa-manual-test-designer": QA_MANUAL_TEST_DESIGNER,
   "qa-case-critique": QA_CASE_CRITIQUE,
+  "qa-journey-from-flow": QA_JOURNEY_FROM_FLOW,
   "qa-playwright-ts-writer": QA_PLAYWRIGHT_TS_WRITER,
   "identify-elements": IDENTIFY_ELEMENTS,
   "judge-test-cases": JUDGE_TEST_CASES,

--- a/src/prompts/local/qa-journey-from-flow.ts
+++ b/src/prompts/local/qa-journey-from-flow.ts
@@ -1,0 +1,28 @@
+/**
+ * #59 — journey design prompt. Generates multi-page USER JOURNEY cases from the observed page/flow
+ * graph. SEPARATE from the per-page design prompt — it does not redesign per-page cases and does not
+ * touch the methodology / assertion-safety rules in `qa-testcase-from-ui`.
+ */
+export const QA_JOURNEY_FROM_FLOW = `You are an experienced QA engineer. From the observed page/flow GRAPH below, design end-to-end USER JOURNEY test cases that span MULTIPLE pages (e.g. login → dashboard → action).
+Write all titles, actions, expected in {{language}} — do not mix languages.
+
+Pages studied (each with its REAL interactive elements — ref · role · name). In a step's elementRefs use ONLY refs from THAT step's page — never invent refs and never use a ref from another page:
+{{pages}}
+
+Observed transitions between pages (act→observe — these are REAL navigations you may rely on):
+{{edges}}
+
+Design journeys that cross page boundaries. For each journey:
+- title — concise title of the end-to-end flow;
+- technique — applied 29119-4 technique (state-transition fits multi-step flows well);
+- type — "Positive" | "Negative";
+- preconditions — what must be true before the journey starts (e.g. "a registered user");
+- steps — an ORDERED list; each step has: page (one of the page URLs above), action (real labels), elementRefs (refs from THAT page only);
+- expected — a single verifiable end state;
+- priority — critical | high | medium | low.
+
+RULES (a journey is a TEST — keep it safe and runnable):
+- A journey MUST span at least TWO distinct pages (≥2 different page URLs across its steps). Single-page checks are NOT journeys — omit them.
+- Read-only by default: assert visibility/state. For destructive/irreversible controls (Delete, Remove, Submit that writes, Log out) only assert the control is VISIBLE — do NOT perform the action.
+- Each step is grounded on its page's observed elements; do not assume elements the graph did not show.
+- Prefer journeys that follow the OBSERVED transitions above (they are known to work).`;

--- a/tests/unit/__snapshots__/cli-modalities.test.ts.snap
+++ b/tests/unit/__snapshots__/cli-modalities.test.ts.snap
@@ -64,6 +64,9 @@ Options:
                          (OpenRouter worker) (sets LLM_ROUTING)
   --critique             self-critique pass after design: prune weak cases + top
                          up technique gaps (1 extra worker-tier LLM call)
+  --flow                 follow in-app navigation across pages and design
+                         multi-page journey cases (opt-in)
+  --max-pages <n>        max pages to crawl with --flow (page cap; default 3)
   -h, --help             display help for command
 "
 `;

--- a/tests/unit/cli-modalities.test.ts
+++ b/tests/unit/cli-modalities.test.ts
@@ -113,10 +113,12 @@ describe("explore parity (C1-02)", () => {
       "--fresh",
       "--routing",
       "--critique",
+      "--flow",
+      "--max-pages",
     ]) {
       expect(longs, `explore should accept ${f}`).toContain(f);
     }
-    expect(longs).toHaveLength(11); // + --critique (opt-in design-time self-critique pass, #82)
+    expect(longs).toHaveLength(13); // + --critique (#82) + --flow / --max-pages (#59)
   });
 
   it("maps flags to runExploration the same way as before the refactor", async () => {

--- a/tests/unit/flow-crawl.test.ts
+++ b/tests/unit/flow-crawl.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { crawlFlow, type FlowNode } from "../../src/flow/crawl.js";
+import { parseAriaSnapshot } from "../../src/observe/parse-aria.js";
+import type { BrowserGateway } from "../../src/browser/gateway.js";
+
+/**
+ * A scripted in-memory app: each page has an ARIA snapshot + a map ref→target page.
+ * The fake gateway is a state machine — observe({url}) navigates, observe({}) returns the
+ * current page, act(click) follows a link. Enough to exercise crawl WITHOUT a browser.
+ */
+interface FakePage {
+  url: string;
+  aria: string;
+  links: Record<string, string>; // synthesized ref (e1, e2…) → target page key
+}
+
+function fakeGateway(pages: Record<string, FakePage>, startKey: string): BrowserGateway {
+  let current = startKey;
+  const keyOfUrl = (u: string): string =>
+    Object.keys(pages).find((k) => pages[k]!.url === u) ?? startKey;
+  return {
+    observe: async ({ url }) => {
+      if (url) current = keyOfUrl(url);
+      const p = pages[current]!;
+      return { url: p.url, screenshotB64: "", ariaSnapshot: p.aria, capturedBy: "lib" };
+    },
+    act: async ({ kind, ref }) => {
+      if (kind === "click" && ref) {
+        const target = pages[current]!.links[ref];
+        if (target) current = target;
+      }
+      return { ok: true, ref };
+    },
+    verify: async (els) => els.map((e) => ({ ...e, count: 1, verified: true })),
+    getState: async () => ({ visible: true, enabled: true }),
+    session: () => ({ load: async () => undefined, save: async () => ({ cookies: [], origins: [] }) }),
+    runTests: async () => ({ passed: 0, failed: 0, flaky: 0 }),
+    close: async () => undefined,
+  };
+}
+
+const aria = (lines: string[]): string => lines.join("\n");
+const nodeFrom = (page: FakePage): FlowNode => {
+  const study = {
+    url: page.url,
+    screenshotB64: "",
+    ariaYaml: page.aria,
+    capturedBy: "lib" as const,
+    elements: parseAriaSnapshot(page.aria),
+  };
+  return { url: page.url, study, verified: study.elements.map((e) => ({ ...e, count: 1, verified: true })), transitions: [] };
+};
+
+describe("crawlFlow (#59)", () => {
+  it("follows in-app links to build a page graph, bounded by maxPages", async () => {
+    const pages: Record<string, FakePage> = {
+      home: {
+        url: "http://app/home",
+        aria: aria(['- link "Dashboard"', '- link "Log out"', '- button "Save"']),
+        links: { e1: "dash" }, // e1 = Dashboard link; e2 = Log out (destructive, must be skipped); e3 = button (not a link)
+      },
+      dash: {
+        url: "http://app/dashboard",
+        aria: aria(['- link "Home"', '- heading "Dashboard"']),
+        links: { e1: "home" },
+      },
+    };
+    const gw = fakeGateway(pages, "home");
+    const graph = await crawlFlow(nodeFrom(pages.home!), { gateway: gw }, { maxPages: 2 });
+
+    expect(graph.nodes.map((n) => n.url)).toEqual(["http://app/home", "http://app/dashboard"]);
+    expect(graph.edges).toHaveLength(1);
+    expect(graph.edges[0]).toMatchObject({ from: "http://app/home", to: "http://app/dashboard", via: { ref: "e1" } });
+  });
+
+  it("never clicks a destructive (Log out) link — session safety", async () => {
+    let loggedOut = false;
+    const pages: Record<string, FakePage> = {
+      home: { url: "http://app/home", aria: aria(['- link "Log out"']), links: { e1: "out" } },
+      out: { url: "http://app/login", aria: aria(['- heading "Sign in"']), links: {} },
+    };
+    const gw = fakeGateway(pages, "home");
+    const realAct = gw.act;
+    gw.act = async (a) => {
+      if (a.kind === "click" && a.ref === "e1") loggedOut = true;
+      return realAct(a);
+    };
+    const graph = await crawlFlow(nodeFrom(pages.home!), { gateway: gw }, { maxPages: 5 });
+
+    expect(loggedOut).toBe(false);
+    expect(graph.nodes).toHaveLength(1); // only the start page
+    expect(graph.edges).toHaveLength(0);
+  });
+
+  it("dedupes revisits and stays in-app (external links skipped)", async () => {
+    const pages: Record<string, FakePage> = {
+      home: {
+        url: "http://app/home",
+        aria: aria(['- link "Dashboard"', '- link "Docs"']),
+        links: { e1: "dash", e2: "ext" },
+      },
+      dash: { url: "http://app/dashboard", aria: aria(['- link "Home"']), links: { e1: "home" } },
+      ext: { url: "http://other.com/docs", aria: aria(['- heading "Docs"']), links: {} },
+    };
+    const gw = fakeGateway(pages, "home");
+    const graph = await crawlFlow(nodeFrom(pages.home!), { gateway: gw }, { maxPages: 5 });
+
+    // home + dashboard only; external other.com skipped; dashboard→home is a revisit (no new node)
+    expect(graph.nodes.map((n) => n.url).sort()).toEqual(["http://app/dashboard", "http://app/home"]);
+  });
+});

--- a/tests/unit/flow-journey.test.ts
+++ b/tests/unit/flow-journey.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { designJourneys, groundJourney } from "../../src/flow/journey.js";
+import { PromptRegistry } from "../../src/prompts/index.js";
+import type { StructuredInvoke } from "../../src/llm/structured.js";
+import type { FlowGraph, FlowNode } from "../../src/flow/crawl.js";
+import type { DesignedJourney } from "../../src/design/schema.js";
+
+const node = (url: string, refs: string[]): FlowNode => ({
+  url,
+  study: { url, screenshotB64: "", ariaYaml: "", capturedBy: "lib", elements: [] },
+  verified: refs.map((ref) => ({ ref, role: "button", name: `el-${ref}`, interactive: true, rank: 3, count: 1, verified: true })),
+  transitions: [],
+});
+
+const graph: FlowGraph = {
+  nodes: [node("http://app/login", ["e1", "e2"]), node("http://app/dash", ["e9"])],
+  edges: [{ from: "http://app/login", to: "http://app/dash", via: { ref: "e2", role: "link", name: "Sign in" } }],
+};
+
+describe("groundJourney (#59)", () => {
+  it("filters each step's refs to those present on THAT step's page", () => {
+    const j: DesignedJourney = {
+      title: "Login then open dashboard",
+      technique: "state-transition",
+      type: "Positive",
+      preconditions: [],
+      steps: [
+        { page: "http://app/login", action: "fill + submit", elementRefs: ["e1", "eGHOST"] },
+        { page: "http://app/dash", action: "see dashboard", elementRefs: ["e9", "e1"] }, // e1 belongs to login, not dash
+      ],
+      expected: "dashboard visible",
+      priority: "high",
+    };
+    const refsByPage = new Map([
+      ["http://app/login", new Set(["e1", "e2"])],
+      ["http://app/dash", new Set(["e9"])],
+    ]);
+    const grounded = groundJourney(j, refsByPage);
+    expect(grounded.steps[0]?.elementRefs).toEqual(["e1"]); // eGHOST dropped
+    expect(grounded.steps[1]?.elementRefs).toEqual(["e9"]); // e1 (wrong page) dropped
+  });
+});
+
+describe("designJourneys (#59)", () => {
+  it("generates grounded journey cases spanning ≥2 pages; drops single-page ones", async () => {
+    const fake: StructuredInvoke = async (schema) =>
+      schema.parse({
+        journeys: [
+          {
+            title: "Login → dashboard",
+            technique: "state-transition",
+            type: "Positive",
+            preconditions: ["a registered user"],
+            steps: [
+              { page: "http://app/login", action: "Sign in", elementRefs: ["e2"] },
+              { page: "http://app/dash", action: "See dashboard", elementRefs: ["e9", "eGHOST"] },
+            ],
+            expected: "dashboard is visible",
+            priority: "high",
+          },
+          {
+            // single-page "journey" — must be dropped (a journey spans ≥2 pages)
+            title: "Just login",
+            technique: "exploratory",
+            type: "Positive",
+            preconditions: [],
+            steps: [{ page: "http://app/login", action: "look", elementRefs: ["e1"] }],
+            expected: "login form visible",
+            priority: "low",
+          },
+        ],
+      });
+
+    const journeys = await designJourneys(
+      { graph },
+      { invoke: fake, prompts: new PromptRegistry() },
+    );
+
+    expect(journeys).toHaveLength(1);
+    expect(journeys[0]?.id).toBe("journey-1");
+    expect(journeys[0]?.steps).toHaveLength(2);
+    expect(journeys[0]?.steps[1]?.elementRefs).toEqual(["e9"]); // eGHOST grounded out per page
+  });
+
+  it("empty graph (single node) → no journeys", async () => {
+    const fake: StructuredInvoke = async (schema) => schema.parse({ journeys: [] });
+    const journeys = await designJourneys(
+      { graph: { nodes: [node("http://app/x", ["e1"])], edges: [] } },
+      { invoke: fake, prompts: new PromptRegistry() },
+    );
+    expect(journeys).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

First step of Explore-Depth: move from single-page testing to **crawling the app graph** and
generating **multi-page user-journey cases** (e.g. login → dashboard → action), reusing the captured
session across pages. Fully **opt-in** behind `--flow` / `--max-pages N`.

## How

- **`src/flow/crawl.ts` (`crawlFlow`)** — pure browser mechanics (no LLM): from the start page it
  follows in-app links, reusing the gateway's `storageState`, to build a **page/flow graph** (nodes =
  studied pages, edges = observed transitions). Per link: re-observe the source (refs valid again) →
  click → observe where it lands. Bounded by `maxPages`, stays **in-origin**, dedupes revisits, and
  **never follows destructive links** (`log out` / `delete` / …) — so session reuse and read-only
  safety hold across the whole walk.
- **`src/flow/journey.ts` (`designJourneys` + `groundJourney`)** + a separate `qa-journey-from-flow`
  prompt — reasoner-tier design of cross-page journeys. Each step's refs are grounded **per page**
  (a step only references elements that exist on its own page), and only journeys spanning **≥2
  distinct pages** survive.
- **Schema** (`src/design/schema.ts`): `JourneyStep` / `DesignedJourney` / `JourneyResult` + `JourneyCase`.
- **Pipeline**: wired into `runExploreGraph` right **after** per-page design (best-effort — a crawl
  failure can't sink the per-page cases), gated by `deps.flow && maxPages>1`. The graph + journeys are
  persisted in `report.json` (`flow`, compact — no screenshots) and rendered in `report.md`.
- **CLI**: `--flow` + `--max-pages N` (default 3) on `explore` and `design`.

## Constraints honored

- **Single-page byte-for-byte unchanged** without `--flow` (the whole block is gated).
- Methodology / assertion-safety / stability rules in the design prompt are **untouched**; journeys
  carry their own read-only / no-destructive rules.
- The crawl uses **no LLM** (only `observe`/`verify`); journey design reuses the reasoner. Page cap
  bounds cost.

## Tests

`flow-crawl.test.ts` (graph build bounded by maxPages, destructive-link skip, revisit dedup +
in-app-only) and `flow-journey.test.ts` (per-page ref grounding, ≥2-page filter, id assignment),
LLM/browser mocked. CLI surface locks updated for the two opt-in flags. `npm run build` /
`npm run lint` / `npm test` (453 passed, 2 skipped) all green.

> Second wave; #60 (state/data setup) and #61 (coverage gap-analysis) stack on this branch's journey
> schema + flow graph.

Closes #59