### PR TITLE
feat: journey state & data setup — fixtures / API seed (--setup) (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Journey state & data setup — `--setup` (#60).** Multi-page journeys (#59) often need a
+  starting state beyond auth (a logged-in user *with* specific data). With `--setup`, Cairn turns each
+  journey's prose preconditions into **structured** ones (worker tier, `CAIRN_ROLE_WORKER`) and assigns
+  a satisfaction **strategy** in priority order: reuse the captured **session** → a Playwright
+  **fixture** (`beforeEach`) → an **API seed** when a concrete endpoint is named → a documented
+  **manual** fallback. It emits a runnable `@playwright/test` spec per journey under `runs/<id>/journeys/`,
+  with the setup established **before** the steps; steps stay read-only (`toBeVisible`) and refs are
+  resolved per page. Safety: an `api-seed` without a concrete endpoint is **downgraded to manual** —
+  Cairn never fabricates (possibly destructive) seeding. Opt-in; absent `--setup`, nothing changes.
+  The setup plans are recorded in `report.json` (`flow.setup`).
+
 - **Multi-page / flow exploration — `--flow` / `--max-pages N` (#59).** Opt-in, Cairn now follows
   in-app navigation from the start page to build a **page/flow graph** (nodes = studied pages, edges =
   observed transitions), reusing the captured `--session` storageState across pages, and designs

--- a/src/agent/graph.ts
+++ b/src/agent/graph.ts
@@ -5,6 +5,8 @@ import { designTestCases, type TestCase } from "../design/index.js";
 import { critiqueCases, type CritiqueDelta } from "../design/critique.js";
 import { crawlFlow, type FlowGraph } from "../flow/crawl.js";
 import { designJourneys } from "../flow/journey.js";
+import { planSetup, type SetupPlan } from "../flow/setup.js";
+import { buildJourneySetupSuite } from "../codegen/journey-setup.js";
 import type { JourneyCase } from "../design/schema.js";
 import { generateSuite, type GeneratedSuite } from "../codegen/index.js";
 import { probeTransitions, type Transition } from "../probe/index.js";
@@ -32,6 +34,10 @@ export interface ExploreDeps {
   flow?: boolean;
   /** #59: max pages to crawl when `flow` is on (page cap — cost guardrail). Default 1 (single page). */
   maxPages?: number;
+  /** #60: plan + emit starting-state setup (fixtures / API seed) for journeys. Opt-in. */
+  setup?: boolean;
+  /** #60: worker-tier invoker for setup planning (precondition extraction). Absent → no setup. */
+  setupInvoke?: StructuredInvoke;
   useVision: boolean;
   checklistText?: string;
   knowledgeText?: string;
@@ -87,6 +93,8 @@ export interface ExploreOutcome {
   flowGraph?: FlowGraph;
   /** #59: multi-page journey cases designed from the graph (undefined for single-page runs). */
   journeys?: JourneyCase[];
+  /** #60: per-journey structured setup plans (undefined unless `setup` ran). */
+  setupPlans?: SetupPlan[];
 }
 
 /** Sprint 3: observe → identify → design → generateCode → validate ⇄ repair (bounded by maxRepair). */
@@ -263,6 +271,7 @@ export async function runExploreGraph(
   // so single-page output is unchanged; best-effort so a crawl failure can't sink the per-page cases.
   let flowGraph: FlowGraph | undefined;
   let journeys: JourneyCase[] | undefined;
+  let setupPlans: SetupPlan[] | undefined;
   if (deps.flow && (deps.maxPages ?? 1) > 1) {
     deps.onProgress?.(`flow — crawling up to ${deps.maxPages} pages (reusing the session)…`);
     try {
@@ -274,6 +283,28 @@ export async function runExploreGraph(
         { invoke: deps.designInvoke, prompts: deps.prompts },
       );
       deps.onProgress?.(`flow — ${journeys.length} journey case(s) spanning ≥2 pages`);
+
+      // #60: plan the starting-state setup per journey + emit runnable journey specs (fixtures / seed).
+      if (deps.setup && deps.setupInvoke && journeys.length > 0) {
+        deps.onProgress?.("flow — planning starting-state setup for journeys (worker)…");
+        setupPlans = [];
+        for (const j of journeys) {
+          try {
+            setupPlans.push(
+              await planSetup({ journey: j, pageSemantics: analysis.pageSemantics }, { invoke: deps.setupInvoke, prompts: deps.prompts }),
+            );
+          } catch {
+            setupPlans.push({ preconditions: [] }); // a planning failure → an empty (no-precondition) spec
+          }
+        }
+        try {
+          const suite = buildJourneySetupSuite(journeys, setupPlans, flowGraph, study.url);
+          const written = await deps.runWriter.writeJourneySpecs(suite.files);
+          deps.onProgress?.(`flow — wrote ${written.length} journey spec(s) with setup → journeys/`);
+        } catch {
+          // best-effort: a write failure must not sink the run
+        }
+      }
     } catch (e) {
       const msg = e instanceof Error ? e.message.split("\n")[0] : String(e);
       deps.onProgress?.(`flow — skipped (${msg})`); // best-effort: keep the per-page cases
@@ -282,7 +313,7 @@ export async function runExploreGraph(
 
   // ── codeless short-circuit ────────────────────────────────────────────────
   if (deps.codeless) {
-    return { study, analysis, verified, transitions, testCases, stoppedEarly: false, attempts: 0, critique, flowGraph, journeys };
+    return { study, analysis, verified, transitions, testCases, stoppedEarly: false, attempts: 0, critique, flowGraph, journeys, setupPlans };
   }
 
   // ── generate → validate → repair (reuse runRepairLoop) ───────────────────
@@ -333,5 +364,6 @@ export async function runExploreGraph(
     critique,
     flowGraph,
     journeys,
+    setupPlans,
   };
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -69,6 +69,8 @@ export interface ExploreInput {
   flow?: boolean;
   /** #59: max pages to crawl when `flow` is on (page cap — cost guardrail). */
   maxPages?: number;
+  /** #60: plan + emit starting-state setup (fixtures / API seed) for journeys. Default off. */
+  setup?: boolean;
 }
 
 export interface ExploreResult {
@@ -191,6 +193,9 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
     critique: input.critique,
     flow: input.flow,
     maxPages: input.maxPages,
+    setup: input.setup,
+    // #60: setup planning runs on the worker tier (CAIRN_ROLE_WORKER); built only when opted in.
+    setupInvoke: input.setup ? router.invoke("worker", router.tierFor("worker", cfg.models.bulk)) : undefined,
     useVision: analyzeTier.supportsVision,
     checklistText: checklistFormatted,
     knowledgeText,
@@ -338,7 +343,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
         const cost = router.ledger.report(); // L1-01: per-role cost + tokens for this run
         const budgetReport: BudgetReport = { used: budget.spent, max: budget.max }; // L1-04 (Box 3)
         const stoppedEarly = Boolean(out.stoppedEarly); // L1-04 (Box 2)
-        const flowReport = flowReportPayload(out.flowGraph, out.journeys); // #59: compact graph + journeys (no screenshots)
+        const flowReport = flowReportPayload(out.flowGraph, out.journeys, out.setupPlans); // #59/#60: graph + journeys + setup
 
         // #39: also emit ATC/MTC case docs (.md) — explore now produces the human-readable cases like
         // design, so manual MTC cases are visible deliverables (not just buried inside report.md).
@@ -533,6 +538,9 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
     critique: input.critique,
     flow: input.flow,
     maxPages: input.maxPages,
+    setup: input.setup,
+    // #60: setup planning runs on the worker tier (CAIRN_ROLE_WORKER); built only when opted in.
+    setupInvoke: input.setup ? router.invoke("worker", router.tierFor("worker", cfg.models.bulk)) : undefined,
     useVision: analyzeTier.supportsVision,
     checklistText: formatChecklist(checklistItems),
     knowledgeText,
@@ -640,7 +648,7 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
           scores,
           cost,
           critique: out.critique, // #82: prune/top-up delta (undefined when the pass didn't run)
-          flow: flowReportPayload(out.flowGraph, out.journeys), // #59: graph + journeys (undefined single-page)
+          flow: flowReportPayload(out.flowGraph, out.journeys, out.setupPlans), // #59/#60: graph + journeys + setup
         });
         await runWriter.writeLog(
           [...logLines, "", `summary: mode=design testCases=${out.testCases.length} suite=${suite} runId=${runId}`].join("\n"),

--- a/src/artifacts/index.ts
+++ b/src/artifacts/index.ts
@@ -19,6 +19,8 @@ export interface RunWriter {
   writeLog(text: string): Promise<void>;
   /** Test cases in the user's format → testcases/<id>.md; returns the paths. */
   writeTestCases(docs: { id: string; md: string }[]): Promise<string[]>;
+  /** #60: journey spec files (with setup) → journeys/; clean-start; returns the paths written. */
+  writeJourneySpecs(files: { path: string; content: string }[]): Promise<string[]>;
 }
 
 /** Local trail of each run: runs/<id>/ (study, tests, snapshots, report). */
@@ -78,6 +80,23 @@ export class ArtifactStore {
           const p = join(tcDir, `${d.id}.md`);
           await writeFile(p, d.md, "utf8");
           out.push(p);
+        }
+        return out;
+      },
+      writeJourneySpecs: async (files) => {
+        // Clean start (like writeSuite) but a SEPARATE tree — never touches tests/.
+        const jDir = join(dir, "journeys");
+        await rm(jDir, { recursive: true, force: true });
+        await mkdir(jDir, { recursive: true });
+        const out: string[] = [];
+        for (const f of files) {
+          const rel0 = f.path.replace(/^journeys[/\\]/, ""); // paths are emitted as "journeys/<id>.spec.ts"
+          const target = resolve(jDir, rel0);
+          const rel = relative(jDir, target);
+          if (rel.startsWith("..") || isAbsolute(rel)) continue; // traversal — skip
+          await mkdir(dirname(target), { recursive: true });
+          await writeFile(target, f.content, "utf8");
+          out.push(target);
         }
         return out;
       },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -116,6 +116,7 @@ export function buildProgram(): Command {
     .option("--critique", "self-critique pass after design: prune weak cases + top up technique gaps (1 extra worker-tier LLM call)")
     .option("--flow", "follow in-app navigation across pages and design multi-page journey cases (opt-in)")
     .option("--max-pages <n>", "max pages to crawl with --flow (page cap; default 3)")
+    .option("--setup", "for journeys (--flow): plan + emit starting-state setup (fixture / API seed; manual fallback)")
     .action(async (opts: Record<string, unknown>) => {
       await runModality("explore", opts);
     });
@@ -228,6 +229,7 @@ export function buildProgram(): Command {
     .option("--critique", "self-critique pass after design: prune weak cases + top up technique gaps (1 extra worker-tier LLM call)")
     .option("--flow", "follow in-app navigation across pages and design multi-page journey cases (opt-in)")
     .option("--max-pages <n>", "max pages to crawl with --flow (page cap; default 3)")
+    .option("--setup", "for journeys (--flow): plan + emit starting-state setup (fixture / API seed; manual fallback)")
     .option("--headed", "visible browser (debug)")
     .action(
       async (opts: {
@@ -243,6 +245,7 @@ export function buildProgram(): Command {
         critique?: boolean;
         flow?: boolean;
         maxPages?: string;
+        setup?: boolean;
       }) => {
         const config = resolveConfig({ routing: opts.routing, channel: opts.channel });
         const checklistText = opts.checklist ? await readInputFile(opts.checklist, "Checklist") : undefined;
@@ -268,6 +271,7 @@ export function buildProgram(): Command {
           critique: opts.critique,
           flow: opts.flow,
           maxPages: opts.flow ? Number(opts.maxPages) || 3 : undefined,
+          setup: opts.setup,
           onProgress: progress.event,
         }).finally(() => progress.stop());
 

--- a/src/codegen/journey-setup.ts
+++ b/src/codegen/journey-setup.ts
@@ -1,0 +1,89 @@
+import type { FileBlob, GeneratedSuite } from "./schema.js";
+import type { JourneyCase } from "../design/schema.js";
+import type { FlowGraph } from "../flow/crawl.js";
+import type { SetupPlan } from "../flow/setup.js";
+import { locatorFor } from "../artifacts/report.js";
+
+/**
+ * #60 — render a runnable @playwright/test spec for one journey, with its SETUP established before the
+ * steps. Pure + deterministic (no LLM): the setup shape is fixed per strategy, so we emit it directly
+ * rather than asking a model. Step assertions are read-only (toBeVisible), refs resolved PER PAGE from
+ * the flow graph. Manual preconditions are documented and the test is skipped (clean fallback).
+ */
+export function renderJourneySetup(
+  journey: JourneyCase,
+  plan: SetupPlan,
+  graph: FlowGraph,
+  baseUrl: string,
+): FileBlob {
+  // ref → locator, resolved within the page the ref belongs to (per-page grounding from #59).
+  const byPage = new Map(graph.nodes.map((n) => [n.url, new Map(n.verified.map((v) => [v.ref, v]))]));
+  const locator = (page: string, ref: string): string | null => {
+    const el = byPage.get(page)?.get(ref);
+    return el ? locatorFor(el) : null;
+  };
+  const esc = (s: string): string => s.replace(/'/g, "");
+
+  const sessions = plan.preconditions.filter((p) => p.strategy === "session");
+  const fixtures = plan.preconditions.filter((p) => p.strategy === "fixture");
+  const seeds = plan.preconditions.filter((p) => p.strategy === "api-seed");
+  const manual = plan.preconditions.filter((p) => p.strategy === "manual");
+
+  const L: string[] = ["import { test, expect } from '@playwright/test';", ""];
+
+  L.push(`// Journey: ${journey.title}`);
+  for (const p of plan.preconditions) L.push(`// precondition [${p.strategy}]: ${p.description}`);
+  for (const s of sessions) L.push(`// "${s.description}" — satisfied by the captured session (storageState).`);
+  L.push("");
+
+  // fixture + api-seed → a beforeEach that establishes the starting state.
+  if (fixtures.length > 0 || seeds.length > 0) {
+    L.push("test.beforeEach(async ({ page, request }) => {");
+    for (const f of fixtures) {
+      L.push(`  // setup (fixture): ${f.description}`);
+      L.push(`  await page.goto('${baseUrl}');`);
+    }
+    for (const sd of seeds) {
+      const method = (sd.method ?? "POST").toLowerCase();
+      L.push(`  // setup (api-seed): ${sd.description}`);
+      L.push(`  await request.${method}('${sd.endpoint ?? ""}');`);
+    }
+    L.push("});", "");
+  }
+
+  // Manual preconditions can't be created safely → skip the test, documenting what a human must set up.
+  const skip =
+    manual.length > 0
+      ? `\n  test.skip(true, 'MANUAL precondition(s): ${esc(manual.map((m) => m.description).join("; "))}');`
+      : "";
+
+  L.push(`test('${esc(journey.title)}', async ({ page }) => {${skip}`);
+  let prevPage = "";
+  for (const step of journey.steps) {
+    L.push(`  await test.step(${JSON.stringify(step.action)}, async () => {`);
+    if (step.page !== prevPage) {
+      L.push(`    await page.goto('${step.page}');`);
+      prevPage = step.page;
+    }
+    for (const ref of step.elementRefs) {
+      const loc = locator(step.page, ref);
+      if (loc) L.push(`    await expect(${loc}).toBeVisible();`); // read-only across the whole journey
+    }
+    L.push("  });");
+  }
+  L.push("});", "");
+
+  return { path: `journeys/${journey.id}.spec.ts`, content: L.join("\n") };
+}
+
+/** Map journeys + their setup plans → a @playwright/test suite (one spec per journey). */
+export function buildJourneySetupSuite(
+  journeys: JourneyCase[],
+  plans: SetupPlan[],
+  graph: FlowGraph,
+  baseUrl: string,
+): GeneratedSuite {
+  return {
+    files: journeys.map((j, i) => renderJourneySetup(j, plans[i] ?? { preconditions: [] }, graph, baseUrl)),
+  };
+}

--- a/src/core/modalities/explore.ts
+++ b/src/core/modalities/explore.ts
@@ -30,6 +30,7 @@ interface ExploreFlags {
   critique?: boolean;
   flow?: boolean;
   maxPages?: string;
+  setup?: boolean;
 }
 
 export const exploreModality: Modality = {
@@ -63,6 +64,7 @@ export const exploreModality: Modality = {
       critique: opts.critique,
       flow: opts.flow,
       maxPages: opts.flow ? Number(opts.maxPages) || 3 : undefined,
+      setup: opts.setup,
       onProgress: progress.event,
     }).finally(() => progress.stop());
 

--- a/src/flow/crawl.ts
+++ b/src/flow/crawl.ts
@@ -4,6 +4,7 @@ import { parseAriaSnapshot } from "../observe/parse-aria.js";
 import type { PageStudy } from "../observe/index.js";
 import type { Transition } from "../probe/index.js";
 import type { JourneyCase } from "../design/schema.js";
+import type { SetupPlan } from "./setup.js";
 
 /** One studied page in the flow graph. */
 export interface FlowNode {
@@ -126,15 +127,21 @@ export async function crawlFlow(
   return { nodes, edges };
 }
 
-/** Compact flow payload for report.json — pages + edges + journeys, WITHOUT page screenshots/ARIA. */
+/** Compact flow payload for report.json — pages + edges + journeys (+ setup), WITHOUT screenshots/ARIA. */
 export interface FlowReport {
   pages: { url: string; interactive: number }[];
   edges: FlowEdge[];
   journeys: JourneyCase[];
+  /** #60: per-journey structured setup plans (omitted when setup didn't run). */
+  setup?: SetupPlan[];
 }
 
 /** Build the report.json `flow` block (undefined when no crawl happened). Pure — unit-testable. */
-export function flowReportPayload(graph?: FlowGraph, journeys?: JourneyCase[]): FlowReport | undefined {
+export function flowReportPayload(
+  graph?: FlowGraph,
+  journeys?: JourneyCase[],
+  setupPlans?: SetupPlan[],
+): FlowReport | undefined {
   if (!graph) return undefined;
   return {
     pages: graph.nodes.map((n) => ({
@@ -143,5 +150,6 @@ export function flowReportPayload(graph?: FlowGraph, journeys?: JourneyCase[]): 
     })),
     edges: graph.edges,
     journeys: journeys ?? [],
+    ...(setupPlans ? { setup: setupPlans } : {}),
   };
 }

--- a/src/flow/setup.ts
+++ b/src/flow/setup.ts
@@ -1,0 +1,73 @@
+import { HumanMessage } from "@langchain/core/messages";
+import { z } from "zod";
+import type { StructuredInvoke } from "../llm/structured.js";
+import type { PromptRegistry } from "../prompts/index.js";
+import type { JourneyCase } from "../design/schema.js";
+
+/**
+ * How a precondition's starting state is established, in priority order:
+ *  - session   — already covered by the captured storageState (auth);
+ *  - fixture   — a Playwright `beforeEach` that drives the UI to the starting state;
+ *  - api-seed  — a request seed against an OBSERVED endpoint (only with a concrete endpoint);
+ *  - manual    — documented, human-established precondition (the safe fallback — never fabricated).
+ */
+export const SetupStrategySchema = z.enum(["session", "fixture", "api-seed", "manual"]);
+export type SetupStrategy = z.infer<typeof SetupStrategySchema>;
+
+/** A structured starting-state requirement (#60) — replaces free prose where it can be made concrete. */
+export const StructuredPreconditionSchema = z.object({
+  /** Human-readable precondition (always present — also the manual-fallback text). */
+  description: z.string(),
+  strategy: SetupStrategySchema,
+  /** Grounded entity the state is about, e.g. "item", "user on plan Pro". */
+  entity: z.string().optional(),
+  /** api-seed only: the endpoint to seed against (required for the strategy to stand). */
+  endpoint: z.string().optional(),
+  /** api-seed only: HTTP method (default POST when seeding). */
+  method: z.enum(["GET", "POST", "PUT", "PATCH"]).optional(),
+});
+export type StructuredPrecondition = z.infer<typeof StructuredPreconditionSchema>;
+
+export const SetupPlanSchema = z.object({ preconditions: z.array(StructuredPreconditionSchema) });
+export type SetupPlan = z.infer<typeof SetupPlanSchema>;
+
+export interface SetupInput {
+  journey: JourneyCase;
+  /** Page purpose (optional context for the planner). */
+  pageSemantics?: string;
+}
+
+export interface SetupDeps {
+  invoke: StructuredInvoke;
+  prompts: PromptRegistry;
+}
+
+/**
+ * Safety post-process: a precondition can only be satisfied by `api-seed` when a CONCRETE endpoint is
+ * named — otherwise we'd be fabricating (possibly destructive) seeding, which is forbidden. Such a
+ * precondition is downgraded to the documented `manual` fallback. Pure — unit-testable.
+ */
+export function enforceSafeStrategies(plan: SetupPlan): SetupPlan {
+  return {
+    preconditions: plan.preconditions.map((p) =>
+      p.strategy === "api-seed" && !p.endpoint ? { ...p, strategy: "manual" as const } : p,
+    ),
+  };
+}
+
+/**
+ * #60 — extract STRUCTURED preconditions from a journey's prose preconditions, on the worker tier.
+ * The planner assigns each one a satisfaction strategy (session > fixture > api-seed > manual);
+ * unsafe/unfounded seeding is forced to manual by {@link enforceSafeStrategies}.
+ */
+export async function planSetup(input: SetupInput, deps: SetupDeps): Promise<SetupPlan> {
+  const { journey } = input;
+  const prompt = await deps.prompts.getPrompt("qa-setup-planner", {
+    title: journey.title,
+    preconditions: journey.preconditions.map((p) => `- ${p}`).join("\n") || "(none stated)",
+    pages: [...new Set(journey.steps.map((s) => s.page))].join(", "),
+    pageSemantics: input.pageSemantics ?? "",
+  });
+  const result = await deps.invoke(SetupPlanSchema, [new HumanMessage(prompt.text)]);
+  return enforceSafeStrategies(result);
+}

--- a/src/prompts/local/index.ts
+++ b/src/prompts/local/index.ts
@@ -2,6 +2,7 @@ import { QA_TESTCASE_FROM_UI } from "./qa-testcase-from-ui.js";
 import { QA_MANUAL_TEST_DESIGNER } from "./qa-manual-test-designer.js";
 import { QA_CASE_CRITIQUE } from "./qa-case-critique.js";
 import { QA_JOURNEY_FROM_FLOW } from "./qa-journey-from-flow.js";
+import { QA_SETUP_PLANNER } from "./qa-setup-planner.js";
 import { QA_PLAYWRIGHT_TS_WRITER } from "./qa-playwright-ts-writer.js";
 import { IDENTIFY_ELEMENTS } from "./identify-elements.js";
 import { JUDGE_TEST_CASES } from "./judge-test-cases.js";
@@ -14,6 +15,7 @@ export const LOCAL_PROMPTS: Record<string, string> = {
   "qa-manual-test-designer": QA_MANUAL_TEST_DESIGNER,
   "qa-case-critique": QA_CASE_CRITIQUE,
   "qa-journey-from-flow": QA_JOURNEY_FROM_FLOW,
+  "qa-setup-planner": QA_SETUP_PLANNER,
   "qa-playwright-ts-writer": QA_PLAYWRIGHT_TS_WRITER,
   "identify-elements": IDENTIFY_ELEMENTS,
   "judge-test-cases": JUDGE_TEST_CASES,

--- a/src/prompts/local/qa-setup-planner.ts
+++ b/src/prompts/local/qa-setup-planner.ts
@@ -1,0 +1,26 @@
+/**
+ * #60 — setup planner prompt. Turns a journey's PROSE preconditions into STRUCTURED ones, each with a
+ * satisfaction strategy. Worker-tier (mechanical extraction). Does not touch design methodology.
+ */
+export const QA_SETUP_PLANNER = `You map a test journey's preconditions to a concrete SETUP plan — how to establish the starting state BEFORE the journey runs.
+
+Journey: {{title}}
+Pages it visits: {{pages}}
+Page purpose: {{pageSemantics}}
+
+Stated preconditions (prose):
+{{preconditions}}
+
+For EACH precondition, choose ONE strategy, in this PRIORITY order (pick the highest that genuinely applies):
+1. "session"  — already true because the run reuses a captured login session (auth / "logged-in user"). Prefer this for anything auth-related.
+2. "fixture"  — can be set up by driving the UI to the starting state (navigate, open, select). Use when no API is known.
+3. "api-seed" — ONLY when a concrete, safe seeding endpoint is obvious (e.g. a REST path you can name). You MUST provide "endpoint" (and "method"). Never guess an endpoint.
+4. "manual"   — anything else, or anything that would require fabricating data / destructive seeding. This is the safe fallback.
+
+Rules:
+- NEVER invent an endpoint. If you can't name a concrete one, do NOT use api-seed — use fixture or manual.
+- NEVER propose destructive seeding (deleting/overwriting real data) — use manual.
+- "description" is always required (it doubles as the documented manual precondition).
+- "entity" is the thing the state is about (e.g. "item", "user on plan Pro"), when identifiable.
+
+Return { preconditions: [ { description, strategy, entity?, endpoint?, method? } ] }.`;

--- a/tests/unit/__snapshots__/cli-modalities.test.ts.snap
+++ b/tests/unit/__snapshots__/cli-modalities.test.ts.snap
@@ -67,6 +67,8 @@ Options:
   --flow                 follow in-app navigation across pages and design
                          multi-page journey cases (opt-in)
   --max-pages <n>        max pages to crawl with --flow (page cap; default 3)
+  --setup                for journeys (--flow): plan + emit starting-state setup
+                         (fixture / API seed; manual fallback)
   -h, --help             display help for command
 "
 `;

--- a/tests/unit/cli-modalities.test.ts
+++ b/tests/unit/cli-modalities.test.ts
@@ -115,10 +115,11 @@ describe("explore parity (C1-02)", () => {
       "--critique",
       "--flow",
       "--max-pages",
+      "--setup",
     ]) {
       expect(longs, `explore should accept ${f}`).toContain(f);
     }
-    expect(longs).toHaveLength(13); // + --critique (#82) + --flow / --max-pages (#59)
+    expect(longs).toHaveLength(14); // + --critique (#82) + --flow / --max-pages (#59) + --setup (#60)
   });
 
   it("maps flags to runExploration the same way as before the refactor", async () => {

--- a/tests/unit/flow-setup-codegen.test.ts
+++ b/tests/unit/flow-setup-codegen.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { renderJourneySetup } from "../../src/codegen/journey-setup.js";
+import type { JourneyCase } from "../../src/design/schema.js";
+import type { FlowGraph } from "../../src/flow/crawl.js";
+import type { SetupPlan } from "../../src/flow/setup.js";
+
+const graph: FlowGraph = {
+  nodes: [
+    {
+      url: "http://app/login",
+      study: { url: "http://app/login", screenshotB64: "", ariaYaml: "", capturedBy: "lib", elements: [] },
+      verified: [{ ref: "e1", role: "textbox", name: "Email", interactive: true, rank: 3, count: 1, verified: true }],
+      transitions: [],
+    },
+    {
+      url: "http://app/dash",
+      study: { url: "http://app/dash", screenshotB64: "", ariaYaml: "", capturedBy: "lib", elements: [] },
+      verified: [{ ref: "e9", role: "heading", name: "Dashboard", interactive: false, rank: 2, count: 1, verified: true }],
+      transitions: [],
+    },
+  ],
+  edges: [],
+};
+
+const journey: JourneyCase = {
+  id: "journey-1",
+  title: "Login to dashboard",
+  technique: "state-transition",
+  type: "Positive",
+  preconditions: ["a registered user"],
+  steps: [
+    { page: "http://app/login", action: "Sign in", elementRefs: ["e1"] },
+    { page: "http://app/dash", action: "See dashboard", elementRefs: ["e9"] },
+  ],
+  expected: "dashboard is visible",
+  priority: "high",
+};
+
+const render = (plan: SetupPlan) => renderJourneySetup(journey, plan, graph, "http://app/login");
+
+describe("renderJourneySetup (#60)", () => {
+  it("always emits a runnable spec with read-only step assertions resolved per page", () => {
+    const file = render({ preconditions: [{ description: "logged-in user", strategy: "session" }] });
+    expect(file.path).toContain("journey-1");
+    expect(file.content).toContain("import { test, expect } from '@playwright/test'");
+    expect(file.content).toContain("getByRole('textbox', { name: 'Email' })"); // e1 on login page
+    expect(file.content).toContain("getByRole('heading', { name: 'Dashboard' })"); // e9 on dash page
+    expect(file.content).toContain("page.goto('http://app/dash')"); // page change between steps
+    expect(file.content).toContain("toBeVisible()"); // read-only assertion
+    // session is satisfied by storageState → documented as a comment, not a beforeEach
+    expect(file.content).toContain("captured session");
+  });
+
+  it("a fixture precondition emits a beforeEach", () => {
+    const file = render({ preconditions: [{ description: "a registered user", strategy: "fixture" }] });
+    expect(file.content).toContain("test.beforeEach");
+    expect(file.content).toContain("a registered user");
+  });
+
+  it("an api-seed precondition emits a request seed step", () => {
+    const file = render({
+      preconditions: [{ description: "an item exists", strategy: "api-seed", endpoint: "/api/items", method: "POST" }],
+    });
+    expect(file.content).toContain("test.beforeEach");
+    expect(file.content).toContain("request.post('/api/items'");
+  });
+
+  it("a manual precondition is documented and the test is skipped (clean fallback, no fabrication)", () => {
+    const file = render({ preconditions: [{ description: "a paid subscription", strategy: "manual" }] });
+    expect(file.content).toContain("a paid subscription");
+    expect(file.content).toMatch(/test\.skip\(/);
+  });
+});

--- a/tests/unit/flow-setup-plan.test.ts
+++ b/tests/unit/flow-setup-plan.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { planSetup } from "../../src/flow/setup.js";
+import { PromptRegistry } from "../../src/prompts/index.js";
+import type { StructuredInvoke } from "../../src/llm/structured.js";
+import type { JourneyCase } from "../../src/design/schema.js";
+
+const journey: JourneyCase = {
+  id: "journey-1",
+  title: "Edit an existing item",
+  technique: "state-transition",
+  type: "Positive",
+  preconditions: ["an existing item in the list", "a logged-in user"],
+  steps: [
+    { page: "http://app/items", action: "open item", elementRefs: ["e1"] },
+    { page: "http://app/items/1", action: "see editor", elementRefs: ["e2"] },
+  ],
+  expected: "editor is visible",
+  priority: "high",
+};
+
+describe("planSetup (#60)", () => {
+  it("turns prose preconditions into a structured plan", async () => {
+    const fake: StructuredInvoke = async (schema) =>
+      schema.parse({
+        preconditions: [
+          { description: "a logged-in user", strategy: "session" },
+          { description: "an existing item", strategy: "fixture", entity: "item" },
+        ],
+      });
+    const plan = await planSetup({ journey }, { invoke: fake, prompts: new PromptRegistry() });
+    expect(plan.preconditions.map((p) => p.strategy)).toEqual(["session", "fixture"]);
+    expect(plan.preconditions[1]?.entity).toBe("item");
+  });
+
+  it("downgrades api-seed WITHOUT an endpoint to manual (never fabricate seeding)", async () => {
+    const fake: StructuredInvoke = async (schema) =>
+      schema.parse({ preconditions: [{ description: "seed three items", strategy: "api-seed" }] });
+    const plan = await planSetup({ journey }, { invoke: fake, prompts: new PromptRegistry() });
+    expect(plan.preconditions[0]?.strategy).toBe("manual");
+  });
+
+  it("keeps api-seed when a concrete endpoint is given", async () => {
+    const fake: StructuredInvoke = async (schema) =>
+      schema.parse({
+        preconditions: [{ description: "an item exists", strategy: "api-seed", endpoint: "/api/items", method: "POST" }],
+      });
+    const plan = await planSetup({ journey }, { invoke: fake, prompts: new PromptRegistry() });
+    expect(plan.preconditions[0]?.strategy).toBe("api-seed");
+    expect(plan.preconditions[0]?.endpoint).toBe("/api/items");
+  });
+});


### PR DESCRIPTION
## What

Multi-page journeys (#59) often need a starting state beyond auth — a logged-in user **with** specific
data (an existing item, a particular plan). With **`--setup`**, a generated journey declares its
preconditions as **structured** data and emits **runnable setup** that establishes the starting state
**before** the steps run.

## How

- **`src/flow/setup.ts`** — `StructuredPrecondition` + `SetupPlan` schema and `planSetup` (worker tier,
  `CAIRN_ROLE_WORKER`): turns a journey's prose preconditions into structured ones, each with a
  satisfaction **strategy** in priority order:
  1. **session** — already covered by the captured storageState (auth);
  2. **fixture** — a Playwright `beforeEach` that drives the UI to the starting state;
  3. **api-seed** — a request seed, **only** when a concrete endpoint is named;
  4. **manual** — documented fallback.
  `enforceSafeStrategies` downgrades an `api-seed` **without** a concrete endpoint to **manual** — Cairn
  never fabricates (possibly destructive) seeding.
- **`src/codegen/journey-setup.ts`** — `renderJourneySetup` (pure, deterministic, no LLM): one
  `@playwright/test` spec per journey — session → comment, fixture → `beforeEach`, api-seed → a
  `request.<method>` seed, manual → documented + `test.skip(...)`. The journey steps stay **read-only**
  (`toBeVisible`) and refs are resolved **per page** from the flow graph.
- **Pipeline**: wired into the `--flow` block (after journeys), gated by `deps.setup` + `setupInvoke`.
  Specs are written to `runs/<id>/journeys/` via a new `RunWriter.writeJourneySpecs` (separate tree —
  never touches `tests/`); plans recorded in `report.json` (`flow.setup`).
- **CLI**: `--setup` on `explore` and `design`.

## Constraints honored

- **Opt-in** — without `--setup` nothing changes (the block is gated, and `--setup` requires `--flow`).
- **Safe seeding** — no fabricated/destructive seeding; unfounded `api-seed` → `manual`.
- **Read-only across the whole journey** — steps only assert visibility.
- Setup extraction runs on the **worker** tier; methodology / assertion-safety rules untouched.

## Tests

`flow-setup-plan.test.ts` (structured extraction, `api-seed`→`manual` safety downgrade, endpoint kept)
and `flow-setup-codegen.test.ts` (session/fixture/api-seed/manual rendering + per-page locator
resolution), LLM mocked. `npm run build` / `npm run lint` / `npm test` (460 passed, 2 skipped) green.

> Stacked on #59 (now in `main`). #61 (coverage gap-analysis) also builds on #59.

Closes #60