### PR TITLE
feat: coverage gap-analysis + suggested gap cases (--gaps) (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Coverage gap-analysis (#61).** After design, every run now emits a **coverage view** — the observed
+  interactive surface (elements per page + flow transitions, #59) **minus** what any case or journey
+  references (by `elementRefs` + journey steps). `report.json` gains a `coverage` block and `report.md`
+  a **Coverage** section: covered vs observed-but-untested, grouped by page, each gap with a short
+  "why it matters", plus any untested transitions. With **`--gaps`**, Cairn additionally suggests cases
+  for the top untested elements (worker tier), grounded to the gap refs and clearly marked as
+  SUGGESTIONS (a `gap-` id prefix). The coverage view is read-only and additive (it changes no generated
+  test artifact); `--gaps` is opt-in and bounded (top-N gaps) to keep cost predictable.
+
 - **Journey state & data setup — `--setup` (#60).** Multi-page journeys (#59) often need a
   starting state beyond auth (a logged-in user *with* specific data). With `--setup`, Cairn turns each
   journey's prose preconditions into **structured** ones (worker tier, `CAIRN_ROLE_WORKER`) and assigns

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -13,6 +13,8 @@ import { parseTestCaseMd } from "../artifacts/testcase-md.js";
 import { automateCases } from "../codegen/index.js";
 import { lintSuite, lintHint } from "../codegen/lint.js";
 import { deterministicScores, type Score } from "../eval/scorers.js";
+import { computeCoverage } from "../eval/coverage.js";
+import { designGapCases } from "../eval/gap-cases.js";
 import { judgeTestCases, judgeChecklistCoverage } from "../eval/judge.js";
 import { pilotReview, type PilotVerdict } from "../eval/pilot.js";
 import { collectPriorRuns, unionPassedTitles, experienceForUrl } from "../eval/collect.js";
@@ -71,6 +73,8 @@ export interface ExploreInput {
   maxPages?: number;
   /** #60: plan + emit starting-state setup (fixtures / API seed) for journeys. Default off. */
   setup?: boolean;
+  /** #61: also suggest cases for the top untested surface (the coverage VIEW is always emitted). Default off. */
+  gaps?: boolean;
 }
 
 export interface ExploreResult {
@@ -345,6 +349,32 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
         const stoppedEarly = Boolean(out.stoppedEarly); // L1-04 (Box 2)
         const flowReport = flowReportPayload(out.flowGraph, out.journeys, out.setupPlans); // #59/#60: graph + journeys + setup
 
+        // #61: coverage view (always — a read-only set-difference); --gaps additionally suggests cases.
+        const coveragePages = out.flowGraph
+          ? out.flowGraph.nodes.map((n) => ({ url: n.url, elements: n.verified }))
+          : [{ url: out.study.url, elements: out.verified }];
+        const coverage = computeCoverage({
+          pages: coveragePages,
+          edges: out.flowGraph?.edges ?? [],
+          testCases: out.testCases,
+          journeys: out.journeys,
+        });
+        let gapCases: TestCase[] = [];
+        if (input.gaps) {
+          const topGaps = coverage.byPage.flatMap((p) => p.gaps).slice(0, 12); // bound cost
+          if (topGaps.length > 0) {
+            onProgress(`gaps — suggesting cases for ${topGaps.length} untested element(s) (worker)…`);
+            try {
+              gapCases = await designGapCases(
+                { gaps: topGaps, pageSemantics: out.analysis.pageSemantics, language: languageText },
+                { invoke: router.invoke("worker", router.tierFor("worker", cfg.models.bulk)), prompts },
+              );
+            } catch {
+              // best-effort — the coverage view still ships without suggestions
+            }
+          }
+        }
+
         // #39: also emit ATC/MTC case docs (.md) — explore now produces the human-readable cases like
         // design, so manual MTC cases are visible deliverables (not just buried inside report.md).
         const caseSuite = suiteFromUrl(out.study.url);
@@ -370,6 +400,8 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
           stoppedEarly,
           critique: out.critique, // #82: prune/top-up delta (undefined when the pass didn't run)
           flow: flowReport, // #59: page/flow graph + journey cases (undefined for single-page runs)
+          coverage, // #61: covered vs observed-but-untested surface
+          ...(gapCases.length ? { gapCases } : {}),
           history: {
             priorRuns: priorRuns.length,
             bestPriorGreen: bestPriorGreen ?? null,
@@ -392,6 +424,8 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
             budget: budgetReport,
             stoppedEarly,
             journeys: out.journeys,
+            coverage,
+            gapCases,
           }),
         );
         const green = validation ? `${Math.round(validation.greenRatio * 100)}%` : "—";
@@ -636,6 +670,31 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
         await runWriter.writeStudy(out.study);
         if (out.study.screenshotB64) await runWriter.writeScreenshot(out.study.screenshotB64);
         await runWriter.writeAria(out.study.ariaYaml);
+        // #61: coverage view (always) + optional gap-case suggestions (--gaps).
+        const coveragePages = out.flowGraph
+          ? out.flowGraph.nodes.map((n) => ({ url: n.url, elements: n.verified }))
+          : [{ url: out.study.url, elements: out.verified }];
+        const coverage = computeCoverage({
+          pages: coveragePages,
+          edges: out.flowGraph?.edges ?? [],
+          testCases: out.testCases,
+          journeys: out.journeys,
+        });
+        let gapCases: TestCase[] = [];
+        if (input.gaps) {
+          const topGaps = coverage.byPage.flatMap((p) => p.gaps).slice(0, 12);
+          if (topGaps.length > 0) {
+            try {
+              gapCases = await designGapCases(
+                { gaps: topGaps, pageSemantics: out.analysis.pageSemantics, language: languageText },
+                { invoke: router.invoke("worker", router.tierFor("worker", cfg.models.bulk)), prompts },
+              );
+            } catch {
+              // best-effort
+            }
+          }
+        }
+
         const cost = router.ledger.report(); // L1-01: per-role cost + tokens for this run
         await runWriter.writeReport({
           runId,
@@ -649,6 +708,8 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
           cost,
           critique: out.critique, // #82: prune/top-up delta (undefined when the pass didn't run)
           flow: flowReportPayload(out.flowGraph, out.journeys, out.setupPlans), // #59/#60: graph + journeys + setup
+          coverage, // #61: covered vs observed-but-untested surface
+          ...(gapCases.length ? { gapCases } : {}),
         });
         await runWriter.writeLog(
           [...logLines, "", `summary: mode=design testCases=${out.testCases.length} suite=${suite} runId=${runId}`].join("\n"),

--- a/src/artifacts/report.ts
+++ b/src/artifacts/report.ts
@@ -1,6 +1,7 @@
 import type { ElementRef } from "../browser/types.js";
 import type { TestCase } from "../design/index.js";
 import type { JourneyCase } from "../design/schema.js";
+import type { CoverageReport } from "../eval/coverage.js";
 import type { ValidationReport } from "../validate/index.js";
 import type { Score } from "../eval/scorers.js";
 import { METRIC_LEGEND, dirGlyph } from "../eval/legend.js";
@@ -31,6 +32,10 @@ export interface ReportInput {
   stoppedEarly?: boolean;
   /** #59: multi-page journey cases (rendered as a section when present). */
   journeys?: JourneyCase[];
+  /** #61: coverage view (covered vs observed-but-untested surface). */
+  coverage?: CoverageReport;
+  /** #61: suggested gap cases (--gaps) — rendered as clearly-marked suggestions. */
+  gapCases?: TestCase[];
 }
 
 function mark(status: string): string {
@@ -116,6 +121,36 @@ export function renderReportMd(r: ReportInput): string {
     lines.push(`- ⇒ ${tc.expected}`);
     if (tc.elementRefs.length) lines.push(`- refs: ${tc.elementRefs.join(", ")}`);
     lines.push("");
+  }
+
+  // #61: coverage gap-analysis — covered vs observed-but-untested, grouped by page.
+  if (r.coverage) {
+    const c = r.coverage;
+    lines.push(`## Coverage (${c.covered}/${c.observed} interactive elements — ${Math.round(c.ratio * 100)}%)`, "");
+    if (c.untestedEdges.length > 0) {
+      lines.push(`- **Untested transitions:** ${c.untestedEdges.length}`);
+      for (const e of c.untestedEdges) lines.push(`  - ${e.from} → ${e.to} (via ${e.via.role} "${e.via.name ?? ""}")`);
+      lines.push("");
+    }
+    for (const p of c.byPage) {
+      if (p.gaps.length === 0) continue;
+      lines.push(`### Untested on ${p.url} (${p.covered}/${p.observed} covered)`, "");
+      lines.push("| ref | role | name | why it matters |", "|---|---|---|---|");
+      for (const g of p.gaps) lines.push(`| ${g.ref} | ${g.role} | ${g.name ?? ""} | ${g.why} |`);
+      lines.push("");
+    }
+  }
+
+  // #61: suggested cases to close the top gaps (only with --gaps) — clearly marked as suggestions.
+  if (r.gapCases && r.gapCases.length > 0) {
+    lines.push(`## Suggested gap cases (${r.gapCases.length}) — SUGGESTIONS, review before adopting`, "");
+    for (const tc of r.gapCases) {
+      lines.push(`### ${tc.id} · [${tc.priority} · ${tc.technique}] ${tc.title}`);
+      for (const s of tc.steps) lines.push(`- ${s}`);
+      lines.push(`- ⇒ ${tc.expected}`);
+      if (tc.elementRefs.length) lines.push(`- refs: ${tc.elementRefs.join(", ")}`);
+      lines.push("");
+    }
   }
 
   // #59: multi-page user journeys (only present on a --flow run).

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -117,6 +117,7 @@ export function buildProgram(): Command {
     .option("--flow", "follow in-app navigation across pages and design multi-page journey cases (opt-in)")
     .option("--max-pages <n>", "max pages to crawl with --flow (page cap; default 3)")
     .option("--setup", "for journeys (--flow): plan + emit starting-state setup (fixture / API seed; manual fallback)")
+    .option("--gaps", "suggest cases for the top untested surface (the coverage view is always emitted)")
     .action(async (opts: Record<string, unknown>) => {
       await runModality("explore", opts);
     });
@@ -230,6 +231,7 @@ export function buildProgram(): Command {
     .option("--flow", "follow in-app navigation across pages and design multi-page journey cases (opt-in)")
     .option("--max-pages <n>", "max pages to crawl with --flow (page cap; default 3)")
     .option("--setup", "for journeys (--flow): plan + emit starting-state setup (fixture / API seed; manual fallback)")
+    .option("--gaps", "suggest cases for the top untested surface (the coverage view is always emitted)")
     .option("--headed", "visible browser (debug)")
     .action(
       async (opts: {
@@ -246,6 +248,7 @@ export function buildProgram(): Command {
         flow?: boolean;
         maxPages?: string;
         setup?: boolean;
+        gaps?: boolean;
       }) => {
         const config = resolveConfig({ routing: opts.routing, channel: opts.channel });
         const checklistText = opts.checklist ? await readInputFile(opts.checklist, "Checklist") : undefined;
@@ -272,6 +275,7 @@ export function buildProgram(): Command {
           flow: opts.flow,
           maxPages: opts.flow ? Number(opts.maxPages) || 3 : undefined,
           setup: opts.setup,
+          gaps: opts.gaps,
           onProgress: progress.event,
         }).finally(() => progress.stop());
 

--- a/src/core/modalities/explore.ts
+++ b/src/core/modalities/explore.ts
@@ -31,6 +31,7 @@ interface ExploreFlags {
   flow?: boolean;
   maxPages?: string;
   setup?: boolean;
+  gaps?: boolean;
 }
 
 export const exploreModality: Modality = {
@@ -65,6 +66,7 @@ export const exploreModality: Modality = {
       flow: opts.flow,
       maxPages: opts.flow ? Number(opts.maxPages) || 3 : undefined,
       setup: opts.setup,
+      gaps: opts.gaps,
       onProgress: progress.event,
     }).finally(() => progress.stop());
 

--- a/src/eval/coverage.ts
+++ b/src/eval/coverage.ts
@@ -1,0 +1,105 @@
+import type { VerifiedElement } from "../browser/types.js";
+import type { TestCase, JourneyCase } from "../design/schema.js";
+import type { FlowEdge } from "../flow/crawl.js";
+
+/** One observed-but-untested interactive element, with a short reason it matters. */
+export interface CoverageGap {
+  page: string;
+  ref: string;
+  role: string;
+  name?: string;
+  /** Why leaving this untested is a risk (role-derived). */
+  why: string;
+}
+
+export interface PageCoverage {
+  url: string;
+  observed: number;
+  covered: number;
+  gaps: CoverageGap[];
+}
+
+export interface CoverageReport {
+  /** Total observed interactive elements across all pages. */
+  observed: number;
+  /** How many of them are referenced by at least one case/journey. */
+  covered: number;
+  /** covered / observed (1 when there is nothing to miss). */
+  ratio: number;
+  byPage: PageCoverage[];
+  /** Observed transitions no journey walks end-to-end. */
+  untestedEdges: FlowEdge[];
+}
+
+export interface CoverageInput {
+  /** Observed surface per page (verified interactive elements). */
+  pages: { url: string; elements: VerifiedElement[] }[];
+  /** Observed transitions between pages (#59). */
+  edges: FlowEdge[];
+  /** Per-page cases (their elementRefs count as coverage). */
+  testCases: TestCase[];
+  /** Journey cases (their per-step elementRefs + page sequence count as coverage). */
+  journeys?: JourneyCase[];
+}
+
+/** Role-derived "why it matters" for an untested control. */
+function whyMatters(role: string): string {
+  switch (role) {
+    case "button":
+      return "actionable control never exercised — its behavior is untested";
+    case "link":
+      return "navigation path not covered — a route may be broken and unnoticed";
+    case "textbox":
+    case "searchbox":
+    case "combobox":
+    case "spinbutton":
+      return "input field never validated — accepts/rejects untested";
+    case "checkbox":
+    case "radio":
+    case "switch":
+      return "state toggle not checked — on/off behavior untested";
+    case "tab":
+    case "menuitem":
+      return "view/menu entry not opened — its content is unverified";
+    default:
+      return "interactive element with no test referencing it";
+  }
+}
+
+/**
+ * #61 — coverage = observed interactive surface + observed edges MINUS what any case/journey references.
+ * Pure set-difference (no LLM, no I/O), grouped by page. `ratio` is 1 when there is nothing observed,
+ * so it never produces NaN. Reconciles with the grounding/technique metrics (same verified refs).
+ */
+export function computeCoverage(input: CoverageInput): CoverageReport {
+  const coveredRefs = new Set<string>([
+    ...input.testCases.flatMap((c) => c.elementRefs),
+    ...(input.journeys ?? []).flatMap((j) => j.steps.flatMap((s) => s.elementRefs)),
+  ]);
+
+  let observed = 0;
+  let covered = 0;
+  const byPage: PageCoverage[] = input.pages.map((p) => {
+    const interactive = p.elements.filter((e) => e.interactive && e.count >= 1);
+    const gaps: CoverageGap[] = [];
+    let pageCovered = 0;
+    for (const e of interactive) {
+      if (coveredRefs.has(e.ref)) pageCovered += 1;
+      else gaps.push({ page: p.url, ref: e.ref, role: e.role, name: e.name, why: whyMatters(e.role) });
+    }
+    observed += interactive.length;
+    covered += pageCovered;
+    return { url: p.url, observed: interactive.length, covered: pageCovered, gaps };
+  });
+
+  // An edge is covered when some journey walks from→to on consecutive steps.
+  const walked = new Set<string>();
+  for (const j of input.journeys ?? []) {
+    for (let i = 0; i + 1 < j.steps.length; i += 1) {
+      walked.add(`${j.steps[i]!.page}|${j.steps[i + 1]!.page}`);
+    }
+  }
+  const untestedEdges = input.edges.filter((e) => !walked.has(`${e.from}|${e.to}`));
+
+  return { observed, covered, ratio: observed === 0 ? 1 : covered / observed, byPage, untestedEdges };
+}

--- a/src/eval/gap-cases.ts
+++ b/src/eval/gap-cases.ts
@@ -1,0 +1,43 @@
+import { HumanMessage } from "@langchain/core/messages";
+import type { StructuredInvoke } from "../llm/structured.js";
+import type { PromptRegistry } from "../prompts/index.js";
+import { DesignResultSchema, type TestCase } from "../design/schema.js";
+import type { CoverageGap } from "./coverage.js";
+
+export interface GapCaseInput {
+  /** Top untested elements to suggest cases for. */
+  gaps: CoverageGap[];
+  pageSemantics?: string;
+  language?: string;
+}
+
+export interface GapCaseDeps {
+  invoke: StructuredInvoke;
+  prompts: PromptRegistry;
+}
+
+/**
+ * #61 — suggest test cases for the top untested surface (worker tier). Returned cases are clearly
+ * marked as SUGGESTIONS via a `gap-` id prefix and grounded to the gap refs (anti-hallucination).
+ * Returns [] without calling the LLM when there are no gaps.
+ */
+export async function designGapCases(input: GapCaseInput, deps: GapCaseDeps): Promise<TestCase[]> {
+  if (input.gaps.length === 0) return [];
+  const known = new Set(input.gaps.map((g) => g.ref));
+  const gapList = input.gaps
+    .map((g) => `- ${g.ref} · ${g.role}${g.name ? ` "${g.name}"` : ""} (${g.page}) — ${g.why}`)
+    .join("\n");
+
+  const prompt = await deps.prompts.getPrompt("qa-gap-cases", {
+    gaps: gapList,
+    pageSemantics: input.pageSemantics ?? "",
+    language: input.language ?? "English",
+  });
+  const result = await deps.invoke(DesignResultSchema, [new HumanMessage(prompt.text)]);
+
+  return result.testCases.map((c, i) => ({
+    ...c,
+    id: `gap-${i + 1}`,
+    elementRefs: c.elementRefs.filter((r) => known.has(r)),
+  }));
+}

--- a/src/prompts/local/index.ts
+++ b/src/prompts/local/index.ts
@@ -3,6 +3,7 @@ import { QA_MANUAL_TEST_DESIGNER } from "./qa-manual-test-designer.js";
 import { QA_CASE_CRITIQUE } from "./qa-case-critique.js";
 import { QA_JOURNEY_FROM_FLOW } from "./qa-journey-from-flow.js";
 import { QA_SETUP_PLANNER } from "./qa-setup-planner.js";
+import { QA_GAP_CASES } from "./qa-gap-cases.js";
 import { QA_PLAYWRIGHT_TS_WRITER } from "./qa-playwright-ts-writer.js";
 import { IDENTIFY_ELEMENTS } from "./identify-elements.js";
 import { JUDGE_TEST_CASES } from "./judge-test-cases.js";
@@ -16,6 +17,7 @@ export const LOCAL_PROMPTS: Record<string, string> = {
   "qa-case-critique": QA_CASE_CRITIQUE,
   "qa-journey-from-flow": QA_JOURNEY_FROM_FLOW,
   "qa-setup-planner": QA_SETUP_PLANNER,
+  "qa-gap-cases": QA_GAP_CASES,
   "qa-playwright-ts-writer": QA_PLAYWRIGHT_TS_WRITER,
   "identify-elements": IDENTIFY_ELEMENTS,
   "judge-test-cases": JUDGE_TEST_CASES,

--- a/src/prompts/local/qa-gap-cases.ts
+++ b/src/prompts/local/qa-gap-cases.ts
@@ -1,0 +1,21 @@
+/**
+ * #61 — gap-case suggester. Given the observed-but-untested interactive elements, propose test cases
+ * that close the gaps. Worker-tier. Output is treated as SUGGESTIONS (gap- id prefix). Does not touch
+ * the design methodology — it reuses the same case shape, scoped to the untested surface.
+ */
+export const QA_GAP_CASES = `You are a QA engineer reviewing test COVERAGE. Below are interactive elements that were observed on the app but are NOT referenced by any existing test case — the coverage gaps.
+Write all titles, steps, expected in {{language}} — do not mix languages.
+
+Page purpose:
+{{pageSemantics}}
+
+Untested elements (ref · role · name · page — why it matters). In elementRefs use ONLY these refs:
+{{gaps}}
+
+Suggest focused test cases that close these gaps. For each case: title, technique (29119-4), kind ("static"|"active"), type ("Positive"|"Negative"), execution ("auto"|"manual"), preconditions, steps (real labels), expected (verifiable), priority, elementRefs (only from the list above).
+
+RULES:
+- Read-only by default: assert visibility/state. For destructive/irreversible controls (Delete, Submit that writes, Log out) only assert VISIBLE — never perform the action.
+- One logical check per case; independent; start from a clean page.
+- Only reference the untested refs above — do not invent elements or re-test already-covered ones.
+- These are SUGGESTIONS to fill coverage gaps; keep them concrete and runnable.`;

--- a/tests/unit/__snapshots__/cli-modalities.test.ts.snap
+++ b/tests/unit/__snapshots__/cli-modalities.test.ts.snap
@@ -69,6 +69,8 @@ Options:
   --max-pages <n>        max pages to crawl with --flow (page cap; default 3)
   --setup                for journeys (--flow): plan + emit starting-state setup
                          (fixture / API seed; manual fallback)
+  --gaps                 suggest cases for the top untested surface (the
+                         coverage view is always emitted)
   -h, --help             display help for command
 "
 `;

--- a/tests/unit/cli-modalities.test.ts
+++ b/tests/unit/cli-modalities.test.ts
@@ -116,10 +116,11 @@ describe("explore parity (C1-02)", () => {
       "--flow",
       "--max-pages",
       "--setup",
+      "--gaps",
     ]) {
       expect(longs, `explore should accept ${f}`).toContain(f);
     }
-    expect(longs).toHaveLength(14); // + --critique (#82) + --flow / --max-pages (#59) + --setup (#60)
+    expect(longs).toHaveLength(15); // + --critique (#82) + --flow / --max-pages (#59) + --setup (#60) + --gaps (#61)
   });
 
   it("maps flags to runExploration the same way as before the refactor", async () => {

--- a/tests/unit/coverage.test.ts
+++ b/tests/unit/coverage.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { computeCoverage } from "../../src/eval/coverage.js";
+import type { VerifiedElement } from "../../src/browser/types.js";
+import type { TestCase, JourneyCase } from "../../src/design/schema.js";
+
+const el = (ref: string, role: string, name: string): VerifiedElement => ({
+  ref,
+  role,
+  name,
+  interactive: true,
+  rank: 3,
+  count: 1,
+  verified: true,
+});
+
+const tc = (id: string, refs: string[]): TestCase => ({
+  id,
+  title: id,
+  technique: "exploratory",
+  kind: "static",
+  type: "Positive",
+  execution: "auto",
+  preconditions: [],
+  steps: ["s"],
+  expected: "e",
+  priority: "medium",
+  elementRefs: refs,
+});
+
+describe("computeCoverage (#61)", () => {
+  it("set-difference: observed interactive surface MINUS refs used by cases = gaps", () => {
+    const page = {
+      url: "http://app/p1",
+      elements: [el("e1", "button", "Save"), el("e2", "textbox", "Email"), el("e3", "link", "Docs")],
+    };
+    const cov = computeCoverage({ pages: [page], edges: [], testCases: [tc("tc-1", ["e1"])], journeys: [] });
+
+    expect(cov.observed).toBe(3);
+    expect(cov.covered).toBe(1);
+    expect(cov.ratio).toBeCloseTo(1 / 3);
+    const gaps = cov.byPage[0]!.gaps.map((g) => g.ref).sort();
+    expect(gaps).toEqual(["e2", "e3"]); // e1 covered, e2/e3 are gaps
+    // each gap carries a non-empty "why it matters"
+    expect(cov.byPage[0]!.gaps.every((g) => g.why.length > 0)).toBe(true);
+  });
+
+  it("journey step refs also count as coverage (reconciles per-page + journey)", () => {
+    const page = { url: "http://app/p1", elements: [el("e1", "button", "Save"), el("e2", "textbox", "Email")] };
+    const journey: JourneyCase = {
+      id: "journey-1",
+      title: "j",
+      technique: "state-transition",
+      type: "Positive",
+      preconditions: [],
+      steps: [{ page: "http://app/p1", action: "fill", elementRefs: ["e2"] }],
+      expected: "ok",
+      priority: "high",
+    };
+    const cov = computeCoverage({ pages: [page], edges: [], testCases: [tc("tc-1", ["e1"])], journeys: [journey] });
+    expect(cov.covered).toBe(2); // e1 by case, e2 by journey
+    expect(cov.byPage[0]!.gaps).toHaveLength(0);
+  });
+
+  it("flags observed transitions/edges not traversed by any journey", () => {
+    const pages = [
+      { url: "http://app/p1", elements: [el("e1", "link", "Next")] },
+      { url: "http://app/p2", elements: [el("e9", "heading", "P2")] },
+    ];
+    const edges = [{ from: "http://app/p1", to: "http://app/p2", via: { ref: "e1", role: "link", name: "Next" } }];
+
+    // no journey traverses the edge → it's an untested transition
+    const cov1 = computeCoverage({ pages, edges, testCases: [], journeys: [] });
+    expect(cov1.untestedEdges).toHaveLength(1);
+
+    // a journey that goes p1 → p2 covers the edge
+    const journey: JourneyCase = {
+      id: "journey-1",
+      title: "j",
+      technique: "state-transition",
+      type: "Positive",
+      preconditions: [],
+      steps: [
+        { page: "http://app/p1", action: "click Next", elementRefs: ["e1"] },
+        { page: "http://app/p2", action: "see p2", elementRefs: ["e9"] },
+      ],
+      expected: "p2 visible",
+      priority: "high",
+    };
+    const cov2 = computeCoverage({ pages, edges, testCases: [], journeys: [journey] });
+    expect(cov2.untestedEdges).toHaveLength(0);
+  });
+
+  it("no observed surface → ratio 1 (nothing to miss), no NaN", () => {
+    const cov = computeCoverage({ pages: [{ url: "http://app/x", elements: [] }], edges: [], testCases: [], journeys: [] });
+    expect(cov.observed).toBe(0);
+    expect(cov.ratio).toBe(1);
+  });
+});

--- a/tests/unit/gap-cases.test.ts
+++ b/tests/unit/gap-cases.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { designGapCases } from "../../src/eval/gap-cases.js";
+import { PromptRegistry } from "../../src/prompts/index.js";
+import type { StructuredInvoke } from "../../src/llm/structured.js";
+import type { CoverageGap } from "../../src/eval/coverage.js";
+
+const gaps: CoverageGap[] = [
+  { page: "http://app/p1", ref: "e2", role: "textbox", name: "Email", why: "input never validated" },
+];
+
+describe("designGapCases (#61)", () => {
+  it("suggests cases for untested surface, marked as suggestions and grounded to gap refs", async () => {
+    const fake: StructuredInvoke = async (schema) =>
+      schema.parse({
+        testCases: [
+          {
+            title: "Validate Email rejects blank",
+            technique: "boundary-value",
+            type: "Negative",
+            preconditions: [],
+            steps: ["leave Email empty", "submit"],
+            expected: "validation message shown",
+            priority: "medium",
+            elementRefs: ["e2", "eGHOST"], // eGHOST is not a gap ref → grounded out
+          },
+        ],
+      });
+    const cases = await designGapCases({ gaps }, { invoke: fake, prompts: new PromptRegistry() });
+    expect(cases).toHaveLength(1);
+    expect(cases[0]?.id).toMatch(/^gap-/); // clearly marked as a suggestion
+    expect(cases[0]?.elementRefs).toEqual(["e2"]);
+  });
+
+  it("no gaps → no LLM call, empty result", async () => {
+    let called = false;
+    const fake: StructuredInvoke = async (schema) => {
+      called = true;
+      return schema.parse({ testCases: [] });
+    };
+    const cases = await designGapCases({ gaps: [] }, { invoke: fake, prompts: new PromptRegistry() });
+    expect(cases).toEqual([]);
+    expect(called).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Turns Cairn from "here are tests" into "here's where you're **exposed**": every run now reports what
is **not** tested versus the observed app surface (elements + the flow-graph edges seen during #59).

## How

- **`src/eval/coverage.ts` (`computeCoverage`)** — a pure **set-difference** (no LLM, no I/O): the
  observed interactive surface (verified elements per page) + observed transitions **minus** everything
  any case or journey references (`elementRefs` + journey-step refs). Grouped **by page**, each gap
  carrying a short role-derived **"why it matters"**; it also flags **untested transitions** (edges no
  journey walks). `ratio` is 1 when there's nothing observed (never NaN), and the observed set is the
  same verified refs the `grounding` metric uses, so the numbers reconcile.
- **Coverage view on every run** — `report.json` gains a `coverage` block and `report.md` a
  **Coverage** section (covered vs observed-but-untested, per page + untested edges). This is read-only
  and **additive** — it changes no generated test artifact.
- **`src/eval/gap-cases.ts` (`designGapCases`)** + `qa-gap-cases` prompt — with **`--gaps`**, suggest
  cases for the top-N untested elements (worker tier, `CAIRN_ROLE_WORKER`), grounded to the gap refs
  and clearly marked as **SUGGESTIONS** (a `gap-` id prefix). Bounded (top 12) to keep cost predictable.
- **CLI**: `--gaps` on `explore` and `design`.

## Constraints honored

- The coverage view is read-only/additive; **`--gaps`** (the only LLM step) is **opt-in** and bounded.
- Suggestions run on the **worker** tier; methodology / assertion-safety rules untouched (the gap prompt
  keeps the read-only / no-destructive rules).

## Tests

`coverage.test.ts` (set-difference, journey-ref coverage, untested-edge detection, no-NaN) and
`gap-cases.test.ts` (suggestion grounding to gap refs, no LLM call when there are no gaps). `npm run build`
/ `npm run lint` / `npm test` (466 passed, 2 skipped) green.

> Stacked on #59 (now in `main`); completes the L2 Explore-Depth wave (#59 → #60 → #61).

Closes #61