### PR TITLE
feat(browser): tiered transient-error recovery for navigation (#90)

### DIFF
--- a/src/browser/backends/playwright-lib.ts
+++ b/src/browser/backends/playwright-lib.ts
@@ -1,6 +1,7 @@
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import type { BrowserBackend } from "../gateway.js";
 import { isMissingBrowserError, missingBrowsersError } from "../preflight.js";
+import { navigateWithRecovery } from "../recovery.js";
 import type {
   ActResult,
   Action,
@@ -75,12 +76,45 @@ export class PlaywrightLibBackend implements BrowserBackend {
     return this.page;
   }
 
+  /**
+   * Navigate with tiered transient-error recovery (#90): a transient SPA nav error (e.g. ERR_ABORTED)
+   * gets a cheap settle + retry on the SAME page — grounded state (refMap) stays valid — and only a
+   * fatal / retry-exhausted error escalates to the expensive {@link recreatePage}.
+   */
+  private async navigate(url: string): Promise<void> {
+    await this.ensurePage();
+    await navigateWithRecovery({
+      goto: async () => {
+        await this.page!.goto(url, { waitUntil: "domcontentloaded" });
+      },
+      settle: async () => {
+        await this.page!.waitForLoadState("networkidle", { timeout: 5_000 }).catch(() => undefined);
+        await this.page!.waitForTimeout(300);
+      },
+      recreate: async () => {
+        await this.recreatePage();
+      },
+    });
+  }
+
+  /**
+   * EXPENSIVE recovery: drop the current page and open a fresh one on the SAME context — auth /
+   * storageState survive, but the grounded refMap is cleared, so the caller must re-observe. Reached
+   * only for fatal / retry-exhausted navigation (transient errors retry the same page instead).
+   */
+  private async recreatePage(): Promise<void> {
+    await this.page?.close().catch(() => undefined);
+    this.page = undefined;
+    this.refMap.clear();
+    await this.ensurePage();
+  }
+
   async observe(opts: ObserveOptions): Promise<Observation> {
-    const page = await this.ensurePage();
     if (opts.url) {
-      await page.goto(opts.url, { waitUntil: "domcontentloaded" });
+      await this.navigate(opts.url);
       this.currentUrl = opts.url;
     }
+    const page = await this.ensurePage(); // after navigate: picks up a recreated page if recovery ran
     // SPA hydration: content loads asynchronously AFTER domcontentloaded.
     // Without this, the snapshot = only the static shell (nav), without the real page content.
     await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => undefined);
@@ -106,7 +140,7 @@ export class PlaywrightLibBackend implements BrowserBackend {
     try {
       const page = await this.ensurePage();
       if (action.kind === "navigate") {
-        await page.goto(action.url, { waitUntil: "domcontentloaded" });
+        await this.navigate(action.url);
         this.currentUrl = action.url;
         return { ok: true };
       }

--- a/src/browser/recovery.ts
+++ b/src/browser/recovery.ts
@@ -1,0 +1,80 @@
+/**
+ * Tiered transient-error recovery for browser navigation (BORROW-02, #90).
+ *
+ * A page navigation can fail for two very different reasons:
+ *  - **transient** — the SPA aborted the in-flight `goto` with a redirect, the network blipped, or a
+ *    load-state wait timed out. Waiting a beat and retrying the SAME page usually fixes it, and crucially
+ *    keeps the grounded state (the backend's ref→locator map) intact — no expensive reload needed.
+ *  - **fatal** — DNS failure, connection refused, bad cert, a missing browser binary, or anything we don't
+ *    recognise. Retrying the same page won't help; only here do we escalate to the expensive recovery
+ *    (recreate the page), which loses grounding and forces a re-observe.
+ *
+ * The borrowed insight (testomatio/explorbot PR #59): handle transient navigation errors BEFORE
+ * escalating to browser recovery, so flaky navigation doesn't waste a run or drop grounded state.
+ */
+
+export type ErrorClass = "transient" | "fatal";
+
+/** Navigation errors worth a cheap wait + retry on the SAME page (everything else is fatal). */
+const TRANSIENT_NAV: RegExp[] = [
+  /net::ERR_ABORTED/i, // SPA redirect interrupts the in-flight goto — the classic flake
+  /net::ERR_NETWORK_CHANGED/i,
+  /net::ERR_CONNECTION_RESET/i,
+  /net::ERR_CONNECTION_CLOSED/i,
+  /net::ERR_TIMED_OUT/i,
+  /net::ERR_HTTP2_PROTOCOL_ERROR/i,
+  /Timeout .* exceeded/i, // goto / waitForLoadState timeout
+  /Execution context was destroyed/i, // navigation mid-evaluate (SPA)
+  /frame was detached/i,
+  /navigation interrupted/i,
+];
+
+/**
+ * Classify a thrown browser error. Unknown errors default to `fatal` — we never want to mask a real
+ * bug behind silent retries; only errors we positively recognise as transient earn a retry.
+ */
+export function classifyBrowserError(e: unknown): ErrorClass {
+  const msg = e instanceof Error ? e.message : String(e);
+  return TRANSIENT_NAV.some((re) => re.test(msg)) ? "transient" : "fatal";
+}
+
+/** The three navigation primitives the recovery ladder drives (injected so it's unit-testable). */
+export interface NavOps {
+  /** Perform the navigation (e.g. page.goto). Throws on failure. */
+  goto(): Promise<void>;
+  /** Cheap settle: wait for the SPA to quiesce before a transient retry (same page). */
+  settle(): Promise<void>;
+  /** EXPENSIVE recovery: recreate the page — grounded state is lost. Only fatal/exhausted reaches here. */
+  recreate(): Promise<void>;
+}
+
+export interface NavRecoveryOpts {
+  /** Transient retries on the same page before escalating to recreate (default 2). */
+  retries?: number;
+}
+
+/**
+ * Tiered navigation recovery ladder:
+ *  1. try `goto`;
+ *  2. on a **transient** error with retries left → `settle` + retry the SAME page (grounding kept);
+ *  3. on a **fatal** error, or once transient retries are exhausted → `recreate` (expensive) + one final
+ *     `goto`. If even that throws, the error propagates.
+ */
+export async function navigateWithRecovery(ops: NavOps, opts: NavRecoveryOpts = {}): Promise<void> {
+  const retries = opts.retries ?? 2;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      await ops.goto();
+      return;
+    } catch (e) {
+      const canRetry = classifyBrowserError(e) === "transient" && attempt < retries;
+      if (!canRetry) {
+        // fatal, or transient retries exhausted → escalate to expensive recovery
+        await ops.recreate();
+        await ops.goto(); // final attempt on the fresh page; throws → propagate
+        return;
+      }
+      await ops.settle(); // cheap: let the SPA settle, then retry the same page
+    }
+  }
+}

--- a/tests/unit/browser-recovery.test.ts
+++ b/tests/unit/browser-recovery.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { classifyBrowserError, navigateWithRecovery, type NavOps } from "../../src/browser/recovery.js";
+
+describe("classifyBrowserError (#90 — transient vs fatal ladder)", () => {
+  it("classifies transient SPA / network navigation errors", () => {
+    for (const m of [
+      "net::ERR_ABORTED at https://app/x",
+      "net::ERR_NETWORK_CHANGED",
+      "net::ERR_CONNECTION_RESET",
+      "Timeout 30000ms exceeded",
+      "Execution context was destroyed, most likely because of a navigation",
+      "frame was detached",
+    ]) {
+      expect(classifyBrowserError(new Error(m)), m).toBe("transient");
+    }
+  });
+
+  it("classifies DNS / refused / cert / missing-binary / unknown as fatal", () => {
+    for (const m of [
+      "net::ERR_NAME_NOT_RESOLVED",
+      "net::ERR_CONNECTION_REFUSED",
+      "net::ERR_CERT_DATE_INVALID",
+      "Executable doesn't exist at /ms-playwright/chromium",
+      "totally unrecognised explosion",
+    ]) {
+      expect(classifyBrowserError(new Error(m)), m).toBe("fatal");
+    }
+  });
+
+  it("treats a non-Error throw safely (stringifies)", () => {
+    expect(classifyBrowserError("net::ERR_ABORTED")).toBe("transient");
+    expect(classifyBrowserError(null)).toBe("fatal");
+  });
+});
+
+/** A fake NavOps with call counters; `gotoResults[i]` drives the i-th goto ("ok" or an error message). */
+function makeOps(gotoResults: Array<"ok" | string>) {
+  const spy = { gotos: 0, settles: 0, recreates: 0 };
+  const ops: NavOps = {
+    goto: async () => {
+      const r = gotoResults[spy.gotos] ?? "ok";
+      spy.gotos += 1;
+      if (r !== "ok") throw new Error(r);
+    },
+    settle: async () => {
+      spy.settles += 1;
+    },
+    recreate: async () => {
+      spy.recreates += 1;
+    },
+  };
+  return { ops, spy };
+}
+
+describe("navigateWithRecovery (#90 — tiered recovery ladder)", () => {
+  it("success on first goto: no settle, no recovery", async () => {
+    const { ops, spy } = makeOps(["ok"]);
+    await navigateWithRecovery(ops);
+    expect(spy).toEqual({ gotos: 1, settles: 0, recreates: 0 });
+  });
+
+  it("transient error → wait+retry on the SAME page (no recreate ⇒ grounded state kept)", async () => {
+    const { ops, spy } = makeOps(["net::ERR_ABORTED", "ok"]);
+    await navigateWithRecovery(ops);
+    expect(spy.gotos).toBe(2);
+    expect(spy.settles).toBe(1);
+    expect(spy.recreates).toBe(0); // the key DoD invariant: transient must NOT trigger recovery
+  });
+
+  it("only a fatal error triggers the expensive recovery (recreate)", async () => {
+    const { ops, spy } = makeOps(["net::ERR_NAME_NOT_RESOLVED", "ok"]);
+    await navigateWithRecovery(ops);
+    expect(spy.settles).toBe(0); // fatal does not waste a transient retry
+    expect(spy.recreates).toBe(1); // recovery WAS triggered
+    expect(spy.gotos).toBe(2); // one retry after recreate
+  });
+
+  it("a persistent fatal error recovers once, then propagates", async () => {
+    const { ops, spy } = makeOps(["net::ERR_NAME_NOT_RESOLVED", "net::ERR_NAME_NOT_RESOLVED"]);
+    await expect(navigateWithRecovery(ops)).rejects.toThrow(/NAME_NOT_RESOLVED/);
+    expect(spy.recreates).toBe(1);
+    expect(spy.gotos).toBe(2);
+  });
+
+  it("exhausting transient retries escalates to recovery (default retries = 2)", async () => {
+    const { ops, spy } = makeOps(["net::ERR_ABORTED", "net::ERR_ABORTED", "net::ERR_ABORTED", "ok"]);
+    await navigateWithRecovery(ops);
+    expect(spy.settles).toBe(2); // two same-page retries
+    expect(spy.recreates).toBe(1); // then escalate
+    expect(spy.gotos).toBe(4); // 3 transient + 1 after recreate
+  });
+
+  it("respects a custom retries count", async () => {
+    const { ops, spy } = makeOps(["net::ERR_ABORTED", "ok"]);
+    await navigateWithRecovery(ops, { retries: 0 }); // no transient retries → straight to recovery
+    expect(spy.settles).toBe(0);
+    expect(spy.recreates).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #90 — **BORROW-02: Tiered transient-error recovery in BrowserGateway (wait+retry before reload).**

## Problem
`PlaywrightLibBackend.observe()` did a bare `page.goto(url, …)` with no error handling. A **transient** SPA navigation error (the classic `net::ERR_ABORTED` when an in-app redirect interrupts the in-flight `goto`, a network blip, or a load-state timeout) killed the whole step — and any expensive escalation would discard the grounded `refMap`.

## What changed
- **`src/browser/recovery.ts`** (new) — the error-classification **ladder**:
  - `classifyBrowserError(e) → "transient" | "fatal"` — explicit transient nav patterns (`ERR_ABORTED`, `ERR_NETWORK_CHANGED`, `ERR_CONNECTION_RESET/CLOSED`, `ERR_TIMED_OUT`, `Timeout … exceeded`, `Execution context was destroyed`, `frame was detached`, …). Everything else — DNS, refused, cert, missing binary, **and anything unrecognised** — is `fatal`, so we never mask a real bug behind silent retries.
  - `navigateWithRecovery(ops, {retries})` — transient → `settle` + retry the **same page** (grounding kept); fatal / retries-exhausted → `recreate` (expensive) + one final `goto`, else propagate. The three primitives are injected, so the ladder is unit-testable without a browser.
- **`src/browser/backends/playwright-lib.ts`** — `observe()` and `act(navigate)` now route through a private `navigate(url)` that drives the ladder. `recreatePage()` is the expensive step: a fresh page on the **same context** (auth/storageState survive; `refMap` cleared → caller re-observes).
- **`tests/unit/browser-recovery.test.ts`** (new) — classifier cases + ladder invariants.

## Scope
- **lib backend only** (PRIMARY — owns the grounded `refMap`). The **CLI backend** (SECONDARY, opt-in, no local `refMap`, drives an external daemon) is out of scope — its state model differs; `classifyBrowserError` is generic enough to reuse there later.

## DoD checklist
- [x] **An error-classification ladder exists** — `classifyBrowserError` (transient vs fatal) + `navigateWithRecovery`.
- [x] **A simulated transient nav error recovers via wait+retry without a full reload and without losing grounded state** — test `transient → wait+retry on the SAME page` asserts `recreates == 0` (refMap untouched) and `settles == 1`.
- [x] **Only genuinely fatal errors trigger recovery** — test `only a fatal error triggers recovery` asserts `recreates == 1` for fatal and `0` for transient; verified the key invariant goes **red** when transient classification is disabled (old behaviour) and green after.

## Verification
- `npm test` → 475 passed, 2 skipped, 0 failed (9 new)
- `npm run build` (tsc) clean · `npm run lint` (eslint) clean

> Not merging — left for human review.