### PR TITLE
feat(safety): provenance-checked Pilot verdicts + data-protection guardrails (#91)

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -330,6 +330,12 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
         // Pilot supervisor: a holistic verdict for the run (idea from explorbot).
         let pilot: PilotVerdict | undefined;
         try {
+          // #91: the session log the provenance check verifies a "pass" against — what the run actually
+          // touched (case titles/steps + observed element names). A "pass" naming an absent entity is rejected.
+          const sessionLog = [
+            ...out.testCases.flatMap((tc) => [tc.title, ...tc.steps]),
+            ...out.verified.map((v) => v.name ?? "").filter(Boolean),
+          ];
           pilot = await pilotReview(
             out.analysis.pageSemantics,
             validation,
@@ -338,6 +344,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
             // intended behavior change toward a "smart judge". See ADR-0011.
             router.invoke("reasoner", router.tierFor("reasoner", cfg.models.reasoning)),
             prompts,
+            sessionLog,
           );
           onProgress(`pilot — verdict: ${pilot.verdict} — ${pilot.reason}`);
         } catch {

--- a/src/eval/pilot.ts
+++ b/src/eval/pilot.ts
@@ -4,11 +4,14 @@ import type { StructuredInvoke } from "../llm/structured.js";
 import type { PromptRegistry } from "../prompts/index.js";
 import type { TestCase } from "../design/index.js";
 import type { ValidationReport } from "../validate/index.js";
+import { checkProvenance } from "../safety/guardrails.js";
 
 export const PilotSchema = z.object({
   verdict: z.enum(["pass", "needs-work", "fail"]),
   reason: z.string(),
   guidance: z.string(),
+  /** Name of the entity this run created/edited (for the provenance check) — "" if read-only (#91). */
+  entity: z.string(),
 });
 export type PilotVerdict = z.infer<typeof PilotSchema>;
 
@@ -22,6 +25,8 @@ export async function pilotReview(
   testCases: TestCase[],
   invoke: StructuredInvoke,
   prompts: PromptRegistry,
+  /** What the run actually touched (case titles/steps, observed element names) — for the #91 provenance check. */
+  sessionLog: string[] = [],
 ): Promise<PilotVerdict> {
   const validationText = validation
     ? `${Math.round(validation.greenRatio * 100)}% green (${validation.results.length} tests, flaky: ${validation.flakyCount})`
@@ -32,5 +37,7 @@ export async function pilotReview(
     validation: validationText,
     cases,
   });
-  return invoke(PilotSchema, [new HumanMessage(prompt.text)]);
+  const verdict = await invoke(PilotSchema, [new HumanMessage(prompt.text)]);
+  // #91: a "pass" that names an entity is only trusted when that entity appears in the session log.
+  return checkProvenance(verdict, sessionLog);
 }

--- a/src/flow/setup.ts
+++ b/src/flow/setup.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { StructuredInvoke } from "../llm/structured.js";
 import type { PromptRegistry } from "../prompts/index.js";
 import type { JourneyCase } from "../design/schema.js";
+import { isDeletionIntent } from "../safety/guardrails.js";
 
 /**
  * How a precondition's starting state is established, in priority order:
@@ -56,6 +57,19 @@ export function enforceSafeStrategies(plan: SetupPlan): SetupPlan {
 }
 
 /**
+ * Data-protection guardrail (#91): a precondition that establishes its state by DELETING / clearing data
+ * is forced to the `manual` fallback — at setup time nothing is self-created yet, so any such deletion
+ * would hit pre-existing data, which is forbidden. The deletion is never auto-seeded; a human decides.
+ */
+export function enforceDataProtection(plan: SetupPlan): SetupPlan {
+  return {
+    preconditions: plan.preconditions.map((p) =>
+      p.strategy !== "manual" && isDeletionIntent(p.description) ? { ...p, strategy: "manual" as const } : p,
+    ),
+  };
+}
+
+/**
  * #60 — extract STRUCTURED preconditions from a journey's prose preconditions, on the worker tier.
  * The planner assigns each one a satisfaction strategy (session > fixture > api-seed > manual);
  * unsafe/unfounded seeding is forced to manual by {@link enforceSafeStrategies}.
@@ -69,5 +83,5 @@ export async function planSetup(input: SetupInput, deps: SetupDeps): Promise<Set
     pageSemantics: input.pageSemantics ?? "",
   });
   const result = await deps.invoke(SetupPlanSchema, [new HumanMessage(prompt.text)]);
-  return enforceSafeStrategies(result);
+  return enforceDataProtection(enforceSafeStrategies(result));
 }

--- a/src/prompts/local/pilot-review.ts
+++ b/src/prompts/local/pilot-review.ts
@@ -9,4 +9,5 @@ Test cases:
 Return:
 - verdict: "pass" (run is sufficient and high-quality) | "needs-work" (gaps exist but not critical) | "fail" (serious problems);
 - reason: ONE sentence — the main basis for the verdict;
-- guidance: ONE concrete next step to improve.`;
+- guidance: ONE concrete next step to improve;
+- entity: the NAME of the entity this run created or edited (e.g. the record/item title), or "" if the run was read-only and created nothing. Do NOT invent a name — use only what the cases above actually reference.`;

--- a/src/safety/guardrails.ts
+++ b/src/safety/guardrails.ts
@@ -1,0 +1,81 @@
+import type { PilotVerdict } from "../eval/pilot.js";
+
+/**
+ * Two cheap safety rules borrowed from Explorbot (BORROW-04, #91), to land BEFORE any stateful /
+ * destructive automation:
+ *  1. Provenance-checked verdicts — a "pass" must be backed by evidence the entity it claims really
+ *     exists in the run's session log (kills a class of LLM false-positives).
+ *  2. Data-protection — never delete pre-existing data or the resource under the current URL; only
+ *     items this run created itself are disposable.
+ *
+ * Pure, side-effect-free — the host wires them into the Pilot judge and the setup planner.
+ */
+
+// ── 1. Provenance ───────────────────────────────────────────────────────────
+
+/**
+ * Gate a Pilot verdict on provenance: a "pass" that names a created/edited entity is only trusted when
+ * that entity actually appears (by name) in the session log. An unfounded "pass" is downgraded to
+ * "needs-work" with the reason recorded. Non-"pass" verdicts and read-only runs (no entity) pass through.
+ */
+export function checkProvenance(verdict: PilotVerdict, sessionLog: string[]): PilotVerdict {
+  if (verdict.verdict !== "pass") return verdict;
+  const entity = verdict.entity.trim();
+  if (!entity) return verdict; // read-only run / nothing claimed → nothing to prove
+  const haystack = sessionLog.join("\n").toLowerCase();
+  if (haystack.includes(entity.toLowerCase())) return verdict;
+  return {
+    ...verdict,
+    verdict: "needs-work",
+    reason:
+      `Provenance check: entity "${entity}" was reported as created/edited but is absent from the ` +
+      `session log — rejecting "pass" to avoid a false-positive. ${verdict.reason}`.trim(),
+  };
+}
+
+// ── 2. Data-protection ──────────────────────────────────────────────────────
+
+export interface DeletionContext {
+  /** URL of the page/resource under test — deleting it is always forbidden. */
+  currentUrl?: string;
+  /** Names/ids this run created itself — the ONLY things that may be deleted. */
+  selfCreated?: Iterable<string>;
+}
+
+export interface GuardResult {
+  allowed: boolean;
+  /** Human-readable basis for the decision (always set — surfaced to the planner/report). */
+  reason: string;
+}
+
+const norm = (s: string): string => s.trim().toLowerCase().replace(/\/+$/, "");
+
+/**
+ * Decide whether deleting `target` is permitted. Forbidden: the resource under the current URL, and any
+ * pre-existing datum (anything not in `selfCreated`). Permitted: an item this run created itself.
+ */
+export function guardDeletion(target: string, ctx: DeletionContext = {}): GuardResult {
+  const t = target.trim();
+  if (!t) return { allowed: false, reason: "Refusing to delete: empty target." };
+
+  if (ctx.currentUrl && norm(t) === norm(ctx.currentUrl)) {
+    return { allowed: false, reason: `Refusing to delete the resource under the current URL (${ctx.currentUrl}).` };
+  }
+
+  const selfCreated = new Set([...(ctx.selfCreated ?? [])].map(norm));
+  if (selfCreated.has(norm(t))) {
+    return { allowed: true, reason: `Allowed: "${t}" was created by this run (disposable).` };
+  }
+  return {
+    allowed: false,
+    reason: `Refusing to delete pre-existing data "${t}" — only self-created items may be removed.`,
+  };
+}
+
+/** Words that signal an intent to delete/clear data — used to gate stateful setup steps. */
+const DELETION_INTENT = /\b(delete|remove|clear|empty|purge|reset|wipe|drop|teardown|clean\s?-?up)\b/i;
+
+/** Whether a free-text step/precondition expresses an intent to delete or clear data. */
+export function isDeletionIntent(text: string): boolean {
+  return DELETION_INTENT.test(text);
+}

--- a/tests/unit/flow-setup-plan.test.ts
+++ b/tests/unit/flow-setup-plan.test.ts
@@ -48,4 +48,13 @@ describe("planSetup (#60)", () => {
     expect(plan.preconditions[0]?.strategy).toBe("api-seed");
     expect(plan.preconditions[0]?.endpoint).toBe("/api/items");
   });
+
+  it("#91: forces a delete/clear precondition to manual (never auto-deletes pre-existing data)", async () => {
+    const fake: StructuredInvoke = async (schema) =>
+      schema.parse({
+        preconditions: [{ description: "delete all existing items so the list is empty", strategy: "api-seed", endpoint: "/api/items" }],
+      });
+    const plan = await planSetup({ journey }, { invoke: fake, prompts: new PromptRegistry() });
+    expect(plan.preconditions[0]?.strategy).toBe("manual"); // data-protection guardrail downgraded it
+  });
 });

--- a/tests/unit/guardrails.test.ts
+++ b/tests/unit/guardrails.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { checkProvenance, guardDeletion, isDeletionIntent } from "../../src/safety/guardrails.js";
+import type { PilotVerdict } from "../../src/eval/pilot.js";
+
+const pass = (entity: string, reason = "looks good"): PilotVerdict => ({
+  verdict: "pass",
+  reason,
+  guidance: "ship it",
+  entity,
+});
+
+describe("checkProvenance (#91 — provenance-checked Pilot verdict)", () => {
+  it("keeps a pass when the named entity appears in the session log", () => {
+    const v = checkProvenance(pass("Invoice #42"), ["created Invoice #42", "filled amount"]);
+    expect(v.verdict).toBe("pass");
+  });
+
+  it("REJECTS a pass when the entity is absent from the log → needs-work with a reason", () => {
+    const v = checkProvenance(pass("Ghost Item"), ["clicked Save", "navigated to /items"]);
+    expect(v.verdict).toBe("needs-work");
+    expect(v.reason).toMatch(/provenance/i);
+    expect(v.reason).toContain("Ghost Item");
+  });
+
+  it("passes a read-only run through (no entity claimed)", () => {
+    const v = checkProvenance(pass(""), []); // nothing created → nothing to prove
+    expect(v.verdict).toBe("pass");
+  });
+
+  it("never upgrades — a non-pass verdict is returned untouched", () => {
+    const nw: PilotVerdict = { verdict: "needs-work", reason: "gaps", guidance: "more cases", entity: "X" };
+    expect(checkProvenance(nw, [])).toEqual(nw);
+  });
+
+  it("matches the entity case-insensitively", () => {
+    expect(checkProvenance(pass("WIDGET"), ["created a widget"]).verdict).toBe("pass");
+  });
+});
+
+describe("guardDeletion (#91 — data-protection guardrail)", () => {
+  it("ALLOWS deleting a self-created item (disposable)", () => {
+    const r = guardDeletion("temp-item-1", { selfCreated: ["temp-item-1"] });
+    expect(r.allowed).toBe(true);
+  });
+
+  it("BLOCKS deleting pre-existing data, with a clear reason", () => {
+    const r = guardDeletion("Customer Acme", { selfCreated: ["temp-item-1"] });
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toMatch(/pre-existing/i);
+    expect(r.reason).toContain("Customer Acme");
+  });
+
+  it("BLOCKS deleting the resource under the current URL", () => {
+    const r = guardDeletion("https://app/items/1", { currentUrl: "https://app/items/1/", selfCreated: ["https://app/items/1"] });
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toMatch(/current URL/i);
+  });
+
+  it("BLOCKS an empty target", () => {
+    expect(guardDeletion("   ").allowed).toBe(false);
+  });
+
+  it("matches self-created entries case/trailing-slash insensitively", () => {
+    expect(guardDeletion("Temp-Item-1", { selfCreated: ["temp-item-1 "] }).allowed).toBe(true);
+  });
+});
+
+describe("isDeletionIntent (#91 — gate for stateful setup steps)", () => {
+  it("flags delete/clear/reset intents", () => {
+    for (const t of ["delete all existing items", "clear the list", "reset the account", "purge old records", "clean up data"]) {
+      expect(isDeletionIntent(t), t).toBe(true);
+    }
+  });
+
+  it("does not flag read/create intents", () => {
+    for (const t of ["log in as admin", "an existing item is in the list", "create a new invoice"]) {
+      expect(isDeletionIntent(t), t).toBe(false);
+    }
+  });
+});

--- a/tests/unit/pilot.test.ts
+++ b/tests/unit/pilot.test.ts
@@ -22,7 +22,7 @@ describe("pilotReview (supervisor)", () => {
     let captured = "";
     const fake: StructuredInvoke = async (schema, messages) => {
       captured = JSON.stringify(messages);
-      return schema.parse({ verdict: "needs-work", reason: "мало негативних", guidance: "додай BVA-кейси" });
+      return schema.parse({ verdict: "needs-work", reason: "мало негативних", guidance: "додай BVA-кейси", entity: "" });
     };
     const v = await pilotReview(
       "Форма логіну",
@@ -34,5 +34,20 @@ describe("pilotReview (supervisor)", () => {
     expect(v.verdict).toBe("needs-work");
     expect(v.guidance).toContain("BVA");
     expect(captured).toContain("100% green");
+  });
+
+  it("#91: rejects a 'pass' whose claimed entity is absent from the session log", async () => {
+    const fake: StructuredInvoke = async (schema) =>
+      schema.parse({ verdict: "pass", reason: "all good", guidance: "ship", entity: "Phantom Record" });
+    const v = await pilotReview("Форма", undefined, [tc], fake, new PromptRegistry(), ["clicked Save", "opened /items"]);
+    expect(v.verdict).toBe("needs-work"); // entity not in the log → provenance downgrade
+    expect(v.reason).toMatch(/provenance/i);
+  });
+
+  it("#91: keeps a 'pass' when the entity is present in the session log", async () => {
+    const fake: StructuredInvoke = async (schema) =>
+      schema.parse({ verdict: "pass", reason: "all good", guidance: "ship", entity: "Order 7" });
+    const v = await pilotReview("Форма", undefined, [tc], fake, new PromptRegistry(), ["created Order 7"]);
+    expect(v.verdict).toBe("pass");
   });
 });


### PR DESCRIPTION
Closes #91 — **BORROW-04: Provenance-checked Pilot verdicts + data-protection guardrails.**

Two cheap, independent safety rules (borrowed from Explorbot), to land **before** any stateful / destructive automation. Core logic is pure in `src/safety/guardrails.ts`; wired into the real Pilot judge and setup planner.

## 1. Provenance-checked Pilot verdict
A holistic `pass` from the Pilot was previously trusted verbatim — an LLM could "pass" a run while referencing an entity that never existed (false-positive).
- `PilotSchema` gains an **`entity`** field (the created/edited entity's name, `""` if read-only).
- `checkProvenance(verdict, sessionLog)` downgrades a `pass` → `needs-work` (with a recorded reason) when the named entity is **absent** from the run's session log. Non-`pass` verdicts and read-only runs pass through.
- `agent/index.ts` builds the **session log** from what the run actually touched — case titles + steps + observed element names — and passes it to `pilotReview`.
- The `pilot-review` prompt now asks for `entity` (and not to invent names).

## 2. Data-protection guardrail
- `guardDeletion(target, {currentUrl, selfCreated})` → refuses to delete the **resource under the current URL** or any **pre-existing** datum; only **self-created** items are disposable. Each decision carries a clear `reason`.
- `flow/setup.ts` gains `enforceDataProtection`: any precondition expressing a **delete/clear intent** is forced to the `manual` fallback — at setup time nothing is self-created yet, so such a deletion would hit pre-existing data. Sits alongside the existing `enforceSafeStrategies`.

## Scope
- The **Tester** side is already read-only by policy (the codegen/journey/gap prompts assert-visible-only for destructive controls); this PR adds the **programmatic** Planner-side guardrail + a reusable policy. `gateway.act` is not instrumented — cairn has no delete-`Action` to gate, so doing so would be speculative.

## DoD checklist
- [x] **Pilot rejects a "pass" when the entity name is absent from the log** — `checkProvenance`; tests in `guardrails.test.ts` + `pilot.test.ts`.
- [x] **A delete attempt on pre-existing / current-URL data is blocked with a clear reason** — `guardDeletion` (pre-existing + current-URL cases) + `enforceDataProtection` (setup → manual).
- [x] **Self-created items can still be cleaned up** — `guardDeletion` allows targets in `selfCreated`.
- [x] Verified each guardrail test goes **red** when its guardrail is neutralised, green after.

## Verification
- `npm test` → 481 passed, 2 skipped, 0 failed (15 new/updated)
- `npm run build` (tsc) clean · `npm run lint` (eslint) clean

> Not merging — left for human review.