### PR TITLE
fix: resilient tests/ cleanup to survive EBUSY on Windows during repair (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`explore` no longer crashes with EBUSY on Windows during repair (#101).** The artifact writer
+  fully overwrites `tests/` on every generation (`writeSuite`), but on Windows the Playwright runner
+  from the just-finished validation can still hold a handle there — so the recursive `rm` threw
+  `EBUSY`/`EPERM` and the whole run rejected on the first repair attempt. Cleanup now goes through a
+  resilient `rmrf` helper that retries the recursive remove with exponential backoff on transient lock
+  codes (`EBUSY`/`EPERM`/`ENOTEMPTY`) and, if the lock never clears, gives up cleanly (best-effort)
+  instead of sinking the run. POSIX behaviour is unchanged (the first attempt always wins) and non-lock
+  errors still propagate immediately. The same guard is applied to `writeJourneySpecs`.
+
 - **Provider-safe strict JSON schemas for all structured LLM invokes (#89).** Strict structured-output
   providers (Groq `fast`, OpenRouter `volume`, Anthropic tool-calling) require **every** property to be
   in `required`; an `.optional()` key is dropped from `required` and causes intermittent cross-provider

--- a/src/artifacts/index.ts
+++ b/src/artifacts/index.ts
@@ -3,6 +3,31 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import type { PageStudy } from "../observe/index.js";
 import type { GeneratedSuite } from "../codegen/index.js";
 
+/** Codes Windows throws when a just-exited process still holds a handle on a dir/file. */
+const LOCK_CODES = new Set(["EBUSY", "EPERM", "ENOTEMPTY"]);
+
+/**
+ * Resilient recursive remove (#101). On Windows the Playwright runner from a just-finished validation
+ * can still hold a handle under `tests/`, so `rm` throws EBUSY/EPERM transiently; `force: true` only
+ * swallows ENOENT, not locks. Retry with exponential backoff to let the handle clear. On POSIX (no file
+ * locking) the first attempt always wins, so the path is unchanged there. If the locks never clear, give
+ * up cleanly (best-effort) instead of rejecting the whole run — the following mkdir + per-file writes
+ * still produce a usable tree. Non-lock errors propagate immediately. `rmFn` is injected for testing.
+ */
+export async function rmrf(path: string, rmFn: typeof rm = rm, retries = 4, baseMs = 100): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await rmFn(path, { recursive: true, force: true });
+      return;
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException).code;
+      if (!code || !LOCK_CODES.has(code)) throw e; // a real error → surface it
+      if (attempt >= retries) return; // locks never cleared → best-effort, don't sink the run
+      await new Promise((r) => setTimeout(r, baseMs * 2 ** attempt));
+    }
+  }
+}
+
 export interface RunWriter {
   runId: string;
   dir: string;
@@ -40,7 +65,7 @@ export class ArtifactStore {
       },
       writeSuite: async (suite) => {
         // Clean start: every generation (including repair) fully overwrites tests/.
-        await rm(testsDir, { recursive: true, force: true });
+        await rmrf(testsDir);
         await mkdir(testsDir, { recursive: true });
         const out: string[] = [];
         for (const f of suite.files) {
@@ -86,7 +111,7 @@ export class ArtifactStore {
       writeJourneySpecs: async (files) => {
         // Clean start (like writeSuite) but a SEPARATE tree — never touches tests/.
         const jDir = join(dir, "journeys");
-        await rm(jDir, { recursive: true, force: true });
+        await rmrf(jDir);
         await mkdir(jDir, { recursive: true });
         const out: string[] = [];
         for (const f of files) {

--- a/tests/unit/artifacts-rmrf.test.ts
+++ b/tests/unit/artifacts-rmrf.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { rm } from "node:fs/promises";
+import { rmrf } from "../../src/artifacts/index.js";
+
+/** A fake `rm` driven by a script: each call consumes the next entry ("ok" or an errno code to throw). */
+function makeRm(results: Array<"ok" | string>) {
+  let calls = 0;
+  const fn = (async () => {
+    const r = results[calls] ?? "ok";
+    calls += 1;
+    if (r !== "ok") {
+      const e = new Error(r) as NodeJS.ErrnoException;
+      e.code = r;
+      throw e;
+    }
+  }) as unknown as typeof rm;
+  return { fn, calls: () => calls };
+}
+
+describe("rmrf — resilient cleanup on Windows file locks (#101)", () => {
+  it("retries on EBUSY and succeeds once the lock clears", async () => {
+    const { fn, calls } = makeRm(["EBUSY", "EBUSY", "ok"]);
+    await expect(rmrf("d", fn, 4, 0)).resolves.toBeUndefined();
+    expect(calls()).toBe(3);
+  });
+
+  it("retries on EPERM (the other Windows lock code)", async () => {
+    const { fn, calls } = makeRm(["EPERM", "ok"]);
+    await rmrf("d", fn, 4, 0);
+    expect(calls()).toBe(2);
+  });
+
+  it("treats ENOTEMPTY (rmdir race) as transient too", async () => {
+    const { fn, calls } = makeRm(["ENOTEMPTY", "ok"]);
+    await rmrf("d", fn, 4, 0);
+    expect(calls()).toBe(2);
+  });
+
+  it("gives up cleanly (no throw) when the lock never clears — the run is NOT rejected", async () => {
+    const { fn, calls } = makeRm(Array(10).fill("EBUSY"));
+    await expect(rmrf("d", fn, 4, 0)).resolves.toBeUndefined(); // graceful, best-effort
+    expect(calls()).toBe(5); // 1 initial + 4 retries
+  });
+
+  it("POSIX path: the first attempt wins → a single call (behaviour unchanged)", async () => {
+    const { fn, calls } = makeRm(["ok"]);
+    await rmrf("d", fn, 4, 0);
+    expect(calls()).toBe(1);
+  });
+
+  it("propagates a non-lock error immediately (never mask a real bug)", async () => {
+    const { fn, calls } = makeRm(["EACCES"]);
+    await expect(rmrf("d", fn, 4, 0)).rejects.toThrow(/EACCES/);
+    expect(calls()).toBe(1); // no retry on a non-lock error
+  });
+
+  it("REGRESSION: the old bare `rm` rejected on EBUSY — which sank the whole run; rmrf absorbs it", async () => {
+    const { fn } = makeRm(["EBUSY"]);
+    // Pre-fix, writeSuite/writeJourneySpecs awaited a bare rm → this rejection propagated → run died.
+    await expect(fn("d", { recursive: true, force: true })).rejects.toThrow(/EBUSY/);
+    // Post-fix the same lock is absorbed (proven by the "gives up cleanly" case above).
+  });
+});


### PR DESCRIPTION
Closes #101.

## Problem
`writeSuite` fully overwrites `runs/<id>/tests/` on every generation via `rm(testsDir, { recursive: true, force: true })`. On Windows the Playwright runner from the just-finished validation still holds a handle under `tests/`, so the recursive `rm` throws `EBUSY`/`EPERM` (and `force: true` only swallows `ENOENT`, not locks). The error was unhandled → the whole `explore` rejected on the first repair attempt.

## Fix
New `rmrf(path, rmFn = rm, retries = 4, baseMs = 100)` in `src/artifacts/index.ts`:
- retries the recursive remove with exponential backoff on transient lock codes (`EBUSY` / `EPERM` / `ENOTEMPTY`) — giving the OS time to release the handle;
- if the lock never clears, **gives up cleanly** (best-effort) instead of rejecting — the following `mkdir` + per-file writes still produce a usable tree;
- **non-lock errors propagate immediately** (don't mask real bugs);
- **POSIX path unchanged** — no file locking there, so the first attempt always wins.

Applied to both `writeSuite` and `writeJourneySpecs` (same clean-start pattern).

## DoD checklist
- [x] **fs mocked so rm throws EBUSY (and EPERM)** — `tests/unit/artifacts-rmrf.test.ts` drives a scripted fake `rm`.
- [x] **cleanup survives it (retry) and the run is NOT rejected** — `gives up cleanly (no throw)` asserts `rmrf` resolves after exhausting retries on a permanent lock.
- [x] **POSIX path not broken** — `first attempt wins → single call` test.
- [x] **non-lock errors still surface** — `EACCES` propagates with no retry.
- [x] Regression contrast: a bare `rm` rejects on `EBUSY` (old behaviour) — what `rmrf` now absorbs.

## Verification
- `npm test` → 512 passed, 2 skipped, 0 failed (7 new)
- `npm run lint` · `npm run typecheck` · `npm run build` clean

> Not merging — left for review.