### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.5.0] - 2026-06-24
+
+### Added
+
 - **Provenance-checked Pilot verdicts + data-protection guardrails (#91).** Two cheap safety rules
   (borrowed from Explorbot) that land **before** any stateful / destructive automation. (1) The Pilot's
   holistic `pass` is now **provenance-checked**: the verdict carries the name of the entity the run
@@ -147,6 +155,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   retry-exhausted error escalates to the expensive recovery (recreate the page on the same context; auth
   survives, grounding is rebuilt). Unknown errors default to `fatal`, so real bugs aren't masked by
   silent retries. lib backend (PRIMARY); the CLI backend is out of scope.
+
+- **Robust `--run` / `--from-run` path resolution on Windows / Git-Bash (#79).** In Git Bash an
+  unquoted backslash is a shell escape, so `--run runs\<id>` reached the process as the glued `runs<id>`
+  (the separator eaten before Node ran) → `ENOENT` on the testcases path. A new `src/fs/run-dir.ts`
+  resolves `runs/<id>`, an absolute path, a bare `<id>`, and recovers the glued case; otherwise it
+  throws an actionable error listing available runs plus a bare-id / Git-Bash tip. `readInputFile` gives
+  a friendly `ENOENT` (+ Git-Bash tip) for file flags (`--checklist` / `--dataset` / `--candidate`), and
+  `defaultRunsBaseDir()` becomes the single source for the runs base dir (was duplicated 5×).
+
+[0.5.0]: https://github.com/plune-ai/cairn/compare/v0.4.0...v0.5.0
 
 ## [0.4.0] - 2026-06-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plune-ai/cairn",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plune-ai/cairn",
-      "version": "0.3.4",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@langchain/anthropic": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plune-ai/cairn",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Cairn — an AI that walks your system and leaves a trail of tests. Autonomous QA agent (UI today; API/unit/docs planned) powered by Claude/OpenRouter, with self-improvement via Langfuse.",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Release **0.5.0** (2026-06-24). Cut from `[Unreleased]`; `package.json` + `package-lock.json` bumped `0.4.0 → 0.5.0`. Not for merge until reviewed.

## Highlights

### Added — new capabilities
- **Multi-page / flow exploration — `--flow` / `--max-pages N` (#59).** Crawl in-app navigation → page/flow graph → cross-page **journey** cases.
- **Journey state & data setup — `--setup` (#60).** Structured preconditions with a satisfaction strategy (session → fixture → api-seed → manual); runnable journey specs.
- **Coverage gap-analysis + `--gaps` (#61).** Coverage view (observed-but-untested surface) in every run; `--gaps` suggests cases for the top gaps.
- **Prompt overrides + house-style packs — `--style` (#80).** Committed `prompts/` scaffold + override precedence; `concise`/`gherkin`/`detailed-manual` packs.
- **`--critique` (#82).** Opt-in design-time self-critique: prune weak cases + top up technique gaps (one worker-tier call).
- **`--fresh` (#77).** Ignore prior-run experience for clean A/B runs.
- **Provenance-checked Pilot verdicts + data-protection guardrails (#91).** A `pass` must be backed by the session log; never delete pre-existing / current-URL data.
- Inline metric legend (#78).

### Changed
- Slimmed README into a ~30-second shop window; deep-dives moved to `docs/` (#81).

### Fixed — BORROW hardenings + robustness
- **Provider-safe strict JSON schemas (#89).** `required == properties` across all structured invokes (schema-lint + drift guard); validated live on `volume`/`fast`.
- **Tiered transient-error recovery in BrowserGateway (#90).** transient → settle+retry (grounding kept); only fatal → expensive recovery.
- **Per-page crawl snapshots (#103).** N snapshot sets (`snapshots/<i>-<slug>/`) + per-page ref in `report.json`.
- **Flow crawl follows client-routed SPAs (#102).** wait-for-URL-change + live `page.url()` + `(name,href)` link dedup.
- **EBUSY-resilient `tests/` cleanup on Windows (#101).** retry on lock codes, graceful give-up.
- **Robust `--run`/`--from-run` path resolution on Windows/Git-Bash (#79).** recovers the Git-Bash glued-path case; actionable errors.

## Verification (local, all green)
- `npm ci` → `npm run build` · `typecheck` · `lint` · `test` (521 passed, 2 skipped) · `smoke:pack` (8 checks, `--version` prints **0.5.0**)
- End-to-end `explore --flow --setup` on a real multi-page SPA: 3-page graph, 6 journeys, per-page snapshots, repair survived (exit 0).

## Post-merge (separate, on request)
- Tag `v0.5.0` + push.
- `npm publish` — only on explicit confirmation.

> Do not merge — left for review.