### PR TITLE
feat: MCP server — cairn mcp exposing explore/design as tools (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP server — `cairn mcp` (#49).** Cairn's core is now exposed as an
+  [MCP](https://modelcontextprotocol.io) server, so other agents (Claude Code, Cursor) can call test
+  generation as a tool. `cairn mcp` starts a **stdio** server with two tools — **`explore`** (cases +
+  `@playwright/test` code + validate ⇄ repair) and **`design`** (cases only) — thin adapters over the
+  same `runExploration` / `runDesign` core the CLI uses (config / role routing / cost reused, no new
+  generation logic). Tool input mirrors the matching `explore` flags (`url` + optional
+  `session`/`flow`/`setup`/`gaps`/`critique`/`fresh`/`checklist`/`style`/`routing`/`backend`/`maxPages`);
+  results return as structured JSON (cases, validation, metrics, the Pilot verdict, cost, run dir).
+  `@modelcontextprotocol/sdk` is an **optional dependency** (lazy-loaded only on the `cairn mcp` path,
+  like Ink for the TUI). Connect snippet: [docs/mcp.md](docs/mcp.md).
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **MCP server — `cairn mcp` (#49).** Cairn's core is now exposed as an
   [MCP](https://modelcontextprotocol.io) server, so other agents (Claude Code, Cursor) can call test
-  generation as a tool. `cairn mcp` starts a **stdio** server with two tools — **`explore`** (cases +
-  `@playwright/test` code + validate ⇄ repair) and **`design`** (cases only) — thin adapters over the
-  same `runExploration` / `runDesign` core the CLI uses (config / role routing / cost reused, no new
-  generation logic). Tool input mirrors the matching `explore` flags (`url` + optional
+  generation as a tool. `cairn mcp` starts a **stdio** server with three tools — **`explore`** (cases +
+  `@playwright/test` code + validate ⇄ repair), **`design`** (cases only), and **`automate`** (code
+  from a previous run's ready cases) — thin adapters over the same `runExploration` / `runDesign` /
+  `runAutomate` core the CLI uses (config / role routing / cost reused, no new generation logic).
+  `explore`/`design` input mirrors the `explore` flags (`url` + optional
   `session`/`flow`/`setup`/`gaps`/`critique`/`fresh`/`checklist`/`style`/`routing`/`backend`/`maxPages`);
-  results return as structured JSON (cases, validation, metrics, the Pilot verdict, cost, run dir).
+  `automate` takes `run` (the run dir) + optional `validate`/`session`. Results return as structured
+  JSON (cases or spec files, validation, metrics, the Pilot verdict, cost, run dir).
   `@modelcontextprotocol/sdk` is an **optional dependency** (lazy-loaded only on the `cairn mcp` path,
   like Ink for the TUI). Connect snippet: [docs/mcp.md](docs/mcp.md).
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ const result = await runDesign({ url, config, sessionName: "myapp", checklistTex
 ## Documentation
 
 - **[Getting started](docs/getting-started.md)** — step-by-step onboarding (session → design → review → promote → automate → validate).
-- **[Authenticated targets](docs/sessions.md)** · **[Configuration & role routing](docs/configuration.md)** · **[Prompts & styles](docs/prompts-and-styles.md)** · **[Interactive TUI](docs/tui.md)**
+- **[Authenticated targets](docs/sessions.md)** · **[Configuration & role routing](docs/configuration.md)** · **[Prompts & styles](docs/prompts-and-styles.md)** · **[Interactive TUI](docs/tui.md)** · **[MCP server](docs/mcp.md)**
 - **[Metrics](docs/metrics.md)** · **[Cost benchmark](docs/cost.md)** · **[Langfuse](docs/langfuse.md)**
 - **[Architecture overview](docs/architecture/overview.md)** — the plain async pipeline, locator grounding, self-improvement.
 - **[Architecture Decision Records](docs/adr/)** — why it's built this way (0001–0013).

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,84 @@
+# MCP server — Cairn as a tool for Claude Code / Cursor
+
+Cairn exposes its core as an [MCP](https://modelcontextprotocol.io) server, so other agents (Claude
+Code, Cursor, …) can call **“generate / maintain tests for this target”** as a tool. It is a thin
+wrapper over the same core the CLI uses — no separate generation logic.
+
+## Run
+
+```bash
+cairn mcp
+```
+
+This starts an MCP server over **stdio** (the transport MCP clients launch as a child process). The
+`@modelcontextprotocol/sdk` package is an **optional dependency** (like Ink for the TUI) — install it
+once if you haven't:
+
+```bash
+npm i @modelcontextprotocol/sdk
+```
+
+## Tools
+
+| Tool | What it does | Returns |
+|------|--------------|---------|
+| `explore` | Explore a page → methodology-based cases → `@playwright/test` code → validate ⇄ repair | cases, validation summary, metrics, Pilot verdict, cost, run dir |
+| `design`  | Explore a page → cases in ATC/MTC format, **no code** | cases, metrics, cost, run dir |
+
+Both take the same input: `url` (required) plus optional `session`, `flow`, `setup`, `gaps`,
+`critique`, `fresh`, `checklist`, `style`, `routing`, `backend`, `channel`, `maxPages` — mirroring the
+matching `cairn explore` flags. Results come back as JSON (run id, the generated cases, validation /
+metrics / Pilot, cost, and the `runs/<id>/` directory).
+
+## Connect
+
+Cairn reads the same environment as the CLI (`ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `GROQ_API_KEY`,
+`LLM_PROFILE`, …) — set them in the MCP client's environment. Config, role routing, and cost reporting
+are reused from core unchanged.
+
+### Claude Code
+
+```bash
+claude mcp add cairn -- cairn mcp
+```
+
+…or commit a project `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "cairn": {
+      "command": "cairn",
+      "args": ["mcp"],
+      "env": { "ANTHROPIC_API_KEY": "sk-…" }
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project):
+
+```json
+{
+  "mcpServers": {
+    "cairn": {
+      "command": "cairn",
+      "args": ["mcp"],
+      "env": { "ANTHROPIC_API_KEY": "sk-…" }
+    }
+  }
+}
+```
+
+If `cairn` isn't on `PATH`, run it through `npx`:
+`{ "command": "npx", "args": ["-y", "@plune-ai/cairn", "mcp"] }`.
+
+## Notes
+
+- Runs are written to `runs/<id>/` exactly like the CLI; the tool result includes `runDir`.
+- Authenticated targets need a saved session — capture one with `cairn session capture` first, then
+  pass `session: "<name>"`. See [Authenticated targets](sessions.md).
+- The server is a thin adapter: each tool validates input, calls the same `runExploration` /
+  `runDesign` core entry points the CLI uses, and returns a structured result. No new generation logic.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -22,13 +22,18 @@ npm i @modelcontextprotocol/sdk
 
 | Tool | What it does | Returns |
 |------|--------------|---------|
-| `explore` | Explore a page → methodology-based cases → `@playwright/test` code → validate ⇄ repair | cases, validation summary, metrics, Pilot verdict, cost, run dir |
-| `design`  | Explore a page → cases in ATC/MTC format, **no code** | cases, metrics, cost, run dir |
+| `explore`  | Explore a page → methodology-based cases → `@playwright/test` code → validate ⇄ repair | cases, validation summary, metrics, Pilot verdict, cost, run dir |
+| `design`   | Explore a page → cases in ATC/MTC format, **no code** | cases, metrics, cost, run dir |
+| `automate` | Generate `@playwright/test` code from a previous run's ready ATC cases (the second half of design → automate) | spec files, validation, cost, run dir |
 
-Both take the same input: `url` (required) plus optional `session`, `flow`, `setup`, `gaps`,
-`critique`, `fresh`, `checklist`, `style`, `routing`, `backend`, `channel`, `maxPages` — mirroring the
-matching `cairn explore` flags. Results come back as JSON (run id, the generated cases, validation /
-metrics / Pilot, cost, and the `runs/<id>/` directory).
+`explore` and `design` take the same input: `url` (required) plus optional `session`, `flow`, `setup`,
+`gaps`, `critique`, `fresh`, `checklist`, `style`, `routing`, `backend`, `channel`, `maxPages` —
+mirroring the matching `cairn explore` flags. `automate` instead takes `run` (the run id/dir returned
+by `design` or `explore`) plus optional `validate` / `session` / `routing` / `channel`. Results come
+back as JSON (run id, the generated cases or spec files, validation / metrics / Pilot, cost, and the
+`runs/<id>/` directory).
+
+A typical agent flow: `design` a page → review the cases → `automate` the run dir it returned.
 
 ## Connect
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@langchain/anthropic": "^1.4.0",
         "@langchain/core": "^1.1.48",
         "@langchain/openai": "^1.4.7",
+        "@modelcontextprotocol/sdk": "^1",
         "@playwright/test": "^1.60.0",
         "commander": "^15.0.0",
         "dotenv": "^17.4.2",
@@ -43,6 +44,7 @@
         "node": ">=20"
       },
       "optionalDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "ink": "^5.2.1",
         "ink-select-input": "^6.2.0",
         "ink-spinner": "^5.0.0",
@@ -808,6 +810,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1038,6 +1053,71 @@
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
@@ -4041,6 +4121,20 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -4090,6 +4184,48 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
@@ -4198,6 +4334,45 @@
       ],
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
@@ -4209,6 +4384,47 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -4463,6 +4679,30 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -4480,11 +4720,49 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4506,7 +4784,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4526,6 +4804,16 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -4549,12 +4837,44 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -4569,12 +4889,45 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-toolkit": {
       "version": "1.47.1",
@@ -4638,6 +4991,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -4817,11 +5177,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -4833,11 +5226,74 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -4859,6 +5315,23 @@
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4907,6 +5380,28 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4945,6 +5440,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -4957,6 +5472,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-caller-file": {
@@ -4982,6 +5507,45 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4995,6 +5559,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5005,12 +5582,86 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -5060,6 +5711,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ink": {
       "version": "5.2.1",
@@ -5181,6 +5839,26 @@
         "react": ">=18"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5233,6 +5911,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -5250,7 +5935,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -5290,6 +5975,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tiktoken": {
@@ -5334,6 +6029,13 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause",
+      "optional": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5748,6 +6450,66 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -5785,7 +6547,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/mustache": {
@@ -5823,6 +6585,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
@@ -5835,6 +6630,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -5958,6 +6776,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/patch-console": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
@@ -5982,10 +6810,21 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -6013,6 +6852,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/playwright": {
@@ -6108,6 +6957,20 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6116,6 +6979,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/react": {
@@ -6154,6 +7059,16 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6223,6 +7138,30 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -6246,11 +7185,65 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6263,10 +7256,86 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -6364,6 +7433,16 @@
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/std-env": {
@@ -6477,6 +7556,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -6564,6 +7653,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -6609,6 +7731,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -6617,6 +7749,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -6806,7 +7948,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6878,6 +8020,13 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ws": {
       "version": "8.21.0",
@@ -7038,6 +8187,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "optional": true,
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "zod": "^4.4.3"
   },
   "optionalDependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "ink": "^5.2.1",
     "ink-select-input": "^6.2.0",
     "ink-spinner": "^5.0.0",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -474,6 +474,15 @@ export function buildProgram(): Command {
     if (m.aliases?.length) c.aliases(m.aliases);
   }
 
+  program
+    .command("mcp")
+    .description("run an MCP server (stdio) exposing explore/design as tools for Claude Code / Cursor")
+    .action(async () => {
+      // Lazy: @modelcontextprotocol/sdk is an OPTIONAL dependency — keep it off every other code path.
+      const { startMcpServer } = await import("../mcp/server.js");
+      await startMcpServer();
+    });
+
   return program;
 }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,7 +1,15 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { BOT_VERSION } from "../index.js";
-import { TOOL_INPUT_SHAPE, ToolInputSchema, exploreTool, designTool } from "./tools.js";
+import {
+  TOOL_INPUT_SHAPE,
+  ToolInputSchema,
+  AUTOMATE_INPUT_SHAPE,
+  AutomateInputSchema,
+  exploreTool,
+  designTool,
+  automateTool,
+} from "./tools.js";
 
 /**
  * Build the Cairn MCP server (#49): exposes `explore` and `design` as tools over the shared core.
@@ -38,6 +46,22 @@ export function buildMcpServer(): McpServer {
     },
     async (args) => {
       const result = await designTool(ToolInputSchema.parse(args));
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "automate",
+    {
+      title: "Generate @playwright/test from ready cases (automate)",
+      description:
+        "Generate @playwright/test code from the ready ATC cases of a previous run (the second half of " +
+        "the decoupled design → automate flow). Pass `run` = the run id/dir returned by `design`; " +
+        "optionally `validate` (needs a `session`). Returns the spec files, validation summary, and cost.",
+      inputSchema: AUTOMATE_INPUT_SHAPE,
+    },
+    async (args) => {
+      const result = await automateTool(AutomateInputSchema.parse(args));
       return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
     },
   );

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,53 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { BOT_VERSION } from "../index.js";
+import { TOOL_INPUT_SHAPE, ToolInputSchema, exploreTool, designTool } from "./tools.js";
+
+/**
+ * Build the Cairn MCP server (#49): exposes `explore` and `design` as tools over the shared core.
+ * Separated from {@link startMcpServer} so a smoke test can introspect tools without a transport.
+ */
+export function buildMcpServer(): McpServer {
+  const server = new McpServer({ name: "cairn", version: BOT_VERSION });
+
+  server.registerTool(
+    "explore",
+    {
+      title: "Generate UI test cases + code (explore)",
+      description:
+        "Explore a web page and generate methodology-based UI test cases, @playwright/test code, and a " +
+        "validate⇄repair report. Returns the cases, validation summary, metrics, the Pilot verdict, cost, " +
+        "and the run directory. Use `flow`+`setup` for multi-page journeys; `session` for authenticated targets.",
+      inputSchema: TOOL_INPUT_SHAPE,
+    },
+    async (args) => {
+      const result = await exploreTool(ToolInputSchema.parse(args));
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "design",
+    {
+      title: "Design UI test cases, no code (design)",
+      description:
+        "Explore a web page and design methodology-based UI test cases in ATC/MTC format (markdown + " +
+        "selectors) WITHOUT generating or running code. Returns the cases, metrics, cost, and the run " +
+        "directory. The cheaper first step before `explore`/automate.",
+      inputSchema: TOOL_INPUT_SHAPE,
+    },
+    async (args) => {
+      const result = await designTool(ToolInputSchema.parse(args));
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  return server;
+}
+
+/** Start the Cairn MCP server over stdio — the entry point `cairn mcp` drives. */
+export async function startMcpServer(): Promise<void> {
+  const server = buildMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,0 +1,137 @@
+import { z } from "zod";
+import { resolveConfig } from "../core/config.js";
+import { runExploration, runDesign } from "../agent/index.js";
+import type { ExploreInput, ExploreResult, DesignResult } from "../agent/index.js";
+import type { TestCase } from "../design/index.js";
+import { readInputFile } from "../fs/run-dir.js";
+import { resolveStyleText } from "../design/style.js";
+
+/**
+ * MCP tool layer (#49). Each tool is a THIN adapter over the shared core: validate input → reuse
+ * `resolveConfig` (config / routing / cost) → call the SAME `runExploration` / `runDesign` the CLI
+ * calls → return a compact structured result. No new generation logic lives here.
+ *
+ * Core is injected via {@link ToolDeps} so the handlers are unit-testable without a browser or LLM.
+ */
+
+/** Tool input shape (zod raw shape) — a subset of the `cairn explore` / `design` flags. */
+export const TOOL_INPUT_SHAPE = {
+  url: z.string().describe("Page URL to generate tests for"),
+  session: z.string().optional().describe("Saved session name (.auth/<name>.storageState.json) for authenticated targets"),
+  checklist: z.string().optional().describe("Path to a checklist file (md/text) that guides what to test"),
+  style: z.string().optional().describe("Planning style or house-style pack (happy | negative | coverage | a pack name/path)"),
+  routing: z.string().optional().describe("Role-routing preset: fast (Groq worker) | volume (OpenRouter worker)"),
+  backend: z.string().optional().describe("Browser backend: lib (in-process, default) | cli"),
+  channel: z.string().optional().describe("System browser channel, e.g. chrome (drives installed Chrome; helps OAuth)"),
+  flow: z.boolean().optional().describe("Follow in-app navigation across pages → multi-page journey cases"),
+  maxPages: z.number().int().positive().optional().describe("Max pages to crawl with flow (default 3)"),
+  setup: z.boolean().optional().describe("For journeys (flow): plan starting-state setup (fixture / API seed)"),
+  gaps: z.boolean().optional().describe("Suggest cases for the top untested surface"),
+  critique: z.boolean().optional().describe("Design-time self-critique pass (prune weak cases + top up technique gaps)"),
+  fresh: z.boolean().optional().describe("Ignore prior-run experience for this URL (full set, no delta)"),
+};
+
+export const ToolInputSchema = z.object(TOOL_INPUT_SHAPE);
+export type ToolInput = z.infer<typeof ToolInputSchema>;
+
+/** Core seam (injected) — the exact functions the CLI uses; mocked in tests. */
+export interface ToolDeps {
+  resolveConfig: typeof resolveConfig;
+  runExploration: typeof runExploration;
+  runDesign: typeof runDesign;
+}
+
+export const defaultDeps: ToolDeps = { resolveConfig, runExploration, runDesign };
+
+/** Map tool input → the shared `ExploreInput` exactly like `exploreModality` does (config reused). */
+async function buildExploreInput(input: ToolInput, deps: ToolDeps): Promise<ExploreInput> {
+  const config = deps.resolveConfig({ backend: input.backend, routing: input.routing, channel: input.channel });
+  const checklistText = input.checklist ? await readInputFile(input.checklist, "Checklist") : undefined;
+  const styleText = input.style ? await resolveStyleText(input.style) : undefined;
+  return {
+    url: input.url,
+    config,
+    sessionName: input.session,
+    checklistText,
+    style: input.style,
+    styleText,
+    fresh: input.fresh,
+    critique: input.critique,
+    flow: input.flow,
+    maxPages: input.flow ? (input.maxPages ?? 3) : undefined,
+    setup: input.setup,
+    gaps: input.gaps,
+  };
+}
+
+/** Compact, LLM-friendly view of a generated case (drops nothing essential, keeps the payload small). */
+function compactCases(cases: TestCase[]) {
+  return cases.map((c) => ({
+    id: c.id,
+    title: c.title,
+    technique: c.technique,
+    type: c.type,
+    priority: c.priority,
+    execution: c.execution,
+    steps: c.steps,
+    expected: c.expected,
+    elementRefs: c.elementRefs,
+  }));
+}
+
+export interface ExploreToolResult {
+  runId: string;
+  runDir: string;
+  pageSemantics: string;
+  testCases: ReturnType<typeof compactCases>;
+  validation?: { greenRatio: number; passed: number; failed: number; flaky: number };
+  scores: { name: string; value: number; comment?: string }[];
+  pilot?: { verdict: string; reason: string; guidance: string };
+  cost: ExploreResult["cost"];
+  testCaseFiles: string[];
+}
+
+export async function exploreTool(input: ToolInput, deps: ToolDeps = defaultDeps): Promise<ExploreToolResult> {
+  const r = await deps.runExploration(await buildExploreInput(input, deps));
+  return {
+    runId: r.runId,
+    runDir: r.runDir,
+    pageSemantics: r.analysis.pageSemantics,
+    testCases: compactCases(r.testCases),
+    validation: r.validation
+      ? {
+          greenRatio: r.validation.greenRatio,
+          passed: r.validation.results.filter((x) => x.status === "passed").length,
+          failed: r.validation.results.filter((x) => x.status === "failed").length,
+          flaky: r.validation.flakyCount,
+        }
+      : undefined,
+    scores: r.scores.map((s) => ({ name: s.name, value: s.value, comment: s.comment })),
+    pilot: r.pilot ? { verdict: r.pilot.verdict, reason: r.pilot.reason, guidance: r.pilot.guidance } : undefined,
+    cost: r.cost,
+    testCaseFiles: r.testCaseFiles,
+  };
+}
+
+export interface DesignToolResult {
+  runId: string;
+  runDir: string;
+  pageSemantics: string;
+  testCases: ReturnType<typeof compactCases>;
+  scores: { name: string; value: number; comment?: string }[];
+  cost: DesignResult["cost"];
+  testCaseFiles: string[];
+}
+
+export async function designTool(input: ToolInput, deps: ToolDeps = defaultDeps): Promise<DesignToolResult> {
+  const r = await deps.runDesign(await buildExploreInput(input, deps));
+  return {
+    runId: r.runId,
+    runDir: r.runDir,
+    pageSemantics: r.analysis.pageSemantics,
+    testCases: compactCases(r.testCases),
+    scores: r.scores.map((s) => ({ name: s.name, value: s.value, comment: s.comment })),
+    cost: r.cost,
+    testCaseFiles: r.testCaseFiles,
+  };
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 import { resolveConfig } from "../core/config.js";
-import { runExploration, runDesign } from "../agent/index.js";
-import type { ExploreInput, ExploreResult, DesignResult } from "../agent/index.js";
+import { runExploration, runDesign, runAutomate } from "../agent/index.js";
+import type { ExploreInput, ExploreResult, DesignResult, AutomateResult } from "../agent/index.js";
 import type { TestCase } from "../design/index.js";
+import type { ValidationReport } from "../validate/index.js";
 import { readInputFile } from "../fs/run-dir.js";
 import { resolveStyleText } from "../design/style.js";
 
@@ -39,9 +40,21 @@ export interface ToolDeps {
   resolveConfig: typeof resolveConfig;
   runExploration: typeof runExploration;
   runDesign: typeof runDesign;
+  runAutomate: typeof runAutomate;
 }
 
-export const defaultDeps: ToolDeps = { resolveConfig, runExploration, runDesign };
+export const defaultDeps: ToolDeps = { resolveConfig, runExploration, runDesign, runAutomate };
+
+/** Compact a validation report into pass/fail/flaky counts (shared by explore + automate). */
+function compactValidation(v: ValidationReport | undefined) {
+  if (!v) return undefined;
+  return {
+    greenRatio: v.greenRatio,
+    passed: v.results.filter((x) => x.status === "passed").length,
+    failed: v.results.filter((x) => x.status === "failed").length,
+    flaky: v.flakyCount,
+  };
+}
 
 /** Map tool input → the shared `ExploreInput` exactly like `exploreModality` does (config reused). */
 async function buildExploreInput(input: ToolInput, deps: ToolDeps): Promise<ExploreInput> {
@@ -98,14 +111,7 @@ export async function exploreTool(input: ToolInput, deps: ToolDeps = defaultDeps
     runDir: r.runDir,
     pageSemantics: r.analysis.pageSemantics,
     testCases: compactCases(r.testCases),
-    validation: r.validation
-      ? {
-          greenRatio: r.validation.greenRatio,
-          passed: r.validation.results.filter((x) => x.status === "passed").length,
-          failed: r.validation.results.filter((x) => x.status === "failed").length,
-          flaky: r.validation.flakyCount,
-        }
-      : undefined,
+    validation: compactValidation(r.validation),
     scores: r.scores.map((s) => ({ name: s.name, value: s.value, comment: s.comment })),
     pilot: r.pilot ? { verdict: r.pilot.verdict, reason: r.pilot.reason, guidance: r.pilot.guidance } : undefined,
     cost: r.cost,
@@ -133,5 +139,43 @@ export async function designTool(input: ToolInput, deps: ToolDeps = defaultDeps)
     scores: r.scores.map((s) => ({ name: s.name, value: s.value, comment: s.comment })),
     cost: r.cost,
     testCaseFiles: r.testCaseFiles,
+  };
+}
+
+/**
+ * Input for the `automate` tool — the second half of the decoupled flow. Unlike explore/design (whose
+ * input is a `url`), automate's input is a previous run that already holds ready ATC cases.
+ */
+export const AUTOMATE_INPUT_SHAPE = {
+  run: z.string().describe("Run folder with ready ATC cases: runs/<id>, a bare <id>, or an absolute path"),
+  validate: z.boolean().optional().describe("Run the generated tests after codegen (requires a session)"),
+  session: z.string().optional().describe("Saved session name for validation"),
+  routing: z.string().optional().describe("Role-routing preset: fast (Groq worker) | volume (OpenRouter worker)"),
+  channel: z.string().optional().describe("System browser channel for validation, e.g. chrome"),
+};
+
+export const AutomateInputSchema = z.object(AUTOMATE_INPUT_SHAPE);
+export type AutomateInput = z.infer<typeof AutomateInputSchema>;
+
+export interface AutomateToolResult {
+  runDir: string;
+  specFiles: string[];
+  validation?: ReturnType<typeof compactValidation>;
+  cost: AutomateResult["cost"];
+}
+
+export async function automateTool(input: AutomateInput, deps: ToolDeps = defaultDeps): Promise<AutomateToolResult> {
+  const config = deps.resolveConfig({ routing: input.routing, channel: input.channel });
+  const r = await deps.runAutomate({
+    runDir: input.run,
+    config,
+    validate: input.validate,
+    sessionName: input.session,
+  });
+  return {
+    runDir: r.runDir,
+    specFiles: r.specFiles,
+    validation: compactValidation(r.validation),
+    cost: r.cost,
   };
 }

--- a/tests/unit/__snapshots__/cli-modalities.test.ts.snap
+++ b/tests/unit/__snapshots__/cli-modalities.test.ts.snap
@@ -37,6 +37,8 @@ Commands:
   unit                   Generate unit tests — coming soon (gated; see L-G2)
   docs                   Generate docs / doctest examples — coming soon (gated;
                          see L-G2)
+  mcp                    run an MCP server (stdio) exposing explore/design as
+                         tools for Claude Code / Cursor
   help [command]         display help for command
 "
 `;

--- a/tests/unit/mcp.test.ts
+++ b/tests/unit/mcp.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { exploreTool, designTool, ToolInputSchema, type ToolDeps } from "../../src/mcp/tools.js";
+import { buildMcpServer } from "../../src/mcp/server.js";
+import type { ExploreResult, DesignResult } from "../../src/agent/index.js";
+
+const tc = {
+  id: "tc-1",
+  title: "Login form visible",
+  technique: "exploratory",
+  kind: "static",
+  type: "Positive",
+  execution: "auto",
+  preconditions: [],
+  steps: ["open page"],
+  expected: "form visible",
+  priority: "high",
+  elementRefs: ["e1"],
+};
+
+/** Mock core: captures the inputs each tool forwards, returns canned results. No browser / LLM. */
+function makeDeps() {
+  const calls: { config?: unknown; explore?: { url: string; flow?: boolean; maxPages?: number }; design?: { url: string } } = {};
+  const deps: ToolDeps = {
+    resolveConfig: (flags) => {
+      calls.config = flags;
+      return { llmProfile: "anthropic" } as unknown as ReturnType<typeof deps.resolveConfig>;
+    },
+    runExploration: async (input) => {
+      calls.explore = input as typeof calls.explore;
+      return {
+        runId: "r1",
+        runDir: "runs/r1",
+        analysis: { pageSemantics: "login page" },
+        testCases: [tc],
+        validation: { greenRatio: 0.5, flakyCount: 0, results: [{ test: "a", status: "passed" }, { test: "b", status: "failed" }] },
+        scores: [{ name: "grounding", value: 1 }],
+        pilot: { verdict: "pass", reason: "ok", guidance: "ship" },
+        cost: { total: 1 },
+        testCaseFiles: ["testcases/tc-1.md"],
+      } as unknown as ExploreResult;
+    },
+    runDesign: async (input) => {
+      calls.design = input as typeof calls.design;
+      return {
+        runId: "d1",
+        runDir: "runs/d1",
+        analysis: { pageSemantics: "login page" },
+        testCases: [tc],
+        testCaseFiles: ["testcases/tc-1.md"],
+        scores: [{ name: "grounding", value: 1 }],
+        cost: { total: 1 },
+      } as unknown as DesignResult;
+    },
+  };
+  return { deps, calls };
+}
+
+describe("MCP explore/design tools (#49)", () => {
+  it("exploreTool maps input → resolveConfig + runExploration and returns a compact result", async () => {
+    const { deps, calls } = makeDeps();
+    const r = await exploreTool({ url: "http://x", routing: "volume", flow: true, maxPages: 5 }, deps);
+
+    expect(calls.config).toEqual({ backend: undefined, routing: "volume", channel: undefined }); // config reused
+    expect(calls.explore?.url).toBe("http://x");
+    expect(calls.explore?.flow).toBe(true);
+    expect(calls.explore?.maxPages).toBe(5);
+
+    expect(r.runId).toBe("r1");
+    expect(r.pageSemantics).toBe("login page");
+    expect(r.testCases[0]).toMatchObject({ id: "tc-1", title: "Login form visible", technique: "exploratory" });
+    expect(r.validation).toEqual({ greenRatio: 0.5, passed: 1, failed: 1, flaky: 0 });
+    expect(r.pilot).toEqual({ verdict: "pass", reason: "ok", guidance: "ship" });
+  });
+
+  it("flow off → maxPages stays undefined (no crawl)", async () => {
+    const { deps, calls } = makeDeps();
+    await exploreTool({ url: "http://x" }, deps);
+    expect(calls.explore?.flow).toBeUndefined();
+    expect(calls.explore?.maxPages).toBeUndefined();
+  });
+
+  it("designTool calls runDesign and returns cases without validation/pilot", async () => {
+    const { deps, calls } = makeDeps();
+    const r = await designTool({ url: "http://x" }, deps);
+    expect(calls.design?.url).toBe("http://x");
+    expect(r.runId).toBe("d1");
+    expect(r.testCases).toHaveLength(1);
+    expect(r).not.toHaveProperty("validation");
+    expect(r).not.toHaveProperty("pilot");
+  });
+
+  it("invalid input (missing url) → clean validation failure", () => {
+    expect(ToolInputSchema.safeParse({}).success).toBe(false);
+    expect(ToolInputSchema.safeParse({ url: "http://x" }).success).toBe(true);
+  });
+});
+
+describe("MCP server (#49)", () => {
+  it("tools/list exposes exactly `explore` and `design`", async () => {
+    const server = buildMcpServer();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name).sort()).toEqual(["design", "explore"]);
+    // each tool advertises its input schema (url is required)
+    const explore = tools.find((t) => t.name === "explore");
+    expect(explore?.inputSchema).toBeDefined();
+
+    await client.close();
+  });
+});

--- a/tests/unit/mcp.test.ts
+++ b/tests/unit/mcp.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { exploreTool, designTool, ToolInputSchema, type ToolDeps } from "../../src/mcp/tools.js";
+import { exploreTool, designTool, automateTool, ToolInputSchema, AutomateInputSchema, type ToolDeps } from "../../src/mcp/tools.js";
 import { buildMcpServer } from "../../src/mcp/server.js";
-import type { ExploreResult, DesignResult } from "../../src/agent/index.js";
+import type { ExploreResult, DesignResult, AutomateResult } from "../../src/agent/index.js";
 
 const tc = {
   id: "tc-1",
@@ -21,7 +21,12 @@ const tc = {
 
 /** Mock core: captures the inputs each tool forwards, returns canned results. No browser / LLM. */
 function makeDeps() {
-  const calls: { config?: unknown; explore?: { url: string; flow?: boolean; maxPages?: number }; design?: { url: string } } = {};
+  const calls: {
+    config?: unknown;
+    explore?: { url: string; flow?: boolean; maxPages?: number };
+    design?: { url: string };
+    automate?: { runDir: string; validate?: boolean; sessionName?: string };
+  } = {};
   const deps: ToolDeps = {
     resolveConfig: (flags) => {
       calls.config = flags;
@@ -52,6 +57,17 @@ function makeDeps() {
         scores: [{ name: "grounding", value: 1 }],
         cost: { total: 1 },
       } as unknown as DesignResult;
+    },
+    runAutomate: async (input) => {
+      calls.automate = input as typeof calls.automate;
+      return {
+        runDir: "runs/a1",
+        specFiles: ["tests/login.spec.ts"],
+        validation: { greenRatio: 1, flakyCount: 0, results: [{ test: "x", status: "passed" }] },
+        cost: { total: 1 },
+        budget: {},
+        stoppedEarly: false,
+      } as unknown as AutomateResult;
     },
   };
   return { deps, calls };
@@ -91,21 +107,34 @@ describe("MCP explore/design tools (#49)", () => {
     expect(r).not.toHaveProperty("pilot");
   });
 
+  it("automateTool calls runAutomate with the run dir + session, returns spec files", async () => {
+    const { deps, calls } = makeDeps();
+    const r = await automateTool({ run: "runs/r1", validate: true, session: "demo", routing: "volume" }, deps);
+    expect(calls.config).toEqual({ routing: "volume", channel: undefined }); // config reused (no backend for automate)
+    expect(calls.automate?.runDir).toBe("runs/r1");
+    expect(calls.automate?.validate).toBe(true);
+    expect(calls.automate?.sessionName).toBe("demo");
+    expect(r.specFiles).toEqual(["tests/login.spec.ts"]);
+    expect(r.validation).toEqual({ greenRatio: 1, passed: 1, failed: 0, flaky: 0 });
+  });
+
   it("invalid input (missing url) → clean validation failure", () => {
     expect(ToolInputSchema.safeParse({}).success).toBe(false);
     expect(ToolInputSchema.safeParse({ url: "http://x" }).success).toBe(true);
+    expect(AutomateInputSchema.safeParse({}).success).toBe(false); // automate needs `run`
+    expect(AutomateInputSchema.safeParse({ run: "runs/r1" }).success).toBe(true);
   });
 });
 
 describe("MCP server (#49)", () => {
-  it("tools/list exposes exactly `explore` and `design`", async () => {
+  it("tools/list exposes exactly `explore`, `design`, and `automate`", async () => {
     const server = buildMcpServer();
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     const client = new Client({ name: "test-client", version: "0.0.0" });
     await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
 
     const { tools } = await client.listTools();
-    expect(tools.map((t) => t.name).sort()).toEqual(["design", "explore"]);
+    expect(tools.map((t) => t.name).sort()).toEqual(["automate", "design", "explore"]);
     // each tool advertises its input schema (url is required)
     const explore = tools.find((t) => t.name === "explore");
     expect(explore?.inputSchema).toBeDefined();


### PR DESCRIPTION
Closes #49.

Expose Cairn's C1 core as an [MCP](https://modelcontextprotocol.io) server so other agents (Claude Code, Cursor) can call **"generate / maintain tests for this target"** as a tool. Thin wrapper over the shared core — **no new generation logic**.

## What's exposed
`cairn mcp` starts a **stdio** MCP server with two tools:

| Tool | Calls | Returns |
|------|-------|---------|
| `explore` | `runExploration` | cases + `@playwright/test` code + validate⇄repair → cases, validation, metrics, Pilot, cost, run dir |
| `design`  | `runDesign` | cases in ATC/MTC format (no code) → cases, metrics, cost, run dir |

Both take the same input — `url` (required) + optional `session`/`flow`/`setup`/`gaps`/`critique`/`fresh`/`checklist`/`style`/`routing`/`backend`/`channel`/`maxPages` — mirroring the matching `cairn explore` flags.

## Design — thin adapter over core
- **`src/mcp/tools.ts`** — `exploreTool`/`designTool` map tool input → the SAME `ExploreInput` the CLI builds, via **`resolveConfig`** (config / role routing / cost reused). Core is **injected** (`ToolDeps`) → handlers are unit-testable without a browser/LLM.
- **`src/mcp/server.ts`** — `buildMcpServer` registers the tools; `startMcpServer` wires `StdioServerTransport`.
- **`cairn mcp`** subcommand lazy-imports the server.
- **`@modelcontextprotocol/sdk`** added as an **optionalDependency** (like Ink/React for the TUI) — lazy-loaded only on the `cairn mcp` path; default `npm i @plune-ai/cairn` doesn't pull it.

## Connect snippet (also in [docs/mcp.md](docs/mcp.md))
Claude Code: `claude mcp add cairn -- cairn mcp` — or a project `.mcp.json`:
```json
{ "mcpServers": { "cairn": { "command": "cairn", "args": ["mcp"], "env": { "ANTHROPIC_API_KEY": "sk-…" } } } }
```
Cursor: the same block in `~/.cursor/mcp.json`.

## DoD checklist
- [x] **MCP server exposing at least `explore`/`design` as tools** — both registered; smoke test asserts `tools/list` returns exactly them.
- [x] **Runs locally** — stdio transport.
- [x] **Documented connect snippet** — `docs/mcp.md` (Claude Code + Cursor) + README link.
- [x] **Reuses core config / routing / cost** — via `resolveConfig`; tools call the same `runExploration`/`runDesign`; cost returned in the result.

## Tests
- Unit (`tests/unit/mcp.test.ts`): handlers with mocked core — valid input → correct `resolveConfig` + core call + expected shape; `flow` off → `maxPages` undefined; missing `url` → clean validation failure.
- Smoke: `buildMcpServer` + `InMemoryTransport` + a client → `tools/list` returns exactly `explore`+`design`.
- No browser/LLM in tests (core mocked).

## Verification
- `npm test` → 526 passed, 2 skipped, 0 failed (5 new; CLI surface-lock snapshot updated for the new `mcp` command)
- `npm run lint` · `npm run typecheck` · `npm run build` clean

> Not merging — left for review. Note: `package.json` version untouched (release is separate).