### PR TITLE
fix: bound slow OpenRouter codegen/reasoning + volume-fast routing (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **OpenRouter codegen/reasoning latency — `explore`/`design` no longer hang (#110).** On the
+  `openrouter` profile / `volume` routing, `deepseek-chat` (codegen) ran 4.5–13 min and `deepseek-r1`
+  (reasoner) overran interactive/MCP timeouts without finishing. Two fixes:
+  - **Per-step timeout** (`STEP_TIMEOUT_MS`, default **240000 ms** / 4 min; `0` disables). Each
+    structured LLM call is now bounded — a pathologically slow provider fails fast with an **actionable
+    error** (suggesting a faster `--routing`/Anthropic, or raising `STEP_TIMEOUT_MS`) instead of hanging
+    indefinitely, which the MCP server's caller cannot otherwise observe. Healthy Anthropic steps
+    (~90 s) are unaffected.
+  - **New `volume-fast` routing preset** (`--routing volume-fast` / `LLM_ROUTING=volume-fast`): codegen
+    + analyze (worker) on Anthropic Sonnet — fast where `deepseek-chat` is not — while the cheap
+    LLM-as-judge scorer stays on OpenRouter via `LLM_PROFILE`. Unlike `fast` (Groq), it avoids the
+    large-codegen `json_schema` 400 (`groq-fast-json-schema-bug`), so it is the recommended escape for
+    slow OpenRouter codegen.
+
 ## [0.5.0] - 2026-06-24
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,8 +3,9 @@
 | Var | Purpose |
 |---|---|
 | `LLM_PROFILE` | `anthropic` \| `openrouter` \| `mixed` (per-tier default models) |
-| `LLM_ROUTING` | per-role preset: `fast` (Groq worker) \| `volume` (OpenRouter worker) — see [Role routing](#role-routing) |
+| `LLM_ROUTING` | per-role preset: `fast` (Groq worker) \| `volume` (OpenRouter worker) \| `volume-fast` (Anthropic codegen) — see [Role routing](#role-routing) |
 | `ANTHROPIC_API_KEY` / `OPENROUTER_API_KEY` / `GROQ_API_KEY` | provider keys (per profile / routing) |
+| `STEP_TIMEOUT_MS` | per-step LLM timeout in ms (default `240000` = 4 min; `0` disables) — see [Provider latency](#provider-latency) |
 | `QA_TESTCASE_LANG` | test-case language (default `English`; e.g. `Ukrainian`, `uk`) |
 | `LANGFUSE_BASE_URL` / `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` | Langfuse — **cloud or self-hosted** (optional; see [Langfuse](langfuse.md)) |
 | `BROWSER_BACKEND` | `lib` (in-process Playwright) \| `cli` |
@@ -13,10 +14,12 @@
 
 - **Env var prefix:** every variable above is read as-is **or** with a `CAIRN_` prefix (e.g. `CAIRN_LLM_PROFILE`, `CAIRN_MAX_REPAIR`). Legacy `LEX_`/`LEXBOT_` prefixes still work but print a one-time deprecation warning — prefer `CAIRN_`.
 - <a id="role-routing"></a>**Role routing (`LLM_ROUTING`, optional):** layer a cheap **worker** over any profile while keeping the strong **reasoner**. One flag picks where the mechanical steps (identify-elements, generate-code/repair) run:
-  - `fast` → worker on **Groq** `llama-3.3-70b-versatile` — lowest latency/cost, OpenAI-compatible tool-calling.
-  - `volume` → worker on **OpenRouter** `deepseek/deepseek-chat` — model breadth.
+  - `fast` → worker on **Groq** `llama-3.3-70b-versatile` — lowest latency/cost, OpenAI-compatible tool-calling. ⚠ Groq 400s on large-codegen `json_schema` (`groq-fast-json-schema-bug`) — fine for design, not a codegen escape.
+  - `volume` → worker on **OpenRouter** `deepseek/deepseek-chat` — model breadth, but **slow on large codegen** (4.5–13 min, see [Provider latency](#provider-latency)).
+  - `volume-fast` → worker on **Anthropic** `claude-sonnet-4-6` — the latency-safe sibling of `volume`: codegen finishes in ~90 s while the cheap `judge` scorer still runs on OpenRouter via `LLM_PROFILE`. **Recommended when OpenRouter codegen overruns timeouts (#110).**
   - default (unset) → the profile's own per-tier models.
 
   In **every** preset the reasoner (design test cases + Pilot verdict) stays on **Anthropic** `claude-opus-4-8` for judgment quality, and the cheap `judge` scorer keeps the profile tier (routing never touches it). Override any role with `CAIRN_ROLE_WORKER` / `CAIRN_ROLE_REASONER=provider:model`; pass `--routing <preset>` on `explore`/`design`/`automate` to set it per run. Per-run **per-role cost** (tokens + $) is printed in the run summary.
+- <a id="provider-latency"></a>**Provider latency & per-step timeout (`STEP_TIMEOUT_MS`, #110):** providers differ by minutes per step. Measured on `https://plune.ai/`: Anthropic `claude-opus-4-8` design ≈ **90 s** (finishes); OpenRouter `deepseek-chat` codegen ≈ **4.5–13 min**; OpenRouter `deepseek-r1` design **overran 4 min without finishing**. Each structured call is bounded by `STEP_TIMEOUT_MS` (default `240000`); on overrun the step fails with an **actionable error** (try a faster `--routing` such as `volume-fast`, or `LLM_PROFILE=anthropic`, or raise `STEP_TIMEOUT_MS`) instead of hanging. `0` disables the timeout. **MCP guidance:** the MCP caller (Claude Code / Cursor) sees a timeout as a clean tool error — keep `STEP_TIMEOUT_MS` at/under your client's tool timeout, and prefer the `volume-fast`/`anthropic` paths for interactive MCP use.
 - **Domain knowledge:** put `*.md` files in `./knowledge/` with a `url:` front-matter to inject credentials/validation rules into design.
 - **Prompt overrides & house-style:** drop `./prompts/<name>.md` to override any built-in prompt, and use `--style` to load a house-style pack — see [Prompts & styles](prompts-and-styles.md).

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -112,7 +112,7 @@ export function buildProgram(): Command {
     .option("--checklist <file>", "checklist file (md/text) — guides what to test")
     .option("--style <s>", "planning style: happy | negative | coverage | all")
     .option("--fresh", "ignore prior runs for this URL — generate a full set, don't dedupe against past cases")
-    .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
+    .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) | volume-fast (Anthropic codegen, cheap judge on OpenRouter) (sets LLM_ROUTING)")
     .option("--critique", "self-critique pass after design: prune weak cases + top up technique gaps (1 extra worker-tier LLM call)")
     .option("--flow", "follow in-app navigation across pages and design multi-page journey cases (opt-in)")
     .option("--max-pages <n>", "max pages to crawl with --flow (page cap; default 3)")
@@ -226,7 +226,7 @@ export function buildProgram(): Command {
     .option("--checklist <file>", "checklist file — guides what to test")
     .option("--style <s>", "planning style: happy | negative | coverage | all")
     .option("--fresh", "ignore prior runs for this URL — generate a full set, don't dedupe against past cases")
-    .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
+    .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) | volume-fast (Anthropic codegen, cheap judge on OpenRouter) (sets LLM_ROUTING)")
     .option("--critique", "self-critique pass after design: prune weak cases + top up technique gaps (1 extra worker-tier LLM call)")
     .option("--flow", "follow in-app navigation across pages and design multi-page journey cases (opt-in)")
     .option("--max-pages <n>", "max pages to crawl with --flow (page cap; default 3)")
@@ -306,7 +306,7 @@ export function buildProgram(): Command {
     .option("--session <name>", "session name for validation")
     .option("--session-file <path>", "path to storageState for validation")
     .option("--channel <channel>", "system browser channel, e.g. chrome — validate on your installed Chrome (no bundled-Chromium download)")
-    .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) (sets LLM_ROUTING)")
+    .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) | volume-fast (Anthropic codegen, cheap judge on OpenRouter) (sets LLM_ROUTING)")
     .action(
       async (opts: { run: string; validate?: boolean; session?: string; sessionFile?: string; channel?: string; routing?: string }) => {
         const config = resolveConfig({ routing: opts.routing, channel: opts.channel });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,6 +8,7 @@ import {
 import type { AppConfig, Provider, ModelTier, RolesConfig } from "./schema.js";
 import { PROFILES, ROUTING_PRESETS } from "./profiles.js";
 import { createEnvReader } from "./env.js";
+import { DEFAULT_STEP_TIMEOUT_MS } from "../llm/structured.js";
 
 export type { AppConfig, ModelsConfig, ModelTier, Provider, LlmProfile, BrowserBackend, Role, RoleModel, RolesConfig } from "./schema.js";
 
@@ -96,6 +97,14 @@ export function loadConfig(
     throw new Error(`Invalid PLAYWRIGHT_WORKERS='${workersRaw}'. Must be a positive integer (≥ 1).`);
   }
 
+  // #110: per-step LLM timeout (ms). Default 240000 (4 min); 0 disables. Guards against a slow
+  // provider hanging explore/design indefinitely (esp. via the MCP server).
+  const stepTimeoutRaw = read("STEP_TIMEOUT_MS");
+  const stepTimeoutMs = stepTimeoutRaw === undefined ? DEFAULT_STEP_TIMEOUT_MS : Number(stepTimeoutRaw);
+  if (!Number.isInteger(stepTimeoutMs) || stepTimeoutMs < 0) {
+    throw new Error(`Invalid STEP_TIMEOUT_MS='${stepTimeoutRaw}'. Must be a non-negative integer in ms (0 disables).`);
+  }
+
   // Test-case language: default English; env override accepts a name or a code (en/uk/ua).
   const langRaw = (read("QA_TESTCASE_LANG") ?? "English").trim();
   const LANG_ALIASES: Record<string, string> = {
@@ -127,6 +136,7 @@ export function loadConfig(
     maxRepair,
     playwrightWorkers,
     testCaseLanguage,
+    stepTimeoutMs,
   };
 }
 

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -39,6 +39,12 @@ export const PROFILES: Record<LlmProfile, ModelsConfig> = {
  * `fast` (L1-02) = the one-flag low-latency preset: the worker on Groq (lowest latency/cost,
  * OpenAI-compatible tool-calling), the reasoner still on Claude Opus (keep judgment strong).
  * Both presets compose with `LLM_PROFILE` and stay overridable via `CAIRN_ROLE_<NAME>`.
+ *
+ * `volume-fast` (#110) = the latency-safe sibling of `volume`: codegen/analyze (worker) move to
+ * Anthropic Sonnet — `deepseek/deepseek-chat` is pathologically slow on large codegen (4.5–13 min)
+ * — while the cheap LLM-as-judge scorer stays on OpenRouter via `LLM_PROFILE`. Unlike `fast`, the
+ * worker is NOT Groq (Groq's OpenAI-compat endpoint 400s on large-codegen json_schema, see
+ * `groq-fast-json-schema-bug`), so this preset is the recommended escape for slow OpenRouter codegen.
  */
 export const ROUTING_PRESETS: Record<string, RolesConfig> = {
   volume: {
@@ -46,6 +52,13 @@ export const ROUTING_PRESETS: Record<string, RolesConfig> = {
     // supportsVision:false → identifyElements falls back to aria-only (ADR-0002, vision-optional).
     worker: { provider: "openrouter", model: "deepseek/deepseek-chat", supportsVision: false },
     // reasoner = designTestCases + Pilot verdict → quality model.
+    reasoner: { provider: "anthropic", model: "claude-opus-4-8", supportsVision: false },
+  },
+  "volume-fast": {
+    // worker (codegen + analyze) → Anthropic Sonnet: fast, finishes in ~90s where deepseek-chat
+    // overruns interactive/MCP timeouts (#110). supportsVision:false → identifyElements aria-only.
+    worker: { provider: "anthropic", model: "claude-sonnet-4-6", supportsVision: false },
+    // reasoner = designTestCases + Pilot verdict → Anthropic Opus (also avoids the deepseek-r1 hang).
     reasoner: { provider: "anthropic", model: "claude-opus-4-8", supportsVision: false },
   },
   fast: {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -64,4 +64,10 @@ export interface AppConfig {
   playwrightWorkers: number;
   /** Language of generated test cases (env QA_TESTCASE_LANG; default "English"). */
   testCaseLanguage: string;
+  /**
+   * Per-step LLM timeout in ms (#110; env STEP_TIMEOUT_MS, default 240000). Bounds each structured
+   * call so a pathologically slow provider (OpenRouter deepseek-r1/deepseek-chat) fails with an
+   * actionable error instead of hanging — important for the MCP server. `0` disables the timeout.
+   */
+  stepTimeoutMs: number;
 }

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -3,8 +3,8 @@ export type { ModelSpec, ProviderKeys } from "./factory.js";
 export { imageBlock } from "./vision.js";
 export type { ImageBlock } from "./vision.js";
 // L1-01 — per-role routing + cost/token accounting (ADR-0011).
-export { structuredInvoker, meteredInvoker, retryInvoke, CallBudget, cappedInvoke } from "./structured.js";
-export type { StructuredInvoke, StructuredMethod } from "./structured.js";
+export { structuredInvoker, meteredInvoker, retryInvoke, CallBudget, cappedInvoke, timeoutInvoke, DEFAULT_STEP_TIMEOUT_MS } from "./structured.js";
+export type { StructuredInvoke, StructuredMethod, TimeoutOptions } from "./structured.js";
 export { RoleRouter, resolveRoleTier, KNOWN_ROLES } from "./routing.js";
 export { CostLedger, DEFAULT_PRICING, priceFor, extractUsage } from "./cost.js";
 export type { CostReport, RoleCost, TokenUsage, ModelPrice } from "./cost.js";

--- a/src/llm/routing.ts
+++ b/src/llm/routing.ts
@@ -1,7 +1,7 @@
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import type { AppConfig, ModelTier, RolesConfig } from "../config/index.js";
 import { makeModel, structuredMethodFor, type ProviderKeys } from "./factory.js";
-import { meteredInvoker, cappedInvoke, retryInvoke } from "./structured.js";
+import { meteredInvoker, cappedInvoke, retryInvoke, timeoutInvoke } from "./structured.js";
 import type { CallBudget, StructuredInvoke } from "./structured.js";
 import { CostLedger, type ModelPrice } from "./cost.js";
 
@@ -60,6 +60,12 @@ export class RoleRouter {
     const method = structuredMethodFor(tier.provider);
     const config = this.callbacks ? { callbacks: this.callbacks } : undefined;
     const metered = meteredInvoker(model, (u, m) => this.ledger.record(role, m, u), tier.model, method, config);
-    return cappedInvoke(retryInvoke(metered), this.budget, this.onCharge);
+    // #110: bound the whole step (incl. retries) so a slow provider fails with an actionable error
+    // instead of hanging. Layered OUTSIDE retryInvoke → the timeout error is never itself retried.
+    const guarded = timeoutInvoke(retryInvoke(metered), {
+      timeoutMs: this.cfg.stepTimeoutMs,
+      label: `role '${role}', model '${tier.model}'`,
+    });
+    return cappedInvoke(guarded, this.budget, this.onCharge);
   }
 }

--- a/src/llm/structured.ts
+++ b/src/llm/structured.ts
@@ -81,6 +81,58 @@ export function retryInvoke(inner: StructuredInvoke, opts: RetryOptions = {}): S
   };
 }
 
+/**
+ * Default per-step LLM timeout (#110). Anthropic finishes a step in ~90s; OpenRouter `deepseek-r1`
+ * (reasoner) / `deepseek-chat` (codegen) can hang for minutes, overrunning interactive/MCP timeouts.
+ * 4 min lets a healthy Anthropic step through while cutting a pathological provider hang short with an
+ * actionable error. Overridable via `STEP_TIMEOUT_MS`; `0` disables the timeout entirely.
+ */
+export const DEFAULT_STEP_TIMEOUT_MS = 240_000;
+
+export interface TimeoutOptions {
+  /** Wall-clock cap per step (ms). `0`/negative/undefined → no timeout (wrapper returns `inner` as-is). */
+  timeoutMs?: number;
+  /** Context for the error message, e.g. `role 'reasoner', model 'deepseek/deepseek-r1'`. */
+  label?: string;
+}
+
+/**
+ * Per-step timeout (#110): bounds the wall-clock of one structured call (incl. its retries when wrapped
+ * OUTSIDE {@link retryInvoke}) and, on overrun, throws ONE actionable error instead of hanging forever —
+ * critical for the MCP server, where the caller can't see progress. The losing inner call is left to
+ * settle in the background (its rejection is swallowed); we don't cancel the HTTP request, we just stop
+ * waiting. The actionable message points at the latency-safe escapes (a faster `--routing`/Anthropic),
+ * deliberately NOT Groq `fast`, which 400s on large codegen (`groq-fast-json-schema-bug`).
+ */
+export function timeoutInvoke(inner: StructuredInvoke, opts: TimeoutOptions = {}): StructuredInvoke {
+  const timeoutMs = opts.timeoutMs ?? 0;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return inner; // disabled → no overhead, no behavior change
+  const where = opts.label ? ` (${opts.label})` : "";
+  return async <T>(schema: ZodType<T>, messages: BaseMessageLike[]): Promise<T> => {
+    const innerP = inner(schema, messages);
+    innerP.catch(() => undefined); // a losing race must not surface as an unhandledRejection
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeoutP = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(
+          new Error(
+            `LLM step timed out after ${timeoutMs}ms${where} — the provider is too slow for this step. ` +
+              `Try a faster routing (e.g. --routing volume-fast) or the Anthropic profile ` +
+              `(LLM_PROFILE=anthropic), or raise STEP_TIMEOUT_MS.`,
+          ),
+        );
+      }, timeoutMs);
+      // Never let a pending timer keep the process alive (e.g. after the call settles late).
+      (timer as { unref?: () => void }).unref?.();
+    });
+    try {
+      return await Promise.race([innerP, timeoutP]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  };
+}
+
 /** Cost-guardrail (Sprint 6): shared LLM-call counter per run — a safeguard against runaway cost. */
 export class CallBudget {
   private n = 0;

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -21,7 +21,7 @@ export const TOOL_INPUT_SHAPE = {
   session: z.string().optional().describe("Saved session name (.auth/<name>.storageState.json) for authenticated targets"),
   checklist: z.string().optional().describe("Path to a checklist file (md/text) that guides what to test"),
   style: z.string().optional().describe("Planning style or house-style pack (happy | negative | coverage | a pack name/path)"),
-  routing: z.string().optional().describe("Role-routing preset: fast (Groq worker) | volume (OpenRouter worker)"),
+  routing: z.string().optional().describe("Role-routing preset: fast (Groq worker) | volume (OpenRouter worker) | volume-fast (Anthropic codegen — faster, recommended when OpenRouter codegen overruns timeouts)"),
   backend: z.string().optional().describe("Browser backend: lib (in-process, default) | cli"),
   channel: z.string().optional().describe("System browser channel, e.g. chrome (drives installed Chrome; helps OAuth)"),
   flow: z.boolean().optional().describe("Follow in-app navigation across pages → multi-page journey cases"),
@@ -150,7 +150,7 @@ export const AUTOMATE_INPUT_SHAPE = {
   run: z.string().describe("Run folder with ready ATC cases: runs/<id>, a bare <id>, or an absolute path"),
   validate: z.boolean().optional().describe("Run the generated tests after codegen (requires a session)"),
   session: z.string().optional().describe("Saved session name for validation"),
-  routing: z.string().optional().describe("Role-routing preset: fast (Groq worker) | volume (OpenRouter worker)"),
+  routing: z.string().optional().describe("Role-routing preset: fast (Groq worker) | volume (OpenRouter worker) | volume-fast (Anthropic codegen — faster, recommended when OpenRouter codegen overruns timeouts)"),
   channel: z.string().optional().describe("System browser channel for validation, e.g. chrome"),
 };
 

--- a/tests/unit/__snapshots__/cli-modalities.test.ts.snap
+++ b/tests/unit/__snapshots__/cli-modalities.test.ts.snap
@@ -63,7 +63,8 @@ Options:
   --fresh                ignore prior runs for this URL — generate a full set,
                          don't dedupe against past cases
   --routing <preset>     role-routing preset: fast (Groq worker) | volume
-                         (OpenRouter worker) (sets LLM_ROUTING)
+                         (OpenRouter worker) | volume-fast (Anthropic codegen,
+                         cheap judge on OpenRouter) (sets LLM_ROUTING)
   --critique             self-critique pass after design: prune weak cases + top
                          up technique gaps (1 extra worker-tier LLM call)
   --flow                 follow in-app navigation across pages and design

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -135,6 +135,17 @@ describe("loadConfig — browser and maxRepair", () => {
     expect(loadConfig({ ...baseEnv, QA_TESTCASE_LANG: "Ukrainian" }).testCaseLanguage).toBe("Ukrainian");
     expect(loadConfig({ ...baseEnv, QA_TESTCASE_LANG: "Deutsch" }).testCaseLanguage).toBe("Deutsch");
   });
+
+  it("stepTimeoutMs defaults to 240000 (4 min), overridable via STEP_TIMEOUT_MS; 0 disables (#110)", () => {
+    expect(loadConfig({ ...baseEnv }).stepTimeoutMs).toBe(240000);
+    expect(loadConfig({ ...baseEnv, STEP_TIMEOUT_MS: "60000" }).stepTimeoutMs).toBe(60000);
+    expect(loadConfig({ ...baseEnv, STEP_TIMEOUT_MS: "0" }).stepTimeoutMs).toBe(0);
+  });
+
+  it("invalid STEP_TIMEOUT_MS (negative or non-numeric) throws a clear error (#110)", () => {
+    expect(() => loadConfig({ ...baseEnv, STEP_TIMEOUT_MS: "-1" })).toThrow(/STEP_TIMEOUT_MS/);
+    expect(() => loadConfig({ ...baseEnv, STEP_TIMEOUT_MS: "abc" })).toThrow(/STEP_TIMEOUT_MS/);
+  });
 });
 
 describe("loadConfig — per-role routing is additive + backward-compatible (L1-01)", () => {
@@ -159,6 +170,22 @@ describe("loadConfig — per-role routing is additive + backward-compatible (L1-
     expect(cfg.roles?.reasoner?.model).toBe("claude-opus-4-8");
     // routing does NOT touch the profile tiers (incl. the cheap judge scorer)
     expect(cfg.models.judge.model).toBe("claude-haiku-4-5");
+  });
+
+  it("LLM_ROUTING=volume-fast → worker=Anthropic Sonnet (fast codegen), reasoner=Anthropic; judge stays cheap (#110)", () => {
+    const cfg = loadConfig({ ...baseEnv, LLM_PROFILE: "openrouter", LLM_ROUTING: "volume-fast" });
+    expect(cfg.roles?.worker?.provider).toBe("anthropic");
+    expect(cfg.roles?.worker?.model).toBe("claude-sonnet-4-6");
+    expect(cfg.roles?.reasoner?.provider).toBe("anthropic");
+    expect(cfg.roles?.reasoner?.model).toBe("claude-opus-4-8");
+    // the cheap judge scorer is NOT a role → it keeps the OpenRouter profile tier (cheap bulk stays on OpenRouter).
+    expect(cfg.models.judge.provider).toBe("openrouter");
+  });
+
+  it("volume-fast without ANTHROPIC_API_KEY → error names ROLE 'worker' + Anthropic (#110)", () => {
+    expect(() => loadConfig({ OPENROUTER_API_KEY: "x", LLM_PROFILE: "openrouter", LLM_ROUTING: "volume-fast" })).toThrow(
+      /Role 'worker'.*Anthropic/i,
+    );
   });
 
   it("LLM_ROUTING=fast → worker=Groq (lowest latency/cost), reasoner=Anthropic (smart) (L1-02)", () => {

--- a/tests/unit/timeout-invoke.test.ts
+++ b/tests/unit/timeout-invoke.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from "vitest";
+import { z } from "zod";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { timeoutInvoke, DEFAULT_STEP_TIMEOUT_MS, CallBudget } from "../../src/llm/structured.js";
+import type { StructuredInvoke } from "../../src/llm/structured.js";
+import { RoleRouter } from "../../src/llm/routing.js";
+import type { AppConfig, ModelTier } from "../../src/config/index.js";
+
+const S = z.object({ ok: z.boolean() });
+
+describe("timeoutInvoke (#110 — per-step timeout)", () => {
+  it("DEFAULT_STEP_TIMEOUT_MS is 4 min (lets a healthy Anthropic step through, cuts a provider hang)", () => {
+    expect(DEFAULT_STEP_TIMEOUT_MS).toBe(240000);
+  });
+
+  it("disabled (0 / negative / undefined) → returns inner unchanged, no overhead", () => {
+    const inner: StructuredInvoke = async (schema) => schema.parse({ ok: true });
+    expect(timeoutInvoke(inner, { timeoutMs: 0 })).toBe(inner);
+    expect(timeoutInvoke(inner, { timeoutMs: -5 })).toBe(inner);
+    expect(timeoutInvoke(inner, {})).toBe(inner);
+    expect(timeoutInvoke(inner)).toBe(inner);
+  });
+
+  it("a fast inner resolves normally and the timer is cleared (no hang)", async () => {
+    const inner: StructuredInvoke = async (schema) => schema.parse({ ok: true });
+    const guarded = timeoutInvoke(inner, { timeoutMs: 10000 });
+    await expect(guarded(S, [])).resolves.toEqual({ ok: true });
+  });
+
+  it("a slow inner overruns the timeout → throws ONE actionable error (does not hang)", async () => {
+    vi.useFakeTimers();
+    try {
+      const inner: StructuredInvoke = () => new Promise(() => undefined); // never settles
+      const guarded = timeoutInvoke(inner, {
+        timeoutMs: 1000,
+        label: "role 'reasoner', model 'deepseek/deepseek-r1'",
+      });
+      const p = guarded(S, []);
+      const assertion = expect(p).rejects.toThrow(/timed out after 1000ms/);
+      await vi.advanceTimersByTimeAsync(1000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("the timeout error is actionable: names the faster routing, the Anthropic profile, STEP_TIMEOUT_MS, and the step label", async () => {
+    vi.useFakeTimers();
+    try {
+      const inner: StructuredInvoke = () => new Promise(() => undefined);
+      const guarded = timeoutInvoke(inner, {
+        timeoutMs: 500,
+        label: "role 'worker', model 'deepseek/deepseek-chat'",
+      });
+      const p = guarded(S, []);
+      const captured = p.catch((e: unknown) => (e instanceof Error ? e.message : String(e)));
+      await vi.advanceTimersByTimeAsync(500);
+      const msg = await captured;
+      expect(msg).toMatch(/volume-fast/); // points at the latency-safe escape…
+      expect(msg).toMatch(/LLM_PROFILE=anthropic/); // …or Anthropic
+      expect(msg).toMatch(/STEP_TIMEOUT_MS/); // …or raising the cap
+      expect(msg).toContain("role 'worker', model 'deepseek/deepseek-chat'"); // which step timed out
+      expect(msg).not.toMatch(/Groq|--routing fast\b/); // NOT the Groq escape (400s on large codegen)
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a losing inner that rejects AFTER the timeout does not surface as an unhandled rejection", async () => {
+    vi.useFakeTimers();
+    let unhandled: unknown;
+    const onUnhandled = (reason: unknown): void => {
+      unhandled = reason;
+    };
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      const inner: StructuredInvoke = () =>
+        new Promise((_, reject) => setTimeout(() => reject(new Error("late provider error")), 2000));
+      const guarded = timeoutInvoke(inner, { timeoutMs: 1000 });
+      const p = guarded(S, []);
+      const assertion = expect(p).rejects.toThrow(/timed out/);
+      await vi.advanceTimersByTimeAsync(1000); // timeout fires first
+      await assertion;
+      await vi.advanceTimersByTimeAsync(1000); // inner rejects late — must be swallowed
+      await Promise.resolve();
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      vi.useRealTimers();
+    }
+    expect(unhandled).toBeUndefined();
+  });
+});
+
+describe("RoleRouter — wires the per-step timeout from cfg.stepTimeoutMs (#110)", () => {
+  const bulk: ModelTier = { provider: "anthropic", model: "claude-sonnet-4-6", supportsVision: false };
+  const vision: ModelTier = { provider: "anthropic", model: "claude-haiku-4-5", supportsVision: true };
+
+  /** Fake model whose structured invoke never settles (simulates a pathologically slow provider). */
+  function hangingModel(): BaseChatModel {
+    return {
+      withStructuredOutput: () => ({ invoke: () => new Promise(() => undefined) }),
+    } as unknown as BaseChatModel;
+  }
+
+  function cfgWithTimeout(stepTimeoutMs: number): AppConfig {
+    return {
+      llmProfile: "anthropic",
+      models: { reasoning: bulk, bulk, judge: bulk, vision },
+      langfuse: { enabled: false },
+      browser: { backend: "lib" },
+      maxRepair: 0,
+      testCaseLanguage: "English",
+      stepTimeoutMs,
+    } as unknown as AppConfig;
+  }
+
+  it("a hanging provider call rejects with the actionable timeout error instead of never resolving", async () => {
+    vi.useFakeTimers();
+    try {
+      const router = new RoleRouter(cfgWithTimeout(800), { anthropicApiKey: "k" }, new CallBudget(80), undefined, () =>
+        hangingModel(),
+      );
+      const p = router.invoke("reasoner", bulk)(S, []);
+      const assertion = expect(p).rejects.toThrow(/timed out after 800ms.*role 'reasoner', model 'claude-sonnet-4-6'/s);
+      await vi.advanceTimersByTimeAsync(800);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stepTimeoutMs=0 disables the timeout — a fast call still resolves (no regression for healthy providers)", async () => {
+    const okModel = {
+      withStructuredOutput: () => ({ invoke: async () => ({ raw: {}, parsed: { ok: true } }) }),
+    } as unknown as BaseChatModel;
+    const router = new RoleRouter(cfgWithTimeout(0), { anthropicApiKey: "k" }, new CallBudget(80), undefined, () => okModel);
+    await expect(router.invoke("worker", bulk)(S, [])).resolves.toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
Closes #110

## Problem
On the `openrouter` profile / `volume` routing, `explore`/`design` were pathologically slow and overran interactive/MCP timeouts — **purely provider latency**, independent of transport.

## What changed (strictly in scope: routing + per-step timeout + actionable error)

### 1. Per-step timeout + actionable error
- New `timeoutInvoke` wrapper (`src/llm/structured.ts`) + `STEP_TIMEOUT_MS` env (default **240000 ms / 4 min**; `0` disables, `DEFAULT_STEP_TIMEOUT_MS`).
- Composed in `RoleRouter.invoke` **outside** `retryInvoke`, so each step's whole wall-clock (incl. retries) is bounded and the timeout error is never itself retried.
- On overrun: **one actionable error** — *"provider too slow; try a faster routing (e.g. --routing volume-fast) or the Anthropic profile, or raise STEP_TIMEOUT_MS"* — instead of an indefinite hang. Critical for the MCP server, where the caller can't see progress (the timeout surfaces as a clean tool error).
- The losing inner call is left to settle in the background; its rejection is swallowed (no `unhandledRejection`). We stop waiting, we don't cancel the HTTP request.

### 2. New `volume-fast` routing preset
`worker` (codegen + analyze) → Anthropic `claude-sonnet-4-6`; `reasoner` → Anthropic `claude-opus-4-8`; the cheap LLM-as-judge scorer **stays on OpenRouter** via `LLM_PROFILE`. Unlike `fast` (Groq), it avoids the large-codegen `json_schema` 400 (`groq-fast-json-schema-bug`) — so it's the recommended escape for slow OpenRouter codegen, and the timeout error points here (not at Groq).

### 3. Docs
`docs/configuration.md`: per-provider latency table + `STEP_TIMEOUT_MS` + **MCP timeout guidance**. CLI/MCP `--routing` help + CHANGELOG updated.

## Verification vs the issue Evidence
| Evidence symptom | Before | After |
|---|---|---|
| `generateCode` deepseek-chat ~4.5–13 min | indefinite/very slow | `--routing volume-fast` → Anthropic Sonnet codegen; **or** bounded by `STEP_TIMEOUT_MS` → actionable error |
| `designTestCases` deepseek-r1 >4 min, didn't finish | hangs | bounded at 4 min → actionable error; **or** `volume-fast` routes reasoner → Anthropic |
| Anthropic ~90s (contrast) | fine | **unchanged** — 4 min cap leaves it untouched; `stepTimeoutMs=0` reproduces the exact prior chain |
| MCP `tools/call design` stalls | caller blind to hang | rejects within `STEP_TIMEOUT_MS` with a clean error |

## Tests (core/LLM mocked, no real browser/provider)
- `tests/unit/timeout-invoke.test.ts`: timeout fires → actionable error (names `volume-fast`, `LLM_PROFILE=anthropic`, `STEP_TIMEOUT_MS`, the step label; **not** Groq/`fast`); fast call resolves; disabled (`0`/neg/undefined) returns inner unchanged; late inner rejection swallowed; `RoleRouter` hanging-provider integration; `stepTimeoutMs=0` no-op (no regression).
- `tests/unit/config.test.ts`: `STEP_TIMEOUT_MS` default/override/validation; `volume-fast` resolution + missing-Anthropic-key error; default Anthropic behavior unchanged.

Local checks: `lint` ✅ · `typecheck` ✅ · `build` ✅ · unit **533 passed** ✅ · `smoke:pack` **8 checks** ✅. (3 integration tests fail only because Chromium isn't installed in this environment — unrelated.)

## Follow-ups (out of scope here)
- Explicit per-step **latency logging** (duration ms). Currently derivable from `run.log` ISO timestamps bracketing each `onProgress` step; an explicit duration line would make slow steps obvious at a glance.
- Optionally pass an `AbortSignal` to the LangChain invoke so the underlying HTTP request is actually cancelled on timeout (today we only stop waiting).
