### PR TITLE
feat: plug into existing Playwright projects — --into-project (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Plug into existing Playwright projects — `--into-project` (#51).** Cairn can now write the
+  generated specs straight into a host project's Playwright setup instead of the greenfield
+  `runs/<id>/tests` folder. `cairn explore … --into-project [dir]` / `cairn automate … --into-project [dir]`
+  (and the `intoProject`/`projectDir` inputs on the public API + MCP `explore`/`automate` tools)
+  detect the nearest `playwright.config.{ts,js,mjs,cjs}` (walking up from the cwd, or from an explicit
+  `dir`), resolve its `testDir`, and emit specs there using the project's filename convention
+  (`.spec.ts` vs `.test.ts`, read best-effort from `testMatch`). Placement is **collision-safe** — a
+  pre-existing spec is never overwritten; Cairn disambiguates its own file (`login.cairn.spec.ts`)
+  instead. Validation/repair still run against an isolated `runs/<id>/tests` sandbox (same Playwright,
+  identical result — so the user's existing suite is never run or deleted); the validated best specs
+  are then ejected into the project's `testDir` (single deliverable, discoverable by the project's own
+  `npx playwright test`) and the sandbox is removed, while the `runs/<id>/` trail keeps
+  study/report/testcases. Without the flag, behavior is unchanged (greenfield `runs/`). When the flag
+  is set but no config is found, Cairn logs that and falls back to greenfield (no failure).
+
 - **MCP server — `cairn mcp` (#49).** Cairn's core is now exposed as an
   [MCP](https://modelcontextprotocol.io) server, so other agents (Claude Code, Cursor) can call test
   generation as a tool. `cairn mcp` starts a **stdio** server with three tools — **`explore`** (cases +

--- a/docs/runbooks/design-and-automate.md
+++ b/docs/runbooks/design-and-automate.md
@@ -32,3 +32,13 @@ cairn automate --run runs/<id> [--validate --session myapp]
 cairn explore --url ... --session ... [--checklist ...]
 ```
 observe→design→code→validation→repair (keep-best)→Pilot verdict — a validated suite + metrics right away.
+
+## 5. Plug into an existing Playwright project (`--into-project`, #51)
+```
+cairn explore  --url ... --into-project           # detect playwright.config.* from cwd
+cairn automate --run runs/<id> --into-project ./e2e   # or point at a project dir
+```
+- Detects the nearest `playwright.config.{ts,js,mjs,cjs}` (walking up from the cwd, or from the given `dir`), resolves its `testDir`, and writes the specs **there** using the project's filename convention (`.spec.ts` vs `.test.ts`, read from `testMatch`). Run them with the project's own `npx playwright test`.
+- **Collision-safe:** a pre-existing spec is never overwritten — Cairn writes a disambiguated file beside it (e.g. `login.cairn.spec.ts`).
+- Validation/repair run against an isolated `runs/<id>/tests` sandbox (same Playwright, identical result — your existing suite is never run or deleted); the validated best specs are then placed in the project's `testDir`, and the `runs/<id>/` trail keeps study/report/testcases.
+- Without the flag, nothing changes (greenfield `runs/<id>/tests/`). If no config is found, Cairn says so and falls back to greenfield.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,13 +1,14 @@
 import { randomUUID } from "node:crypto";
 import { resolve, dirname, basename, join } from "node:path";
-import { readFile, readdir } from "node:fs/promises";
+import { readFile, readdir, rm } from "node:fs/promises";
 import { makeGateway } from "../browser/index.js";
 import { ensureBrowsersInstalled } from "../browser/preflight.js";
 import { RoleRouter, type CostReport } from "../llm/index.js";
 import { CallBudget } from "../llm/structured.js";
 import { PromptRegistry } from "../prompts/index.js";
 import { initTelemetry } from "../telemetry/index.js";
-import { ArtifactStore } from "../artifacts/index.js";
+import { ArtifactStore, rmrf, type RunWriter } from "../artifacts/index.js";
+import { resolveProjectTarget, ejectSuiteToProject } from "../project/index.js";
 import { renderReportMd } from "../artifacts/report.js";
 import { parseTestCaseMd } from "../artifacts/testcase-md.js";
 import { automateCases } from "../codegen/index.js";
@@ -75,6 +76,10 @@ export interface ExploreInput {
   setup?: boolean;
   /** #61: also suggest cases for the top untested surface (the coverage VIEW is always emitted). Default off. */
   gaps?: boolean;
+  /** #51: write the final specs into an existing Playwright project's testDir (conventions-respecting) instead of runs/<id>/tests. */
+  intoProject?: boolean;
+  /** #51: explicit project dir for --into-project; when omitted, detection searches from cwd upward. */
+  projectDir?: string;
 }
 
 export interface ExploreResult {
@@ -95,6 +100,50 @@ export interface ExploreResult {
   stoppedEarly: boolean;
   /** ATC/MTC case docs written to testcases/ (#39 — explore now emits them like design). */
   testCaseFiles: string[];
+  /** #51: when --into-project ejected specs into a host project, the absolute paths written there. */
+  projectSpecFiles?: string[];
+  /** #51: the host project's testDir the specs were ejected into (undefined in greenfield mode). */
+  projectTestDir?: string;
+}
+
+/**
+ * INT-03 (#51): if `--into-project` is set, eject the final best suite into a detected Playwright
+ * project's testDir (conventions-respecting, collision-safe) and remove the run-private `tests/`
+ * sandbox so the trail keeps NO duplicate of the deliverable. Validation/repair already ran against
+ * that sandbox (same Playwright, identical result) — this only relocates the validated specs to where
+ * the project's own runner discovers them. Returns {} (greenfield fallthrough) when not requested or
+ * when no `playwright.config.*` is found; the caller then restores the suite to runs/<id>/tests.
+ */
+async function ejectToProjectIfRequested(opts: {
+  intoProject?: boolean;
+  projectDir?: string;
+  suite?: GeneratedSuite;
+  runWriter: RunWriter;
+  onProgress: (event: string) => void;
+}): Promise<{ projectSpecFiles?: string[]; projectTestDir?: string }> {
+  if (!opts.intoProject || !opts.suite) return {};
+  const target = await resolveProjectTarget({ dir: opts.projectDir });
+  if (!target) {
+    opts.onProgress(
+      `into-project — no playwright.config.* found (searched from ${displayPath(process.cwd())} upward) — wrote to runs/<id>/tests instead.`,
+    );
+    return {};
+  }
+  const res = await ejectSuiteToProject(opts.suite.files, target);
+  // Single deliverable: drop the run-private sandbox (+ its generated config) so the trail holds no
+  // spec duplicate — study/report/testcases stay in runs/<id>/ (best-effort; never sinks the run).
+  try {
+    await rmrf(join(opts.runWriter.dir, "tests"));
+    await rm(join(opts.runWriter.dir, "playwright.config.cjs"), { force: true });
+  } catch {
+    // best-effort cleanup
+  }
+  const renameNote = res.renamed.length ? ` · ${res.renamed.length} renamed (name collisions avoided)` : "";
+  opts.onProgress(
+    `into-project — wrote ${res.written.length} spec(s) → ${displayPath(res.testDir)}` +
+      `${target.configPath ? ` (config: ${displayPath(target.configPath)})` : ""}${renameNote}`,
+  );
+  return { projectSpecFiles: res.written, projectTestDir: res.testDir };
 }
 
 /**
@@ -252,7 +301,15 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
         // keep-best: final = the BEST suite/validation across all attempts (repair could not make it worse).
         const suite = out.bestSuite ?? out.suite;
         const validation = out.bestValidation ?? out.validation;
-        if (out.bestSuite) await runWriter.writeSuite(out.bestSuite); // restore the best code on disk
+        // #51: eject into an existing Playwright project when requested; else restore best to runs/<id>/tests.
+        const ejected = await ejectToProjectIfRequested({
+          intoProject: input.intoProject,
+          projectDir: input.projectDir,
+          suite,
+          runWriter,
+          onProgress,
+        });
+        if (!ejected.projectTestDir && out.bestSuite) await runWriter.writeSuite(out.bestSuite); // restore the best code on disk
 
         // Phase 4: study prior runs of this URL + collect the best (collect-best).
         const runsBase = resolve(input.runsBaseDir ?? defaultRunsBaseDir());
@@ -464,6 +521,8 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
           budget: budgetReport,
           stoppedEarly,
           testCaseFiles,
+          projectSpecFiles: ejected.projectSpecFiles,
+          projectTestDir: ejected.projectTestDir,
         };
       },
     );
@@ -778,6 +837,8 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
 export interface AutomateResult {
   runDir: string;
   specFiles: string[];
+  /** #51: the host project's testDir specs were ejected into (undefined in greenfield mode). */
+  projectTestDir?: string;
   validation?: ValidationReport;
   /** Per-role cost + tokens for the codegen step(s) (L1-01). */
   cost: CostReport;
@@ -800,6 +861,10 @@ export async function runAutomate(input: {
   sessionFile?: string;
   sessionsDir?: string;
   validate?: boolean;
+  /** #51: eject specs into an existing Playwright project's testDir instead of runDir/tests. */
+  intoProject?: boolean;
+  /** #51: explicit project dir for --into-project (detection searches from cwd upward when omitted). */
+  projectDir?: string;
   onProgress?: (event: string) => void;
 }): Promise<AutomateResult> {
   const cfg = input.config;
@@ -878,10 +943,23 @@ export async function runAutomate(input: {
     suite = await buildSuite(); // single pass — repair needs validation to measure progress
   }
 
-  const specFiles = await runWriter.writeSuite(suite); // final/best suite on disk
-  onProgress(`automate — ${specFiles.length} spec file(s) → tests/`);
+  // #51: eject into an existing Playwright project when requested; else write to runDir/tests as before.
+  const ejected = await ejectToProjectIfRequested({
+    intoProject: input.intoProject,
+    projectDir: input.projectDir,
+    suite,
+    runWriter,
+    onProgress,
+  });
+  let specFiles: string[];
+  if (ejected.projectTestDir) {
+    specFiles = ejected.projectSpecFiles ?? [];
+  } else {
+    specFiles = await runWriter.writeSuite(suite); // final/best suite on disk
+    onProgress(`automate — ${specFiles.length} spec file(s) → tests/`);
+  }
 
   const cost = router.ledger.report(); // L1-01: per-role cost + tokens for the codegen step(s)
   const budgetReport: BudgetReport = { used: budget.spent, max: budget.max };
-  return { runDir: runWriter.dir, specFiles, validation, stoppedEarly, cost, budget: budgetReport };
+  return { runDir: runWriter.dir, specFiles, projectTestDir: ejected.projectTestDir, validation, stoppedEarly, cost, budget: budgetReport };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -118,6 +118,7 @@ export function buildProgram(): Command {
     .option("--max-pages <n>", "max pages to crawl with --flow (page cap; default 3)")
     .option("--setup", "for journeys (--flow): plan + emit starting-state setup (fixture / API seed; manual fallback)")
     .option("--gaps", "suggest cases for the top untested surface (the coverage view is always emitted)")
+    .option("--into-project [dir]", "write specs into an existing Playwright project's testDir (detect playwright.config.*; respects testDir/naming) instead of runs/<id>/tests")
     .action(async (opts: Record<string, unknown>) => {
       await runModality("explore", opts);
     });
@@ -307,8 +308,9 @@ export function buildProgram(): Command {
     .option("--session-file <path>", "path to storageState for validation")
     .option("--channel <channel>", "system browser channel, e.g. chrome — validate on your installed Chrome (no bundled-Chromium download)")
     .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) | volume-fast (Anthropic codegen, cheap judge on OpenRouter) (sets LLM_ROUTING)")
+    .option("--into-project [dir]", "write specs into an existing Playwright project's testDir (detect playwright.config.*; respects testDir/naming) instead of runs/<id>/tests")
     .action(
-      async (opts: { run: string; validate?: boolean; session?: string; sessionFile?: string; channel?: string; routing?: string }) => {
+      async (opts: { run: string; validate?: boolean; session?: string; sessionFile?: string; channel?: string; routing?: string; intoProject?: boolean | string }) => {
         const config = resolveConfig({ routing: opts.routing, channel: opts.channel });
         process.stderr.write(`▸ Automating cases from ${displayPath(opts.run)}…\n`);
         const progress = makeCliProgress({
@@ -322,10 +324,13 @@ export function buildProgram(): Command {
           validate: opts.validate,
           sessionName: opts.session,
           sessionFile: opts.sessionFile,
+          intoProject: opts.intoProject !== undefined && opts.intoProject !== false,
+          projectDir: typeof opts.intoProject === "string" ? opts.intoProject : undefined,
           onProgress: progress.event,
         }).finally(() => progress.stop());
+        const dest = result.projectTestDir ? displayPath(result.projectTestDir) : `${displayPath(result.runDir)}/tests/`;
         process.stdout.write(
-          `\n=== ${result.specFiles.length} spec files → ${displayPath(result.runDir)}/tests/ ===\n`,
+          `\n=== ${result.specFiles.length} spec files → ${dest} ===\n`,
         );
         for (const f of result.specFiles) process.stdout.write(`  ${displayPath(f)}\n`);
         if (result.validation) {

--- a/src/core/modalities/explore.ts
+++ b/src/core/modalities/explore.ts
@@ -32,6 +32,7 @@ interface ExploreFlags {
   maxPages?: string;
   setup?: boolean;
   gaps?: boolean;
+  intoProject?: boolean | string;
 }
 
 export const exploreModality: Modality = {
@@ -67,6 +68,8 @@ export const exploreModality: Modality = {
       maxPages: opts.flow ? Number(opts.maxPages) || 3 : undefined,
       setup: opts.setup,
       gaps: opts.gaps,
+      intoProject: opts.intoProject !== undefined && opts.intoProject !== false,
+      projectDir: typeof opts.intoProject === "string" ? opts.intoProject : undefined,
       onProgress: progress.event,
     }).finally(() => progress.stop());
 
@@ -117,6 +120,12 @@ export const exploreModality: Modality = {
     // #39: explore now also writes ATC/MTC cases, and points at the review-first flow for next time.
     if (result.testCaseFiles.length > 0) {
       ctx.out(`  Cases (ATC/MTC .md): ${displayPath(result.runDir)}/testcases/\n`);
+    }
+    // #51: when ejected into an existing Playwright project, show WHERE the runnable specs landed.
+    if (result.projectTestDir && result.projectSpecFiles?.length) {
+      ctx.out(
+        `  Specs → project: ${result.projectSpecFiles.length} file(s) in ${displayPath(result.projectTestDir)} (run with your project's \`npx playwright test\`)\n`,
+      );
     }
     ctx.out(
       "\nTip: to review cases BEFORE generating code, run `cairn design` then `cairn automate`.\n",

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -30,6 +30,8 @@ export const TOOL_INPUT_SHAPE = {
   gaps: z.boolean().optional().describe("Suggest cases for the top untested surface"),
   critique: z.boolean().optional().describe("Design-time self-critique pass (prune weak cases + top up technique gaps)"),
   fresh: z.boolean().optional().describe("Ignore prior-run experience for this URL (full set, no delta)"),
+  intoProject: z.boolean().optional().describe("explore only: write specs into an existing Playwright project's testDir (detect playwright.config.*) instead of runs/<id>/tests"),
+  projectDir: z.string().optional().describe("Explicit project dir for intoProject (detection searches from cwd upward when omitted)"),
 };
 
 export const ToolInputSchema = z.object(TOOL_INPUT_SHAPE);
@@ -74,6 +76,8 @@ async function buildExploreInput(input: ToolInput, deps: ToolDeps): Promise<Expl
     maxPages: input.flow ? (input.maxPages ?? 3) : undefined,
     setup: input.setup,
     gaps: input.gaps,
+    intoProject: input.intoProject,
+    projectDir: input.projectDir,
   };
 }
 
@@ -152,6 +156,8 @@ export const AUTOMATE_INPUT_SHAPE = {
   session: z.string().optional().describe("Saved session name for validation"),
   routing: z.string().optional().describe("Role-routing preset: fast (Groq worker) | volume (OpenRouter worker) | volume-fast (Anthropic codegen — faster, recommended when OpenRouter codegen overruns timeouts)"),
   channel: z.string().optional().describe("System browser channel for validation, e.g. chrome"),
+  intoProject: z.boolean().optional().describe("Write specs into an existing Playwright project's testDir (detect playwright.config.*) instead of the run's tests/"),
+  projectDir: z.string().optional().describe("Explicit project dir for intoProject (detection searches from cwd upward when omitted)"),
 };
 
 export const AutomateInputSchema = z.object(AUTOMATE_INPUT_SHAPE);
@@ -160,6 +166,8 @@ export type AutomateInput = z.infer<typeof AutomateInputSchema>;
 export interface AutomateToolResult {
   runDir: string;
   specFiles: string[];
+  /** #51: host project's testDir specs were ejected into (undefined in greenfield mode). */
+  projectTestDir?: string;
   validation?: ReturnType<typeof compactValidation>;
   cost: AutomateResult["cost"];
 }
@@ -171,10 +179,13 @@ export async function automateTool(input: AutomateInput, deps: ToolDeps = defaul
     config,
     validate: input.validate,
     sessionName: input.session,
+    intoProject: input.intoProject,
+    projectDir: input.projectDir,
   });
   return {
     runDir: r.runDir,
     specFiles: r.specFiles,
+    projectTestDir: r.projectTestDir,
     validation: compactValidation(r.validation),
     cost: r.cost,
   };

--- a/src/project/index.ts
+++ b/src/project/index.ts
@@ -1,0 +1,216 @@
+/**
+ * INT-03 (#51) — plug into existing Playwright projects.
+ *
+ * Detect a host project's Playwright setup (`playwright.config.{ts,js,mjs,cjs}`) and resolve the
+ * conventions Cairn must respect when EJECTING generated specs into it instead of the greenfield
+ * `runs/<id>/tests` folder: the `testDir` the project's runner discovers, and the spec-filename
+ * suffix (`.spec.ts` vs `.test.ts`) implied by `testMatch`.
+ *
+ * Leaf module — depends only on node fs/path (and the codegen `FileBlob` type). Detection is opt-in
+ * (the `--into-project` flag); without it nothing here runs and the greenfield path is unchanged.
+ *
+ * Config parsing is best-effort (text regex, not evaluation): a TS/JS/ESM config can't be imported
+ * cheaply and safely, so we read the well-known keys from source. A missed key falls back to the
+ * Playwright default (testDir = the config's own directory; suffix = `.spec.ts`).
+ */
+import { stat, readFile, mkdir, writeFile, access } from "node:fs/promises";
+import { dirname, join, resolve, parse as parsePath } from "node:path";
+import type { FileBlob } from "../codegen/index.js";
+
+/** Playwright config filenames, in the order Playwright itself resolves them. */
+export const PW_CONFIG_NAMES = [
+  "playwright.config.ts",
+  "playwright.config.js",
+  "playwright.config.mjs",
+  "playwright.config.cjs",
+] as const;
+
+/** A spec filename: `<name>.spec.ts` or `<name>.test.ts` (the infix Cairn writes). */
+export type SpecSuffix = ".spec.ts" | ".test.ts";
+
+export interface ProjectTarget {
+  /** Absolute directory the project's runner discovers specs in (where Cairn writes). */
+  testDir: string;
+  /** Spec-filename suffix derived from the project's `testMatch` (default `.spec.ts`). */
+  specSuffix: SpecSuffix;
+  /** Absolute path to the detected `playwright.config.*` (undefined when a bare dir was given). */
+  configPath?: string;
+}
+
+/** Matches any Playwright spec/test filename so its infix+extension can be normalized to the project suffix. */
+const SPEC_FILE_RE = /\.(spec|test)\.(c|m)?[jt]sx?$/i;
+
+/** Does this generated file look like a runnable spec (vs a POM/helper that keeps its name)? */
+export function isSpecFile(name: string): boolean {
+  return SPEC_FILE_RE.test(name);
+}
+
+/** Walk up from `startDir` (inclusive) to the filesystem root, returning the nearest Playwright config. */
+export async function findPlaywrightConfig(startDir: string): Promise<string | undefined> {
+  let dir = resolve(startDir);
+  for (;;) {
+    for (const name of PW_CONFIG_NAMES) {
+      const candidate = join(dir, name);
+      try {
+        await access(candidate);
+        return candidate;
+      } catch {
+        // not here — try the next name / parent
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return undefined; // reached the root
+    dir = parent;
+  }
+}
+
+/**
+ * Best-effort parse of `testDir` + spec suffix from a Playwright config's SOURCE TEXT.
+ * `testDir` → absolute (resolved against the config's dir); a missing/non-literal value falls back to
+ * the Playwright default (the config's own directory). The suffix is `.test.ts` only when `testMatch`
+ * clearly targets `.test.` and not `.spec.`; otherwise the conventional `.spec.ts`.
+ */
+export function parseConfigConventions(
+  configText: string,
+  configDir: string,
+): { testDir: string; specSuffix: SpecSuffix } {
+  // testDir: '...'  /  testDir: "..."  /  testDir: `...`  (string literals only — best effort)
+  const testDirRel = /testDir\s*:\s*(['"`])([^'"`]+)\1/.exec(configText)?.[2];
+  const testDir = testDirRel ? resolve(configDir, testDirRel) : resolve(configDir);
+
+  // testMatch can be a string, RegExp, or array (single- or multi-line). We only flip to `.test.ts`
+  // when the value clearly mentions `test` and NOT `spec` — a safe, conservative read of a ~160-char
+  // window after the key (default stays `.spec.ts`). Anything ambiguous keeps the convention.
+  let specSuffix: SpecSuffix = ".spec.ts";
+  const keyIdx = configText.search(/testMatch\s*:/);
+  if (keyIdx >= 0) {
+    const window = configText.slice(keyIdx, keyIdx + 160);
+    const mentionsTest = /\.test\.|\btest\b/i.test(window);
+    const mentionsSpec = /\.spec\.|\bspec\b/i.test(window);
+    if (mentionsTest && !mentionsSpec) specSuffix = ".test.ts";
+  }
+  return { testDir, specSuffix };
+}
+
+/**
+ * Resolve where to write specs for an existing Playwright project.
+ *  - `dir` given → search it (and up) for a config; if none, treat `dir` itself as the testDir
+ *    (the explicit `--into-project ./e2e` request is honored even without a config).
+ *  - no `dir` → search from `cwd` upward; returns undefined when no config exists (caller falls back
+ *    to the greenfield `runs/` behavior, with a clear message — no regression).
+ */
+export async function resolveProjectTarget(opts: {
+  cwd?: string;
+  dir?: string;
+}): Promise<ProjectTarget | undefined> {
+  const startDir = resolve(opts.dir ?? opts.cwd ?? process.cwd());
+  const configPath = await findPlaywrightConfig(startDir);
+  if (configPath) {
+    const text = await readFile(configPath, "utf8").catch(() => "");
+    const { testDir, specSuffix } = parseConfigConventions(text, dirname(configPath));
+    return { testDir, specSuffix, configPath };
+  }
+  if (opts.dir) {
+    // Explicit target dir without a config: write there with the default suffix.
+    return { testDir: resolve(opts.dir), specSuffix: ".spec.ts" };
+  }
+  return undefined;
+}
+
+export interface PlannedFile {
+  /** Final relative path under the testDir (POSIX separators). */
+  rel: string;
+  content: string;
+  /** Set when a collision forced a rename (original generated path) — surfaced for logging. */
+  renamedFrom?: string;
+}
+
+/** Normalize a generated filename to the project's spec suffix; non-spec files (POM/helpers) keep their name. */
+function applySuffix(rel: string, suffix: SpecSuffix): string {
+  if (!isSpecFile(rel)) return rel;
+  return rel.replace(SPEC_FILE_RE, suffix);
+}
+
+/** Insert a `.cairn`/`.cairn-N` disambiguator before the spec infix or extension to dodge a collision. */
+function disambiguate(rel: string, attempt: number): string {
+  const tag = attempt === 1 ? "cairn" : `cairn-${attempt - 1}`;
+  if (SPEC_FILE_RE.test(rel)) {
+    // foo.spec.ts → foo.cairn.spec.ts
+    return rel.replace(SPEC_FILE_RE, (m) => `.${tag}${m}`);
+  }
+  const p = parsePath(rel);
+  const dir = p.dir ? `${p.dir}/` : "";
+  return `${dir}${p.name}.${tag}${p.ext}`;
+}
+
+/**
+ * Pure placement planner (#51): map generated files → final relative paths under the project testDir,
+ * normalizing the spec suffix and dodging collisions. `isTaken(rel)` reports paths already present
+ * (pre-existing project files) so an existing spec is NEVER overwritten — Cairn renames its own file
+ * instead. Deterministic and side-effect-free for unit testing.
+ */
+export function planPlacement(
+  files: FileBlob[],
+  specSuffix: SpecSuffix,
+  isTaken: (relPosix: string) => boolean,
+): PlannedFile[] {
+  const used = new Set<string>();
+  const taken = (rel: string): boolean => used.has(rel) || isTaken(rel);
+  const out: PlannedFile[] = [];
+  for (const f of files) {
+    const normalized = applySuffix(f.path.replace(/\\/g, "/"), specSuffix);
+    let rel = normalized;
+    let attempt = 0;
+    while (taken(rel)) rel = disambiguate(normalized, ++attempt);
+    used.add(rel);
+    out.push({ rel, content: f.content, ...(rel !== normalized ? { renamedFrom: f.path } : {}) });
+  }
+  return out;
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface EjectResult {
+  /** Absolute paths written into the project's testDir. */
+  written: string[];
+  /** Collisions Cairn dodged by renaming its own file (original → final relative path). */
+  renamed: { from: string; to: string }[];
+  testDir: string;
+}
+
+/**
+ * Eject a generated suite into the project's testDir (#51): collision-safe, non-destructive — it
+ * never deletes or overwrites a pre-existing file (unlike the greenfield `writeSuite`, which cleans
+ * its run-private `tests/` on every attempt). Subdirectories in generated paths (e.g. POM `pages/`)
+ * are preserved; only the spec infix is normalized to the project's convention.
+ */
+export async function ejectSuiteToProject(files: FileBlob[], target: ProjectTarget): Promise<EjectResult> {
+  await mkdir(target.testDir, { recursive: true });
+  const used = new Set<string>(); // names placed within THIS batch (avoid intra-batch collisions)
+  const written: string[] = [];
+  const renamed: { from: string; to: string }[] = [];
+  for (const f of files) {
+    const normalized = applySuffix(f.path.replace(/\\/g, "/"), target.specSuffix);
+    // A path is free when it is neither used in this batch nor already present on disk — so a
+    // pre-existing project file is never overwritten; Cairn disambiguates its own file instead.
+    let rel = normalized;
+    let attempt = 0;
+    while (used.has(rel) || (await pathExists(resolve(target.testDir, rel)))) {
+      rel = disambiguate(normalized, ++attempt);
+    }
+    used.add(rel);
+    const abs = resolve(target.testDir, rel);
+    await mkdir(dirname(abs), { recursive: true });
+    await writeFile(abs, f.content, "utf8");
+    written.push(abs);
+    if (rel !== normalized) renamed.push({ from: f.path, to: rel });
+  }
+  return { written, renamed, testDir: target.testDir };
+}

--- a/tests/unit/__snapshots__/cli-modalities.test.ts.snap
+++ b/tests/unit/__snapshots__/cli-modalities.test.ts.snap
@@ -74,6 +74,9 @@ Options:
                          (fixture / API seed; manual fallback)
   --gaps                 suggest cases for the top untested surface (the
                          coverage view is always emitted)
+  --into-project [dir]   write specs into an existing Playwright project's
+                         testDir (detect playwright.config.*; respects
+                         testDir/naming) instead of runs/<id>/tests
   -h, --help             display help for command
 "
 `;

--- a/tests/unit/cli-modalities.test.ts
+++ b/tests/unit/cli-modalities.test.ts
@@ -117,10 +117,11 @@ describe("explore parity (C1-02)", () => {
       "--max-pages",
       "--setup",
       "--gaps",
+      "--into-project",
     ]) {
       expect(longs, `explore should accept ${f}`).toContain(f);
     }
-    expect(longs).toHaveLength(15); // + --critique (#82) + --flow / --max-pages (#59) + --setup (#60) + --gaps (#61)
+    expect(longs).toHaveLength(16); // + --critique (#82) + --flow / --max-pages (#59) + --setup (#60) + --gaps (#61) + --into-project (#51)
   });
 
   it("maps flags to runExploration the same way as before the refactor", async () => {

--- a/tests/unit/project.test.ts
+++ b/tests/unit/project.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm, readFile, readdir, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  findPlaywrightConfig,
+  parseConfigConventions,
+  resolveProjectTarget,
+  isSpecFile,
+  planPlacement,
+  ejectSuiteToProject,
+} from "../../src/project/index.js";
+import type { FileBlob } from "../../src/codegen/index.js";
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("project detection (#51)", () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "cairn-proj-"));
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("findPlaywrightConfig walks up to the nearest config (any supported extension)", async () => {
+    await writeFile(join(root, "playwright.config.ts"), "export default {}");
+    const nested = join(root, "packages", "web", "src");
+    await mkdir(nested, { recursive: true });
+    expect(await findPlaywrightConfig(nested)).toBe(join(root, "playwright.config.ts"));
+  });
+
+  it("findPlaywrightConfig returns undefined when no config exists anywhere up to root", async () => {
+    const nested = join(root, "a", "b");
+    await mkdir(nested, { recursive: true });
+    expect(await findPlaywrightConfig(nested)).toBeUndefined();
+  });
+
+  it("parseConfigConventions resolves a custom testDir relative to the config dir", () => {
+    const { testDir, specSuffix } = parseConfigConventions(`export default { testDir: './e2e' }`, root);
+    expect(testDir).toBe(resolve(root, "e2e"));
+    expect(specSuffix).toBe(".spec.ts"); // no testMatch → conventional default
+  });
+
+  it("parseConfigConventions falls back to the config dir when testDir is absent (Playwright default)", () => {
+    const { testDir } = parseConfigConventions(`export default defineConfig({ retries: 1 })`, root);
+    expect(testDir).toBe(resolve(root));
+  });
+
+  it("parseConfigConventions derives a .test.ts suffix when testMatch targets .test. and not .spec.", () => {
+    const cfg = `export default { testMatch: '**/*.test.ts' }`;
+    expect(parseConfigConventions(cfg, root).specSuffix).toBe(".test.ts");
+  });
+
+  it("parseConfigConventions keeps .spec.ts when testMatch mentions spec (conservative)", () => {
+    const cfg = `export default { testMatch: /.*\\.(spec|test)\\.ts/ }`;
+    expect(parseConfigConventions(cfg, root).specSuffix).toBe(".spec.ts");
+  });
+
+  it("resolveProjectTarget: config present → testDir + configPath", async () => {
+    await writeFile(join(root, "playwright.config.ts"), `export default { testDir: './tests' }`);
+    const t = await resolveProjectTarget({ cwd: root });
+    expect(t?.testDir).toBe(resolve(root, "tests"));
+    expect(t?.configPath).toBe(join(root, "playwright.config.ts"));
+  });
+
+  it("resolveProjectTarget: explicit dir without a config → that dir IS the testDir (honor the request)", async () => {
+    const t = await resolveProjectTarget({ dir: join(root, "e2e") });
+    expect(t?.testDir).toBe(resolve(root, "e2e"));
+    expect(t?.configPath).toBeUndefined();
+  });
+
+  it("resolveProjectTarget: no config and no explicit dir → undefined (greenfield fallback)", async () => {
+    expect(await resolveProjectTarget({ cwd: root })).toBeUndefined();
+  });
+});
+
+describe("placement planning (#51 — pure, collision-safe)", () => {
+  const blob = (path: string): FileBlob => ({ path, content: `// ${path}` });
+
+  it("isSpecFile distinguishes specs from POM/helpers", () => {
+    expect(isSpecFile("login.spec.ts")).toBe(true);
+    expect(isSpecFile("cart.test.ts")).toBe(true);
+    expect(isSpecFile("pages/LoginPage.ts")).toBe(false);
+  });
+
+  it("normalizes the spec suffix to the project convention; POM files keep their name", () => {
+    const plan = planPlacement([blob("login.spec.ts"), blob("pages/LoginPage.ts")], ".test.ts", () => false);
+    expect(plan[0]?.rel).toBe("login.test.ts");
+    expect(plan[1]?.rel).toBe("pages/LoginPage.ts"); // non-spec untouched
+    expect(plan[0]?.renamedFrom).toBeUndefined(); // suffix change is not a "collision rename"
+  });
+
+  it("never collides with a pre-existing file — renames Cairn's own spec instead", () => {
+    const taken = new Set(["login.spec.ts"]);
+    const plan = planPlacement([blob("login.spec.ts")], ".spec.ts", (r) => taken.has(r));
+    expect(plan[0]?.rel).toBe("login.cairn.spec.ts");
+    expect(plan[0]?.renamedFrom).toBe("login.spec.ts");
+  });
+
+  it("dedupes within a single batch (two files normalizing to the same name)", () => {
+    const plan = planPlacement([blob("a.spec.ts"), blob("a.test.ts")], ".spec.ts", () => false);
+    expect(plan.map((p) => p.rel)).toEqual(["a.spec.ts", "a.cairn.spec.ts"]);
+  });
+});
+
+describe("ejectSuiteToProject (#51 — writes into the project, non-destructive)", () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "cairn-eject-"));
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("DoD: config with custom testDir → specs land there in the project's naming; greenfield runs/ untouched", async () => {
+    await writeFile(join(root, "playwright.config.ts"), `export default { testDir: './e2e', testMatch: '**/*.test.ts' }`);
+    const target = await resolveProjectTarget({ cwd: root });
+    expect(target).toBeDefined();
+    const res = await ejectSuiteToProject(
+      [{ path: "login.spec.ts", content: "// login" }, { path: "pages/LoginPage.ts", content: "// pom" }],
+      target!,
+    );
+    // spec renamed to the project's .test.ts convention, POM preserved under its subdir
+    expect(await readFile(join(root, "e2e", "login.test.ts"), "utf8")).toBe("// login");
+    expect(await readFile(join(root, "e2e", "pages", "LoginPage.ts"), "utf8")).toBe("// pom");
+    expect(res.written).toHaveLength(2);
+    expect(await exists(join(root, "runs"))).toBe(false); // no greenfield runs/ folder created by the eject
+  });
+
+  it("does NOT overwrite a pre-existing project spec — writes a disambiguated file beside it", async () => {
+    const testDir = join(root, "tests");
+    await mkdir(testDir, { recursive: true });
+    await writeFile(join(testDir, "login.spec.ts"), "// HAND-WRITTEN — must survive");
+    const res = await ejectSuiteToProject([{ path: "login.spec.ts", content: "// generated" }], {
+      testDir,
+      specSuffix: ".spec.ts",
+    });
+    expect(await readFile(join(testDir, "login.spec.ts"), "utf8")).toBe("// HAND-WRITTEN — must survive");
+    expect(await readFile(join(testDir, "login.cairn.spec.ts"), "utf8")).toBe("// generated");
+    expect(res.renamed).toEqual([{ from: "login.spec.ts", to: "login.cairn.spec.ts" }]);
+    expect((await readdir(testDir)).sort()).toEqual(["login.cairn.spec.ts", "login.spec.ts"]);
+  });
+});


### PR DESCRIPTION
Closes #51

## What
INT-03 — detect a host project's Playwright setup and write generated specs into **its** conventions (testDir, naming) so they run under the project's existing runner, instead of the greenfield `runs/<id>/tests` folder.

Opt-in via `--into-project [dir]` on `explore`/`automate` (and `intoProject`/`projectDir` on the public API + MCP `explore`/`automate` tools). Without the flag, nothing changes.

```
cairn explore  --url ... --into-project            # detect playwright.config.* from cwd
cairn automate --run runs/<id> --into-project ./e2e   # or point at a project dir
```

## How it works
- **Detect:** `findPlaywrightConfig` walks up from the cwd (or the given dir) for `playwright.config.{ts,js,mjs,cjs}`; `parseConfigConventions` reads `testDir` and the filename suffix (`.spec.ts` vs `.test.ts`, best-effort from `testMatch`).
- **Write:** the validated best suite is ejected into the project's `testDir` using that convention. **Collision-safe** — a pre-existing spec is never overwritten; Cairn disambiguates its own file (`login.cairn.spec.ts`).
- **Validate/repair (explore):** still run against an isolated `runs/<id>/tests` sandbox — same Playwright binary, identical result — so the user's own suite is never executed or deleted. After convergence the specs land in the project `testDir` (single deliverable) and the sandbox is removed; the `runs/<id>/` trail keeps study/report/testcases.
- **Fallbacks:** no flag → greenfield unchanged; flag set but no config found → logs the fallback and writes greenfield (no failure).

New leaf module `src/project/` (depends only on node fs/path + the codegen `FileBlob` type); thin wiring in `agent/index.ts`, `cli/index.ts`, `core/modalities/explore.ts`, `mcp/tools.ts`.

## Verification vs DoD
DoD: *given a repo with `playwright.config.*`, Cairn writes specs into the project's conventions and they run under the project's existing runner.*

| DoD scenario | Covered by |
|---|---|
| repo with `playwright.config.ts` + custom `testDir` → specs written there in the project's naming | `project.test.ts` › "DoD: config with custom testDir → specs land there… greenfield runs/ untouched" (testDir `./e2e`, `testMatch '**/*.test.ts'` → `e2e/login.test.ts`) |
| repo **without** config → greenfield fallback (no regression) | `resolveProjectTarget` returns `undefined` → eject is skipped; greenfield path unchanged. Unit: "no config and no explicit dir → undefined" |
| respect custom `testDir`/`testMatch` | "resolves a custom testDir relative to the config dir"; ".test.ts suffix when testMatch targets .test." |
| run under the project's runner | specs placed in `testDir` with the project's filename convention → discovered by the project's own `npx playwright test` |
| name collisions with existing specs | "does NOT overwrite a pre-existing project spec — writes a disambiguated file beside it" (hand-written `login.spec.ts` survives; generated → `login.cairn.spec.ts`) |
| `.ts`/`.js`/`.mjs`/`.cjs`, monorepo (nearest config up the tree) | `findPlaywrightConfig` walk-up tests |

Local checks: `lint` ✅ · `typecheck` ✅ · `build` ✅ · unit **548 passed** ✅ · `smoke:pack` **8 checks** ✅. (Validity of generated specs verified by detection/placement parsing + dry placement into temp dirs — no real runner/provider/browser, per the test constraints. The 3 integration tests that need a real Chromium are skipped only because the browser binary isn't installed in this environment.)

## Note on the design (per the clarifying answers)
Confirmed up front:
1. **Activation** — explicit `--into-project` flag (no surprise auto-write).
2. **Output** — specs are the single deliverable in the project's `testDir`; the `runs/<id>/` **trail is kept** for study/report/testcases (no spec duplicate). This intentionally refines the issue's original "no `runs/`" wording — the run trail still exists, only the spec deliverable moves to the project.
3. **Validation** — reuse the existing validator/repair; runs against an isolated sandbox copy of the exact specs (identical result) rather than literally executing inside the project dir, to avoid ever running or deleting the user's existing suite. The deliverables are discoverable by the project's runner.
4. **Conventions scope** — `testDir` + filename suffix + collision-safety this PR; fixtures wiring is a follow-up.

## Follow-ups (out of scope here)
- **Fixtures/POM wiring:** import a project's custom `test` fixture (`import { test } from '../fixtures'`) into generated specs. Today generated specs are self-contained (`import { test, expect } from '@playwright/test'`).
- **Literal in-place validation** under the project's own `playwright.config` (honoring its `projects`/`webServer`/`baseURL`), if desired over the sandbox approach.
- **`testMatch` parsing** is best-effort (source-text regex). A non-literal/computed `testDir`/`testMatch` falls back to the Playwright defaults (config dir; `.spec.ts`).
- **JS-only projects:** Cairn still emits `.ts` specs (honoring the spec/test infix); emitting `.js` is a separate concern.