### PR TITLE
feat: CI / PR bot — GitHub Action (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CI / PR bot — GitHub Action (#50).** A reusable composite action (`action/`) that runs Cairn on a
+  pull request, posts (or updates) a **summary comment**, and **optionally opens a follow-up PR** with
+  the generated tests. `v1` is generation-on-PR; maintenance/self-heal stays in epic #46. The action is
+  a thin wrapper over the shared core via a new `cairn ci` command (same pattern as `cairn mcp`, #49):
+  inputs flow in as `INPUT_*` env, provider keys are read from repo secrets (never hardcoded), and
+  generated specs land in the host Playwright project through the `--into-project` writer (#51).
+  Behavior: the comment is **idempotent** (matched by a hidden marker — re-runs update, never
+  duplicate); a `paths` glob gates on the PR's **changed surface** (no match → a no-op comment, no run);
+  the follow-up PR is **opt-in** (`open-pr`, `explore` mode only); **fork PRs** (read-only token) skip
+  the write effects with a logged reason. Required secrets/permissions are documented in
+  [`action/README.md`](action/README.md) for a repo admin to set — the action never configures them.
+
 - **Plug into existing Playwright projects — `--into-project` (#51).** Cairn can now write the
   generated specs straight into a host project's Playwright setup instead of the greenfield
   `runs/<id>/tests` folder. `cairn explore … --into-project [dir]` / `cairn automate … --into-project [dir]`

--- a/action/README.md
+++ b/action/README.md
@@ -1,0 +1,113 @@
+# Cairn — CI / PR bot (GitHub Action)
+
+Run [Cairn](https://github.com/plune-ai/cairn) on a pull request: it generates/updates Playwright UI
+tests for the changed surface, posts a **summary comment**, and can **optionally open a follow-up PR**
+carrying the tests (#50, `v1 = generation-on-PR`). Maintenance / self-heal is a later epic (#46) and is
+out of scope here.
+
+The action is a thin wrapper over the shared Cairn core (same entry points as `cairn explore` /
+`cairn design`); generated specs land in your existing Playwright project via the `--into-project`
+writer (#51) when a `playwright.config.*` is present.
+
+## Usage
+
+```yaml
+# .github/workflows/cairn.yml
+name: Cairn tests
+on:
+  pull_request:
+
+permissions:
+  contents: write        # only needed when open-pr: true (creates a branch + commit)
+  pull-requests: write   # post the summary comment / open the follow-up PR
+
+jobs:
+  cairn:
+    runs-on: ubuntu-latest
+    env:
+      # Provider keys come from repo secrets — NOT from action inputs (so they are never echoed).
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      # Optional, depending on your routing / observability:
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BASE_URL }}
+      LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+      LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: plune-ai/cairn-action@v1      # see "Distribution" below
+        with:
+          url: https://staging.example.com/login
+          mode: explore
+          paths: |
+            src/app/login/**
+            src/components/auth/**
+          comment: true
+          open-pr: false
+```
+
+## Inputs
+
+| Input            | Default                          | Description |
+| ---------------- | -------------------------------- | ----------- |
+| `url`            | — (**required**)                 | Page URL to generate tests for. |
+| `mode`           | `explore`                        | `explore` (cases + code) or `design` (cases only). A follow-up PR needs `explore`. |
+| `session`        | —                                | Saved session name for authenticated targets. |
+| `checklist`      | —                                | Path to a checklist file that steers what to test. |
+| `style`          | —                                | Planning style / house-style pack. |
+| `routing`        | —                                | Role-routing preset: `fast` \| `volume` \| `volume-fast`. |
+| `backend`        | `lib`                            | Browser backend: `lib` \| `cli`. |
+| `channel`        | —                                | System browser channel (e.g. `chrome`). |
+| `into-project`   | `true`                           | Write specs into the host Playwright `testDir` (else greenfield `runs/`). |
+| `project-dir`    | —                                | Explicit project dir for `into-project`. |
+| `paths`          | —                                | Newline/comma globs — run only when the PR changed a matching file (changed-surface gate). |
+| `comment`        | `true`                           | Post/update the summary comment. |
+| `open-pr`        | `false`                          | Open a follow-up PR with the generated tests. |
+| `pr-branch`      | `cairn/update-tests`             | Branch prefix for the follow-up PR (PR number appended). |
+| `commit-message` | `test: update generated …`       | Commit message for the follow-up PR. |
+| `pr-title`       | (commit message)                 | Title for the follow-up PR. |
+| `github-token`   | `${{ github.token }}`            | Token for commenting / opening the follow-up PR. |
+| `cairn-version`  | `latest`                         | npm version/tag of `@plune-ai/cairn` to install. |
+| `install-browsers` | `true`                         | Install Playwright Chromium before running. |
+
+## Required secrets (set by a repo admin — the action does **not** set these)
+
+- `ANTHROPIC_API_KEY` (and/or `OPENROUTER_API_KEY`, `GROQ_API_KEY`, per your `routing`).
+- Optional Langfuse: `LANGFUSE_BASE_URL`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`.
+
+Add them under **Settings → Secrets and variables → Actions**, then map them to job/step `env:` as in
+the example above. Cairn reads them from the environment; they are never passed as action inputs.
+
+## Required permissions
+
+Grant these in the calling workflow (or org/repo default `GITHUB_TOKEN` permissions):
+
+- `pull-requests: write` — to post/update the summary comment and open the follow-up PR.
+- `contents: write` — **only** when `open-pr: true` (the follow-up PR creates a branch + commit).
+
+## Fork PRs
+
+On the default `pull_request` trigger, PRs from forks receive a **read-only** token, so the action
+**skips** commenting / opening a PR (it logs the reason and still exits cleanly). To comment on fork
+PRs you can use `pull_request_target` — do so deliberately and review the
+[security implications](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/).
+
+## Behavior notes
+
+- **Idempotent comment.** Re-running on the same PR **updates** the existing Cairn comment (matched by a
+  hidden marker) instead of posting duplicates.
+- **No changed surfaces.** When `paths` is set and the PR touched no matching file, the run is a no-op:
+  it posts a short "no tests generated" comment and skips generation.
+- **Follow-up PR is opt-in.** It only runs with `open-pr: true`, in `explore` mode, with a writable
+  token, and when specs were actually generated.
+
+## Distribution
+
+`v1` ships the action **source in the Cairn repo** under [`action/`](.). Reference it either by sub-path:
+
+```yaml
+- uses: plune-ai/cairn/action@v1
+```
+
+or, once a maintainer mirrors `action/` to a dedicated `plune-ai/cairn-action` repo (a release step, not
+done by this PR), by the short form `uses: plune-ai/cairn-action@v1`.

--- a/action/action.yml
+++ b/action/action.yml
@@ -1,0 +1,117 @@
+name: "Cairn — CI / PR bot"
+description: >-
+  Run Cairn on a pull request: generate/update Playwright UI tests for the changed surface,
+  post a summary comment, and optionally open a follow-up PR with the tests (#50).
+author: "plune-ai"
+branding:
+  icon: "check-circle"
+  color: "purple"
+
+inputs:
+  url:
+    description: "Page URL to generate tests for (required)."
+    required: true
+  mode:
+    description: "explore (cases + @playwright/test code) or design (cases only). Code is needed for a follow-up PR."
+    required: false
+    default: "explore"
+  session:
+    description: "Saved session name (.auth/<name>.storageState.json) for authenticated targets."
+    required: false
+  checklist:
+    description: "Path to a checklist file (md/text) that steers what to test."
+    required: false
+  style:
+    description: "Planning style or house-style pack (happy | negative | coverage | a pack name/path)."
+    required: false
+  routing:
+    description: "Role-routing preset: fast | volume | volume-fast."
+    required: false
+  backend:
+    description: "Browser backend: lib (default) | cli."
+    required: false
+  channel:
+    description: "System browser channel, e.g. chrome."
+    required: false
+  into-project:
+    description: "Write specs into the host project's Playwright testDir (detect playwright.config.*) instead of greenfield runs/."
+    required: false
+    default: "true"
+  project-dir:
+    description: "Explicit project dir for into-project (detection searches from cwd upward when omitted)."
+    required: false
+  paths:
+    description: "Optional newline/comma globs — only run when the PR changed a matching file (changed-surface gate)."
+    required: false
+  comment:
+    description: "Post/update a summary comment on the PR."
+    required: false
+    default: "true"
+  open-pr:
+    description: "Open a follow-up PR carrying the generated tests (off by default)."
+    required: false
+    default: "false"
+  pr-branch:
+    description: "Branch prefix for the follow-up PR (the PR number is appended)."
+    required: false
+    default: "cairn/update-tests"
+  commit-message:
+    description: "Commit message for the follow-up PR."
+    required: false
+    default: "test: update generated Playwright tests (cairn)"
+  pr-title:
+    description: "Title for the follow-up PR (defaults to the commit message)."
+    required: false
+  github-token:
+    description: "Token for commenting / opening the follow-up PR. Needs pull-requests: write (and contents: write for open-pr)."
+    required: false
+    default: ${{ github.token }}
+  cairn-version:
+    description: "npm version/tag of @plune-ai/cairn to install."
+    required: false
+    default: "latest"
+  install-browsers:
+    description: "Install the Playwright Chromium browser before running (needed for observe/validate)."
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+
+    - name: Install Cairn
+      shell: bash
+      run: npm install -g @plune-ai/cairn@${{ inputs.cairn-version }}
+
+    - name: Install Playwright browser
+      if: ${{ inputs.install-browsers == 'true' }}
+      shell: bash
+      run: npx --yes playwright install --with-deps chromium
+
+    - name: Run Cairn CI
+      shell: bash
+      run: cairn ci
+      env:
+        # Provider keys (ANTHROPIC_API_KEY, OPENROUTER_API_KEY, GROQ_API_KEY, LANGFUSE_*) are NOT inputs:
+        # set them as job/step env from repo secrets in the calling workflow — Cairn reads them from env.
+        INPUT_URL: ${{ inputs.url }}
+        INPUT_MODE: ${{ inputs.mode }}
+        INPUT_SESSION: ${{ inputs.session }}
+        INPUT_CHECKLIST: ${{ inputs.checklist }}
+        INPUT_STYLE: ${{ inputs.style }}
+        INPUT_ROUTING: ${{ inputs.routing }}
+        INPUT_BACKEND: ${{ inputs.backend }}
+        INPUT_CHANNEL: ${{ inputs.channel }}
+        INPUT_INTO-PROJECT: ${{ inputs.into-project }}
+        INPUT_PROJECT-DIR: ${{ inputs.project-dir }}
+        INPUT_PATHS: ${{ inputs.paths }}
+        INPUT_COMMENT: ${{ inputs.comment }}
+        INPUT_OPEN-PR: ${{ inputs.open-pr }}
+        INPUT_PR-BRANCH: ${{ inputs.pr-branch }}
+        INPUT_COMMIT-MESSAGE: ${{ inputs.commit-message }}
+        INPUT_PR-TITLE: ${{ inputs.pr-title }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/src/ci/github.ts
+++ b/src/ci/github.ts
@@ -1,0 +1,171 @@
+/**
+ * INT-02 (#50) — GitHub effects for the CI / PR bot.
+ *
+ * A small seam over the GitHub REST API: list a PR's changed files, upsert the summary comment
+ * (idempotent — one comment per PR, updated on re-runs), and optionally open a follow-up PR carrying
+ * the generated tests. The orchestrator ({@link ./run.ts}) depends only on the {@link GitHubClient}
+ * interface, so it is unit-tested against a mock with NO network. The default implementation uses the
+ * built-in `fetch` (Node 20+) — no Octokit/`@actions` dependency added to the package.
+ */
+import type { CiContext } from "./inputs.js";
+
+/** A file changed in the PR (subset of the REST "list pull request files" item). */
+export interface ChangedFile {
+  filename: string;
+  status: string;
+}
+
+/** A repo-relative file to commit in the follow-up PR (POSIX path). */
+export interface CommitFile {
+  path: string;
+  content: string;
+}
+
+export interface FollowupPrParams {
+  /** New branch name to push the generated tests onto. */
+  branch: string;
+  /** Branch the new branch is cut from and the PR targets (the PR's own head branch). */
+  baseBranch: string;
+  commitMessage: string;
+  title: string;
+  body: string;
+  files: CommitFile[];
+}
+
+/** The GitHub effects the CI bot needs — implemented for real by {@link RestGitHubClient}, mocked in tests. */
+export interface GitHubClient {
+  listChangedFiles(prNumber: number): Promise<ChangedFile[]>;
+  upsertComment(prNumber: number, body: string): Promise<{ action: "created" | "updated"; id: number }>;
+  openFollowupPr(params: FollowupPrParams): Promise<{ url: string; number: number }>;
+}
+
+/** Hidden marker stamped into the bot's comment so a re-run UPDATES it instead of posting a duplicate. */
+export const COMMENT_MARKER = "<!-- cairn-ci:summary -->";
+
+/** An existing issue comment (subset) used to find the bot's prior comment. */
+export interface ExistingComment {
+  id: number;
+  body?: string;
+}
+
+/**
+ * Pure decision for comment idempotency: reuse the first comment carrying {@link COMMENT_MARKER}
+ * (update it), otherwise create a new one. Kept side-effect-free so it is unit-testable directly.
+ */
+export function selectCommentAction(
+  existing: ExistingComment[],
+  marker: string = COMMENT_MARKER,
+): { action: "created" } | { action: "updated"; id: number } {
+  const mine = existing.find((c) => c.body?.includes(marker));
+  return mine ? { action: "updated", id: mine.id } : { action: "created" };
+}
+
+/** Stamp the marker onto a comment body so future runs can find and update it. */
+export function withMarker(body: string, marker: string = COMMENT_MARKER): string {
+  return `${marker}\n${body}`;
+}
+
+/** Default REST-backed client. Constructed only on the live path; tests inject a mock instead. */
+export class RestGitHubClient implements GitHubClient {
+  constructor(
+    private readonly ctx: CiContext,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {
+    if (!ctx.token) throw new Error("A GitHub token is required for REST calls (set the `github-token` input).");
+  }
+
+  private async api<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const res = await this.fetchImpl(`${this.ctx.apiUrl}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.ctx.token}`,
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`GitHub API ${method} ${path} failed: ${res.status} ${res.statusText} ${text}`.trim());
+    }
+    return (await res.json()) as T;
+  }
+
+  private get base(): string {
+    return `/repos/${this.ctx.owner}/${this.ctx.repo}`;
+  }
+
+  async listChangedFiles(prNumber: number): Promise<ChangedFile[]> {
+    const files: ChangedFile[] = [];
+    // Paginate (100/page) so large PRs are fully covered — no silent truncation of the surface set.
+    for (let page = 1; ; page++) {
+      const batch = await this.api<ChangedFile[]>(
+        "GET",
+        `${this.base}/pulls/${prNumber}/files?per_page=100&page=${page}`,
+      );
+      files.push(...batch);
+      if (batch.length < 100) break;
+    }
+    return files;
+  }
+
+  async upsertComment(prNumber: number, body: string): Promise<{ action: "created" | "updated"; id: number }> {
+    const existing = await this.api<ExistingComment[]>(
+      "GET",
+      `${this.base}/issues/${prNumber}/comments?per_page=100`,
+    );
+    const decision = selectCommentAction(existing);
+    const payload = { body: withMarker(body) };
+    if (decision.action === "updated") {
+      const r = await this.api<{ id: number }>("PATCH", `${this.base}/issues/comments/${decision.id}`, payload);
+      return { action: "updated", id: r.id };
+    }
+    const r = await this.api<{ id: number }>("POST", `${this.base}/issues/${prNumber}/comments`, payload);
+    return { action: "created", id: r.id };
+  }
+
+  /**
+   * Open a follow-up PR via the Git Data API: blobs → tree (on top of the base branch's tree) →
+   * commit → branch ref → pull request. Non-destructive: it only adds a branch and PR.
+   */
+  async openFollowupPr(p: FollowupPrParams): Promise<{ url: string; number: number }> {
+    // 1. Resolve the base branch tip + its tree.
+    const ref = await this.api<{ object: { sha: string } }>(
+      "GET",
+      `${this.base}/git/ref/heads/${encodeURIComponent(p.baseBranch)}`,
+    );
+    const baseSha = ref.object.sha;
+    const baseCommit = await this.api<{ tree: { sha: string } }>("GET", `${this.base}/git/commits/${baseSha}`);
+
+    // 2. Blob per file → a new tree based on the base tree.
+    const tree = await Promise.all(
+      p.files.map(async (f) => {
+        const blob = await this.api<{ sha: string }>("POST", `${this.base}/git/blobs`, {
+          content: f.content,
+          encoding: "utf-8",
+        });
+        return { path: f.path, mode: "100644", type: "blob", sha: blob.sha };
+      }),
+    );
+    const newTree = await this.api<{ sha: string }>("POST", `${this.base}/git/trees`, {
+      base_tree: baseCommit.tree.sha,
+      tree,
+    });
+
+    // 3. Commit → new branch ref → PR.
+    const commit = await this.api<{ sha: string }>("POST", `${this.base}/git/commits`, {
+      message: p.commitMessage,
+      tree: newTree.sha,
+      parents: [baseSha],
+    });
+    await this.api("POST", `${this.base}/git/refs`, { ref: `refs/heads/${p.branch}`, sha: commit.sha });
+    const pr = await this.api<{ html_url: string; number: number }>("POST", `${this.base}/pulls`, {
+      title: p.title,
+      body: p.body,
+      head: p.branch,
+      base: p.baseBranch,
+    });
+    return { url: pr.html_url, number: pr.number };
+  }
+}

--- a/src/ci/index.ts
+++ b/src/ci/index.ts
@@ -1,0 +1,38 @@
+/**
+ * INT-02 (#50) — CI / PR bot entry point.
+ *
+ * The thin runtime `cairn ci` drives: read the GitHub event payload (so we know the PR number, head/
+ * base refs and fork status) and delegate to the injectable {@link runCi} orchestrator. Kept tiny on
+ * purpose — all logic lives in the testable seams under `src/ci/`.
+ */
+import { readFile } from "node:fs/promises";
+import { runCi } from "./run.js";
+import type { PullRequestEvent } from "./inputs.js";
+
+export { runCi, defaultDeps } from "./run.js";
+export type { CiDeps, CiRunResult } from "./run.js";
+export { parseInputs, buildContext } from "./inputs.js";
+export type { CiInputs, CiContext } from "./inputs.js";
+export { RestGitHubClient } from "./github.js";
+export type { GitHubClient } from "./github.js";
+export { renderCiSummary } from "./summary.js";
+export type { CiSummary } from "./summary.js";
+
+/** Best-effort read of the GitHub Actions event payload (`GITHUB_EVENT_PATH`). */
+export async function readEvent(env: NodeJS.ProcessEnv = process.env): Promise<PullRequestEvent> {
+  const path = env.GITHUB_EVENT_PATH;
+  if (!path) return {};
+  try {
+    return JSON.parse(await readFile(path, "utf8")) as PullRequestEvent;
+  } catch {
+    return {};
+  }
+}
+
+/** Run the CI bot from the live environment, surfacing skipped effects. Throws on a hard failure. */
+export async function startCi(): Promise<void> {
+  const event = await readEvent();
+  const result = await runCi(process.env, event);
+  for (const note of result.skippedEffects) process.stderr.write(`note: ${note}\n`);
+  if (!result.ranCore) process.stderr.write("Cairn CI: no-op (changed-surface gate).\n");
+}

--- a/src/ci/inputs.ts
+++ b/src/ci/inputs.ts
@@ -1,0 +1,165 @@
+/**
+ * INT-02 (#50) — CI / PR bot input layer.
+ *
+ * Parse + validate the GitHub Action's `inputs:` from the environment. GitHub passes each declared
+ * input as an `INPUT_<NAME>` env var (name upper-cased, spaces → `_`) — exactly what `@actions/core`
+ * reads — so this module needs no Actions toolkit dependency and stays trivially unit-testable by
+ * handing it a plain env record.
+ *
+ * Provider keys (ANTHROPIC_API_KEY, OPENROUTER_API_KEY, …) are NOT read here: they flow straight into
+ * `process.env` from repo secrets and are consumed by `resolveConfig`/`loadConfig` like everywhere
+ * else — never hardcoded, never echoed.
+ */
+
+type Env = Record<string, string | undefined>;
+
+/** Read one Action input from env, replicating `@actions/core.getInput` name→env mapping. */
+export function getInput(env: Env, name: string): string | undefined {
+  const key = `INPUT_${name.replace(/ /g, "_").toUpperCase()}`;
+  const raw = env[key];
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+/** Parse a boolean input the way Actions' YAML truthiness works (`true`/`false`, case-insensitive). */
+function getBool(env: Env, name: string, fallback: boolean): boolean {
+  const v = getInput(env, name)?.toLowerCase();
+  if (v === undefined) return fallback;
+  if (v === "true") return true;
+  if (v === "false") return false;
+  throw new Error(`Input "${name}" must be "true" or "false" (got "${v}").`);
+}
+
+/** Split a multiline / comma-separated input into trimmed, non-empty entries. */
+function getList(env: Env, name: string): string[] {
+  const raw = getInput(env, name);
+  if (!raw) return [];
+  return raw
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/** The exploration mode the action drives — `explore` emits code (needed for a follow-up PR). */
+export type CiMode = "explore" | "design";
+
+/** Validated, normalized inputs for one CI run. Mirrors the `cairn explore`/`design` flag surface. */
+export interface CiInputs {
+  url: string;
+  mode: CiMode;
+  session?: string;
+  checklist?: string;
+  style?: string;
+  routing?: string;
+  backend?: string;
+  channel?: string;
+  /** Write specs into the host project's Playwright `testDir` (#51) instead of greenfield `runs/`. */
+  intoProject: boolean;
+  projectDir?: string;
+  /** Optional glob filter on the PR's changed files — no match → the run is a no-op (changed-surface gate). */
+  paths: string[];
+  /** Post / update the summary comment on the PR. */
+  comment: boolean;
+  /** Open a follow-up PR carrying the generated tests (toggle, default off). */
+  openPr: boolean;
+  /** Branch name for the follow-up PR. */
+  prBranch: string;
+  /** Commit message for the follow-up PR. */
+  commitMessage: string;
+  /** Title for the follow-up PR (defaults from the commit message). */
+  prTitle: string;
+}
+
+/**
+ * Parse + validate inputs from `env`. Throws a single, clean error on the first problem (missing
+ * `url`, bad boolean, bad `mode`) so the action fails fast with an actionable message rather than
+ * deep inside the core run.
+ */
+export function parseInputs(env: Env = process.env): CiInputs {
+  const url = getInput(env, "url");
+  if (!url) throw new Error('Required input "url" is missing.');
+
+  const modeRaw = (getInput(env, "mode") ?? "explore").toLowerCase();
+  if (modeRaw !== "explore" && modeRaw !== "design") {
+    throw new Error(`Input "mode" must be "explore" or "design" (got "${modeRaw}").`);
+  }
+  const mode = modeRaw as CiMode;
+
+  const commitMessage =
+    getInput(env, "commit-message") ?? "test: update generated Playwright tests (cairn)";
+
+  return {
+    url,
+    mode,
+    session: getInput(env, "session"),
+    checklist: getInput(env, "checklist"),
+    style: getInput(env, "style"),
+    routing: getInput(env, "routing"),
+    backend: getInput(env, "backend"),
+    channel: getInput(env, "channel"),
+    intoProject: getBool(env, "into-project", true),
+    projectDir: getInput(env, "project-dir"),
+    paths: getList(env, "paths"),
+    comment: getBool(env, "comment", true),
+    openPr: getBool(env, "open-pr", false),
+    prBranch: getInput(env, "pr-branch") ?? "cairn/update-tests",
+    commitMessage,
+    prTitle: getInput(env, "pr-title") ?? commitMessage,
+  };
+}
+
+/** GitHub-provided run context (repo, PR number, refs) — distinct from user-configured inputs. */
+export interface CiContext {
+  /** `owner/repo` from `GITHUB_REPOSITORY`. */
+  owner: string;
+  repo: string;
+  /** PR number from the event payload (undefined when not a pull_request event). */
+  prNumber?: number;
+  /** Head branch (where a follow-up PR's commit lands / branches from). */
+  headRef?: string;
+  /** Base branch the PR targets. */
+  baseRef?: string;
+  /** REST API base (GitHub.com or GHES) — `GITHUB_API_URL`. */
+  apiUrl: string;
+  /** Auth token from env (`github-token` input → `INPUT_GITHUB-TOKEN`, falling back to `GITHUB_TOKEN`). */
+  token?: string;
+  /** True when the PR comes from a fork — the token is typically read-only, so write effects are skipped. */
+  isFork: boolean;
+}
+
+/** Minimal shape of the slice of the `pull_request` event payload we consume (for testable injection). */
+export interface PullRequestEvent {
+  pull_request?: {
+    number?: number;
+    head?: { ref?: string; repo?: { full_name?: string } | null };
+    base?: { ref?: string; repo?: { full_name?: string } | null };
+  };
+  number?: number;
+}
+
+/**
+ * Build the run context from env + an already-parsed event payload (injected so tests need no file).
+ * `repoFullName` defaults from `GITHUB_REPOSITORY`; fork detection compares head/base repo full names.
+ */
+export function buildContext(env: Env = process.env, event: PullRequestEvent = {}): CiContext {
+  const repoFull = env.GITHUB_REPOSITORY ?? "";
+  const [owner = "", repo = ""] = repoFull.split("/");
+
+  const pr = event.pull_request;
+  const prNumber = pr?.number ?? event.number;
+  const headRepo = pr?.head?.repo?.full_name;
+  const baseRepo = pr?.base?.repo?.full_name ?? (repoFull || undefined);
+  const isFork = Boolean(headRepo && baseRepo && headRepo !== baseRepo);
+
+  return {
+    owner,
+    repo,
+    prNumber: typeof prNumber === "number" ? prNumber : undefined,
+    headRef: pr?.head?.ref ?? env.GITHUB_HEAD_REF,
+    baseRef: pr?.base?.ref ?? env.GITHUB_BASE_REF,
+    apiUrl: env.GITHUB_API_URL ?? "https://api.github.com",
+    token: getInput(env, "github-token") ?? env.GITHUB_TOKEN,
+    isFork,
+  };
+}

--- a/src/ci/run.ts
+++ b/src/ci/run.ts
@@ -1,0 +1,245 @@
+/**
+ * INT-02 (#50) — CI / PR bot orchestrator.
+ *
+ * A THIN wrapper over the shared core (same pattern as the MCP layer, #49): validate inputs → reuse
+ * `resolveConfig` (routing / cost / config) → call the SAME `runExploration` / `runDesign` the CLI
+ * calls → compose a summary → post it as the PR comment → OPTIONALLY open a follow-up PR with the
+ * generated tests. No new generation logic lives here; specs land via the #51 project-fit writer.
+ *
+ * Every external effect (core, GitHub API, fs, clock) is injected through {@link CiDeps}, so the whole
+ * flow is unit-testable with mocks — no browser, no LLM, no network.
+ */
+import { join, relative, resolve } from "node:path";
+import { readFile as fsReadFile } from "node:fs/promises";
+import { resolveConfig } from "../core/config.js";
+import { runExploration, runDesign } from "../agent/index.js";
+import type { ExploreInput, ExploreResult, DesignResult } from "../agent/index.js";
+import { readInputFile } from "../fs/run-dir.js";
+import { resolveStyleText } from "../design/style.js";
+import { parseInputs, buildContext } from "./inputs.js";
+import type { CiInputs, CiContext, PullRequestEvent } from "./inputs.js";
+import { RestGitHubClient } from "./github.js";
+import type { GitHubClient, CommitFile } from "./github.js";
+import { renderCiSummary } from "./summary.js";
+import type { CiSummary } from "./summary.js";
+
+type Env = Record<string, string | undefined>;
+
+/** Injected seams — every dep defaults to the real implementation; tests pass mocks. */
+export interface CiDeps {
+  resolveConfig: typeof resolveConfig;
+  runExploration: typeof runExploration;
+  runDesign: typeof runDesign;
+  /** Build the GitHub client for a context (default: REST). Skipped entirely when there is no token. */
+  makeGitHubClient: (ctx: CiContext) => GitHubClient;
+  readInputFile: typeof readInputFile;
+  resolveStyleText: typeof resolveStyleText;
+  /** Read a generated spec from disk (for the follow-up PR commit). */
+  readFile: (absPath: string) => Promise<string>;
+  /** Working directory used to relativize spec paths into repo-relative commit paths. */
+  cwd: () => string;
+  log: (msg: string) => void;
+}
+
+export const defaultDeps: CiDeps = {
+  resolveConfig,
+  runExploration,
+  runDesign,
+  makeGitHubClient: (ctx) => new RestGitHubClient(ctx),
+  readInputFile,
+  resolveStyleText,
+  readFile: (p) => fsReadFile(p, "utf8"),
+  cwd: () => process.cwd(),
+  log: (m) => process.stderr.write(`${m}\n`),
+};
+
+export interface CiRunResult {
+  /** True when the core run executed (false on a no-op gate). */
+  ranCore: boolean;
+  summary: CiSummary;
+  /** The comment that was posted/updated, when the comment effect ran. */
+  comment?: { action: "created" | "updated"; id: number };
+  /** The follow-up PR, when the toggle ran it. */
+  followupPr?: { url: string; number: number };
+  /** Why a requested effect was skipped (fork / missing token / not a PR) — surfaced, never silent. */
+  skippedEffects: string[];
+}
+
+/** Translate a single glob (`*`, `**`, `?`) into an anchored RegExp over POSIX paths. */
+function globToRegExp(glob: string): RegExp {
+  const escaped = glob.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  // Single pass so a `*` emitted by an earlier replacement (e.g. inside `(?:.*/)?`) is not re-expanded.
+  const body = escaped.replace(/\*\*\/|\*\*|\*|\?/g, (m) => {
+    if (m === "**/") return "(?:.*/)?"; // any directories (or none)
+    if (m === "**") return ".*";
+    if (m === "*") return "[^/]*";
+    return "."; // ?
+  });
+  return new RegExp(`^${body}$`);
+}
+
+/** Does any glob match the file path? Empty glob list means "no filter" (always true at the call site). */
+export function matchesAnyGlob(file: string, globs: string[]): boolean {
+  const posix = file.replace(/\\/g, "/");
+  return globs.some((g) => globToRegExp(g).test(posix));
+}
+
+/** Map inputs → the shared `ExploreInput` (config reused), exactly like the CLI/MCP adapters do. */
+async function buildExploreInput(inputs: CiInputs, deps: CiDeps): Promise<ExploreInput> {
+  const config = deps.resolveConfig({
+    backend: inputs.backend,
+    routing: inputs.routing,
+    channel: inputs.channel,
+  });
+  const checklistText = inputs.checklist ? await deps.readInputFile(inputs.checklist, "Checklist") : undefined;
+  const styleText = inputs.style ? await deps.resolveStyleText(inputs.style) : undefined;
+  return {
+    url: inputs.url,
+    config,
+    sessionName: inputs.session,
+    checklistText,
+    style: inputs.style,
+    styleText,
+    intoProject: inputs.intoProject,
+    projectDir: inputs.projectDir,
+  };
+}
+
+/** Absolute paths of the spec files Cairn wrote (project-fit ejection wins; else the greenfield sandbox). */
+function generatedSpecPaths(result: ExploreResult): string[] {
+  if (result.projectSpecFiles?.length) return result.projectSpecFiles;
+  if (result.suite) return result.suite.files.map((f) => join(result.runDir, "tests", f.path));
+  return [];
+}
+
+/** Read the generated specs and turn them into repo-relative commit files for a follow-up PR. */
+async function collectCommitFiles(result: ExploreResult, deps: CiDeps): Promise<CommitFile[]> {
+  const root = deps.cwd();
+  const files: CommitFile[] = [];
+  for (const abs of generatedSpecPaths(result)) {
+    const content = await deps.readFile(abs);
+    const rel = relative(root, resolve(abs)).replace(/\\/g, "/");
+    files.push({ path: rel, content });
+  }
+  return files;
+}
+
+/** Build the compact validation roll-up the summary renders. */
+function compactValidation(result: ExploreResult): CiSummary["validation"] {
+  const v = result.validation;
+  if (!v) return undefined;
+  return {
+    greenRatio: v.greenRatio,
+    passed: v.results.filter((r) => r.status === "passed").length,
+    failed: v.results.filter((r) => r.status === "failed").length,
+    flaky: v.flakyCount,
+  };
+}
+
+/**
+ * Run the CI / PR bot end to end. Reads inputs + context from `env`/`event` (injected so tests need no
+ * files), runs the core, and applies the GitHub effects guarded by toggles + permission reality (fork
+ * PRs and missing tokens are read-only — those effects are skipped with a logged reason, never crash).
+ */
+export async function runCi(
+  env: Env = process.env,
+  event: PullRequestEvent = {},
+  deps: CiDeps = defaultDeps,
+): Promise<CiRunResult> {
+  const inputs = parseInputs(env);
+  const ctx = buildContext(env, event);
+  const skippedEffects: string[] = [];
+
+  // A token is required for any GitHub effect. Fork PRs get a read-only token under `pull_request`,
+  // so we also treat forks as "cannot write" (maintainers opt into pull_request_target deliberately).
+  const canWrite = Boolean(ctx.token) && !ctx.isFork && ctx.prNumber !== undefined;
+  const github = ctx.token ? deps.makeGitHubClient(ctx) : undefined;
+  if (!ctx.token) skippedEffects.push("no github-token — GitHub effects skipped");
+  else if (ctx.isFork) skippedEffects.push("fork PR (read-only token) — GitHub effects skipped");
+  else if (ctx.prNumber === undefined) skippedEffects.push("not a pull_request event — GitHub effects skipped");
+
+  // Changed-surface gate: when `paths` is set, only run if the PR touched a matching file. Needs read
+  // access to the PR's files; if we can't read them we conservatively proceed (better a run than a miss).
+  if (inputs.paths.length > 0 && github && ctx.prNumber !== undefined) {
+    const changed = await github.listChangedFiles(ctx.prNumber);
+    const hit = changed.some((f) => matchesAnyGlob(f.filename, inputs.paths));
+    if (!hit) {
+      deps.log("No changed files match `paths` — skipping generation (no-op).");
+      const summary: CiSummary = {
+        mode: inputs.mode,
+        url: inputs.url,
+        caseCount: 0,
+        specCount: 0,
+        noOpReason: "no changed surfaces matched the configured `paths`",
+      };
+      const comment = inputs.comment && canWrite ? await github.upsertComment(ctx.prNumber, renderCiSummary(summary)) : undefined;
+      return { ranCore: false, summary, comment, skippedEffects };
+    }
+  }
+
+  // Core run (the same entry points the CLI uses).
+  deps.log(`Running cairn ${inputs.mode} against ${inputs.url} …`);
+  const exploreInput = await buildExploreInput(inputs, deps);
+  let result: ExploreResult | DesignResult;
+  let exploreResult: ExploreResult | undefined;
+  if (inputs.mode === "explore") {
+    exploreResult = await deps.runExploration(exploreInput);
+    result = exploreResult;
+  } else {
+    result = await deps.runDesign(exploreInput);
+  }
+
+  const summary: CiSummary = {
+    mode: inputs.mode,
+    url: inputs.url,
+    runId: result.runId,
+    caseCount: result.testCases.length,
+    specCount: exploreResult ? generatedSpecPaths(exploreResult).length : 0,
+    validation: exploreResult ? compactValidation(exploreResult) : undefined,
+    pilot: exploreResult?.pilot
+      ? { verdict: exploreResult.pilot.verdict, reason: exploreResult.pilot.reason }
+      : undefined,
+    cost: { totalTokens: result.cost.totalTokens, totalCostUsd: result.cost.totalCostUsd },
+    projectTestDir: exploreResult?.projectTestDir,
+  };
+
+  // Optional follow-up PR — ONLY on explicit toggle, with writable context and actual specs to carry.
+  let followupPr: { url: string; number: number } | undefined;
+  if (inputs.openPr) {
+    if (inputs.mode !== "explore") {
+      skippedEffects.push("open-pr ignored — only `explore` mode produces code");
+    } else if (!canWrite || !github) {
+      skippedEffects.push("open-pr requested but context is read-only — follow-up PR skipped");
+    } else {
+      const files = await collectCommitFiles(exploreResult!, deps);
+      if (files.length === 0) {
+        skippedEffects.push("open-pr requested but no specs were generated — follow-up PR skipped");
+      } else {
+        const branch = `${inputs.prBranch}-${ctx.prNumber}`;
+        followupPr = await github.openFollowupPr({
+          branch,
+          baseBranch: ctx.headRef ?? ctx.baseRef ?? "main",
+          commitMessage: inputs.commitMessage,
+          title: inputs.prTitle,
+          body: `Generated by Cairn for #${ctx.prNumber}.`,
+          files,
+        });
+        summary.followupPr = followupPr;
+        deps.log(`Opened follow-up PR: ${followupPr.url}`);
+      }
+    }
+  }
+
+  // Summary comment (idempotent upsert) — last, so it reflects the follow-up PR.
+  let comment: { action: "created" | "updated"; id: number } | undefined;
+  if (inputs.comment) {
+    if (canWrite && github && ctx.prNumber !== undefined) {
+      comment = await github.upsertComment(ctx.prNumber, renderCiSummary(summary));
+      deps.log(`${comment.action === "created" ? "Posted" : "Updated"} the summary comment.`);
+    } else {
+      skippedEffects.push("comment requested but context is read-only — comment skipped");
+    }
+  }
+
+  return { ranCore: true, summary, comment, followupPr, skippedEffects };
+}

--- a/src/ci/summary.ts
+++ b/src/ci/summary.ts
@@ -1,0 +1,74 @@
+/**
+ * INT-02 (#50) — compose the PR summary comment from a CI run result.
+ *
+ * Pure string assembly (no I/O) so it is unit-testable directly. The output is GitHub-flavored
+ * markdown; the {@link ./github.ts} client stamps the idempotency marker before posting.
+ */
+
+/** Validation roll-up (mirrors the compact shape the MCP layer already produces). */
+export interface SummaryValidation {
+  greenRatio: number;
+  passed: number;
+  failed: number;
+  flaky: number;
+}
+
+/** Everything the comment renders — filled by the orchestrator from the core run result. */
+export interface CiSummary {
+  mode: "explore" | "design";
+  url: string;
+  runId?: string;
+  caseCount: number;
+  specCount: number;
+  validation?: SummaryValidation;
+  pilot?: { verdict: string; reason: string };
+  cost?: { totalTokens: number; totalCostUsd: number | null };
+  /** Where specs were written into the host Playwright project (#51), when into-project ran. */
+  projectTestDir?: string;
+  /** The opened follow-up PR, when the toggle ran it. */
+  followupPr?: { url: string; number: number };
+  /** Set when the run was skipped (e.g. no changed surfaces) — renders a no-op note instead of metrics. */
+  noOpReason?: string;
+}
+
+const TITLE = "### 🪨 Cairn — generated UI tests";
+
+/** Format a cost line, tolerating an unknown (null) USD total. */
+function costLine(cost: CiSummary["cost"]): string {
+  if (!cost) return "";
+  const usd = cost.totalCostUsd === null ? "n/a" : `$${cost.totalCostUsd.toFixed(4)}`;
+  return `- **Cost:** ${cost.totalTokens.toLocaleString("en-US")} tokens · ${usd}`;
+}
+
+/** Render the full comment body (without the hidden marker — the client adds that). */
+export function renderCiSummary(s: CiSummary): string {
+  if (s.noOpReason) {
+    return [TITLE, "", `No tests generated — ${s.noOpReason}.`].join("\n");
+  }
+
+  const lines: string[] = [TITLE, ""];
+  lines.push(`Ran \`cairn ${s.mode}\` against \`${s.url}\`.`, "");
+
+  lines.push(`- **Test cases:** ${s.caseCount}`);
+  if (s.mode === "explore") lines.push(`- **Spec files:** ${s.specCount}`);
+
+  if (s.validation) {
+    const pct = Math.round(s.validation.greenRatio * 100);
+    lines.push(
+      `- **Validation:** ${pct}% green — ${s.validation.passed} passed, ` +
+        `${s.validation.failed} failed, ${s.validation.flaky} flaky`,
+    );
+  }
+  if (s.pilot) lines.push(`- **Pilot verdict:** ${s.pilot.verdict} — ${s.pilot.reason}`);
+  if (s.projectTestDir) lines.push(`- **Written to:** \`${s.projectTestDir}\``);
+  const cost = costLine(s.cost);
+  if (cost) lines.push(cost);
+
+  if (s.followupPr) {
+    lines.push("", `📦 Opened follow-up PR with the tests: ${s.followupPr.url} (#${s.followupPr.number}).`);
+  } else if (s.mode === "explore" && s.specCount > 0) {
+    lines.push("", "_Tests were generated in the workflow run. Enable `open-pr` to receive them as a follow-up PR._");
+  }
+
+  return lines.join("\n");
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -488,6 +488,15 @@ export function buildProgram(): Command {
       await startMcpServer();
     });
 
+  program
+    .command("ci")
+    .description("CI / PR bot (#50): run cairn on a PR from GitHub Action inputs/env, post a summary comment, optionally open a follow-up PR")
+    .action(async () => {
+      // Thin wrapper: all config comes from the action's inputs (INPUT_* env) + the GitHub event.
+      const { startCi } = await import("../ci/index.js");
+      await startCi();
+    });
+
   return program;
 }
 

--- a/tests/unit/__snapshots__/cli-modalities.test.ts.snap
+++ b/tests/unit/__snapshots__/cli-modalities.test.ts.snap
@@ -39,6 +39,9 @@ Commands:
                          see L-G2)
   mcp                    run an MCP server (stdio) exposing explore/design as
                          tools for Claude Code / Cursor
+  ci                     CI / PR bot (#50): run cairn on a PR from GitHub Action
+                         inputs/env, post a summary comment, optionally open a
+                         follow-up PR
   help [command]         display help for command
 "
 `;

--- a/tests/unit/ci.test.ts
+++ b/tests/unit/ci.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi } from "vitest";
+import { parseInputs, buildContext } from "../../src/ci/inputs.js";
+import { selectCommentAction, withMarker, RestGitHubClient, COMMENT_MARKER } from "../../src/ci/github.js";
+import { renderCiSummary } from "../../src/ci/summary.js";
+import { runCi, matchesAnyGlob, type CiDeps } from "../../src/ci/run.js";
+import type { ExploreResult, DesignResult } from "../../src/agent/index.js";
+
+type Env = Record<string, string | undefined>;
+
+// ── inputs ───────────────────────────────────────────────────────────────────
+describe("CI inputs (#50)", () => {
+  const base: Env = { INPUT_URL: "https://x" };
+
+  it("parses valid inputs with sensible defaults", () => {
+    const i = parseInputs(base);
+    expect(i.url).toBe("https://x");
+    expect(i.mode).toBe("explore");
+    expect(i.intoProject).toBe(true); // project-fit on by default
+    expect(i.comment).toBe(true);
+    expect(i.openPr).toBe(false); // follow-up PR opt-in
+    expect(i.prBranch).toBe("cairn/update-tests");
+  });
+
+  it("missing url → clean error", () => {
+    expect(() => parseInputs({})).toThrow(/Required input "url"/);
+  });
+
+  it("rejects a bad boolean and a bad mode", () => {
+    expect(() => parseInputs({ ...base, "INPUT_OPEN-PR": "yes" })).toThrow(/must be "true" or "false"/);
+    expect(() => parseInputs({ ...base, INPUT_MODE: "fuzz" })).toThrow(/must be "explore" or "design"/);
+  });
+
+  it("parses passthrough flags + multiline paths", () => {
+    const i = parseInputs({
+      ...base,
+      INPUT_MODE: "design",
+      INPUT_ROUTING: "volume",
+      "INPUT_INTO-PROJECT": "false",
+      INPUT_PATHS: "src/a/**\n  src/b/*  ,src/c.ts",
+    });
+    expect(i.mode).toBe("design");
+    expect(i.routing).toBe("volume");
+    expect(i.intoProject).toBe(false);
+    expect(i.paths).toEqual(["src/a/**", "src/b/*", "src/c.ts"]);
+  });
+
+  it("buildContext reads repo/PR/token and detects forks", () => {
+    const env: Env = { GITHUB_REPOSITORY: "plune-ai/cairn", GITHUB_TOKEN: "tok" };
+    const ctx = buildContext(env, {
+      pull_request: {
+        number: 7,
+        head: { ref: "feat", repo: { full_name: "contributor/cairn" } },
+        base: { ref: "main", repo: { full_name: "plune-ai/cairn" } },
+      },
+    });
+    expect(ctx.owner).toBe("plune-ai");
+    expect(ctx.repo).toBe("cairn");
+    expect(ctx.prNumber).toBe(7);
+    expect(ctx.token).toBe("tok");
+    expect(ctx.isFork).toBe(true);
+  });
+});
+
+// ── comment idempotency + summary ──────────────────────────────────────────────
+describe("CI comment + summary (#50)", () => {
+  it("selectCommentAction updates the marked comment, else creates", () => {
+    expect(selectCommentAction([])).toEqual({ action: "created" });
+    expect(selectCommentAction([{ id: 3, body: "hi" }])).toEqual({ action: "created" });
+    expect(selectCommentAction([{ id: 9, body: withMarker("prev") }])).toEqual({ action: "updated", id: 9 });
+  });
+
+  it("renderCiSummary renders metrics for explore + a no-op note", () => {
+    const body = renderCiSummary({
+      mode: "explore",
+      url: "https://x",
+      caseCount: 4,
+      specCount: 2,
+      validation: { greenRatio: 1, passed: 3, failed: 0, flaky: 0 },
+      pilot: { verdict: "pass", reason: "looks good" },
+      cost: { totalTokens: 1234, totalCostUsd: 0.0123 },
+      followupPr: { url: "https://pr/7", number: 7 },
+    });
+    expect(body).toContain("Test cases:** 4");
+    expect(body).toContain("Spec files:** 2");
+    expect(body).toContain("100% green");
+    expect(body).toContain("Pilot verdict:** pass");
+    expect(body).toContain("$0.0123");
+    expect(body).toContain("follow-up PR");
+
+    const noop = renderCiSummary({ mode: "explore", url: "https://x", caseCount: 0, specCount: 0, noOpReason: "no changed surfaces matched the configured `paths`" });
+    expect(noop).toContain("No tests generated");
+  });
+
+  it("globs gate changed files", () => {
+    expect(matchesAnyGlob("src/app/login/page.tsx", ["src/app/login/**"])).toBe(true);
+    expect(matchesAnyGlob("src/other.ts", ["src/app/login/**"])).toBe(false);
+    expect(matchesAnyGlob("a/b/c.ts", ["**/*.ts"])).toBe(true);
+  });
+});
+
+// ── REST client idempotency (mocked fetch, no network) ─────────────────────────
+describe("RestGitHubClient.upsertComment (#50)", () => {
+  function okJson(data: unknown) {
+    return { ok: true, status: 200, statusText: "OK", json: async () => data, text: async () => "" } as Response;
+  }
+
+  it("PATCHes the existing marked comment instead of posting a duplicate", async () => {
+    const calls: { method?: string; url: string }[] = [];
+    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      calls.push({ method: init?.method, url: u });
+      if (init?.method === "GET") return okJson([{ id: 42, body: `${COMMENT_MARKER}\nold` }]);
+      return okJson({ id: 42 });
+    });
+    const client = new RestGitHubClient(
+      { owner: "o", repo: "r", apiUrl: "https://api.github.com", token: "tok", isFork: false },
+      fetchImpl as unknown as typeof fetch,
+    );
+    const r = await client.upsertComment(7, "new body");
+    expect(r).toEqual({ action: "updated", id: 42 });
+    expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/issues/comments/42"))).toBe(true);
+    expect(calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("POSTs a new comment when none is marked", async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === "GET") return okJson([{ id: 1, body: "unrelated" }]);
+      return okJson({ id: 99 });
+    });
+    const client = new RestGitHubClient(
+      { owner: "o", repo: "r", apiUrl: "https://api.github.com", token: "tok", isFork: false },
+      fetchImpl as unknown as typeof fetch,
+    );
+    const r = await client.upsertComment(7, "new body");
+    expect(r).toEqual({ action: "created", id: 99 });
+  });
+});
+
+// ── orchestrator ───────────────────────────────────────────────────────────────
+const exploreResult = {
+  runId: "r1",
+  runDir: "runs/r1",
+  testCases: [{ id: "tc-1" }, { id: "tc-2" }],
+  suite: { files: [{ path: "login.spec.ts", content: "x" }] },
+  projectSpecFiles: ["/work/e2e/login.spec.ts"],
+  projectTestDir: "/work/e2e",
+  validation: { greenRatio: 1, flakyCount: 0, results: [{ status: "passed" }] },
+  pilot: { verdict: "pass", reason: "ok", guidance: "" },
+  cost: { totalTokens: 100, totalCostUsd: 0.01 },
+} as unknown as ExploreResult;
+
+const designResult = {
+  runId: "d1",
+  runDir: "runs/d1",
+  testCases: [{ id: "tc-1" }],
+  cost: { totalTokens: 50, totalCostUsd: 0.005 },
+} as unknown as DesignResult;
+
+function makeDeps(over: Partial<CiDeps> = {}) {
+  const calls: { config?: unknown; explore?: unknown; design?: unknown } = {};
+  const github = {
+    listChangedFiles: vi.fn(async () => [{ filename: "src/app/login/page.tsx", status: "modified" }]),
+    upsertComment: vi.fn(async () => ({ action: "created" as const, id: 1 })),
+    openFollowupPr: vi.fn(async () => ({ url: "https://pr/7", number: 7 })),
+  };
+  const deps: CiDeps = {
+    resolveConfig: vi.fn((flags) => {
+      calls.config = flags;
+      return {} as unknown as ReturnType<CiDeps["resolveConfig"]>;
+    }),
+    runExploration: vi.fn(async (input) => {
+      calls.explore = input;
+      return exploreResult;
+    }),
+    runDesign: vi.fn(async (input) => {
+      calls.design = input;
+      return designResult;
+    }),
+    makeGitHubClient: () => github,
+    readInputFile: vi.fn(async () => "checklist text"),
+    resolveStyleText: vi.fn(async () => "style text"),
+    readFile: vi.fn(async () => "spec content"),
+    cwd: () => "/work",
+    log: () => undefined,
+    ...over,
+  };
+  return { deps, github, calls };
+}
+
+const prEvent = {
+  pull_request: {
+    number: 7,
+    head: { ref: "feat", repo: { full_name: "plune-ai/cairn" } },
+    base: { ref: "main", repo: { full_name: "plune-ai/cairn" } },
+  },
+};
+
+function env(over: Env = {}): Env {
+  return { GITHUB_REPOSITORY: "plune-ai/cairn", GITHUB_API_URL: "https://api.github.com", GITHUB_TOKEN: "tok", INPUT_URL: "https://x", ...over };
+}
+
+describe("runCi orchestrator (#50)", () => {
+  it("explore: reuses resolveConfig, calls core with project-fit, posts the comment", async () => {
+    const { deps, github, calls } = makeDeps();
+    const r = await runCi(env({ INPUT_ROUTING: "volume" }), prEvent, deps);
+
+    // config reused (routing flows through resolveConfig — keys are read from env there, not hardcoded)
+    expect(calls.config).toEqual({ backend: undefined, routing: "volume", channel: undefined });
+    expect(deps.runExploration).toHaveBeenCalledTimes(1);
+    expect((calls.explore as { url: string; intoProject: boolean }).url).toBe("https://x");
+    expect((calls.explore as { intoProject: boolean }).intoProject).toBe(true); // project-fit (#51)
+
+    expect(r.ranCore).toBe(true);
+    expect(r.summary.caseCount).toBe(2);
+    expect(r.summary.specCount).toBe(1);
+    expect(github.upsertComment).toHaveBeenCalledTimes(1);
+    expect(r.comment).toEqual({ action: "created", id: 1 });
+    expect(github.openFollowupPr).not.toHaveBeenCalled(); // toggle off
+  });
+
+  it("opens a follow-up PR ONLY when open-pr is on (and carries repo-relative specs)", async () => {
+    const { deps, github } = makeDeps();
+    const r = await runCi(env({ "INPUT_OPEN-PR": "true" }), prEvent, deps);
+    expect(github.openFollowupPr).toHaveBeenCalledTimes(1);
+    const arg = github.openFollowupPr.mock.calls[0][0];
+    expect(arg.files).toEqual([{ path: "e2e/login.spec.ts", content: "spec content" }]);
+    expect(arg.baseBranch).toBe("feat"); // branch from the PR head
+    expect(arg.branch).toBe("cairn/update-tests-7");
+    expect(r.followupPr).toEqual({ url: "https://pr/7", number: 7 });
+  });
+
+  it("open-pr in design mode is ignored (no code to carry)", async () => {
+    const { deps, github } = makeDeps();
+    const r = await runCi(env({ INPUT_MODE: "design", "INPUT_OPEN-PR": "true" }), prEvent, deps);
+    expect(deps.runDesign).toHaveBeenCalledTimes(1);
+    expect(github.openFollowupPr).not.toHaveBeenCalled();
+    expect(r.skippedEffects.join(" ")).toMatch(/only `explore` mode produces code/);
+  });
+
+  it("changed-surface gate: no matching path → no-op, core not run", async () => {
+    const { deps, github } = makeDeps({
+      // PR touched only an unrelated file
+    });
+    github.listChangedFiles.mockResolvedValueOnce([{ filename: "README.md", status: "modified" }]);
+    const r = await runCi(env({ INPUT_PATHS: "src/app/login/**" }), prEvent, deps);
+    expect(r.ranCore).toBe(false);
+    expect(deps.runExploration).not.toHaveBeenCalled();
+    expect(r.summary.noOpReason).toMatch(/no changed surfaces/);
+    expect(github.upsertComment).toHaveBeenCalledTimes(1); // no-op comment still posted
+  });
+
+  it("matching path → core runs", async () => {
+    const { deps } = makeDeps();
+    const r = await runCi(env({ INPUT_PATHS: "src/app/login/**" }), prEvent, deps);
+    expect(r.ranCore).toBe(true);
+    expect(deps.runExploration).toHaveBeenCalledTimes(1);
+  });
+
+  it("fork PR → core still runs but GitHub effects are skipped (read-only token)", async () => {
+    const { deps, github } = makeDeps();
+    const forkEvent = {
+      pull_request: { number: 7, head: { ref: "feat", repo: { full_name: "contributor/cairn" } }, base: { ref: "main", repo: { full_name: "plune-ai/cairn" } } },
+    };
+    const r = await runCi(env({ "INPUT_OPEN-PR": "true" }), forkEvent, deps);
+    expect(r.ranCore).toBe(true);
+    expect(github.upsertComment).not.toHaveBeenCalled();
+    expect(github.openFollowupPr).not.toHaveBeenCalled();
+    expect(r.skippedEffects.join(" ")).toMatch(/fork PR/);
+  });
+
+  it("no token → effects skipped, no client built, core still runs", async () => {
+    const made = makeDeps();
+    const r = await runCi(env({ GITHUB_TOKEN: undefined }), prEvent, made.deps);
+    expect(r.ranCore).toBe(true);
+    expect(made.github.upsertComment).not.toHaveBeenCalled();
+    expect(r.skippedEffects.join(" ")).toMatch(/no github-token/);
+  });
+});


### PR DESCRIPTION
Closes #50.

## What

INT-02 — a reusable **GitHub Action** that runs Cairn on a pull request, posts a summary comment, and optionally opens a follow-up PR with the generated tests. Scope is strictly `v1 = generation-on-PR`; maintenance/self-heal (epic #46) is out of scope.

The action is a **thin wrapper over the shared core** (same pattern as the MCP server, #49) — no new generation logic, no refactors outside scope.

### Added
- **`action/action.yml`** — composite action: `inputs:` (url, mode, session, checklist, style, routing, backend, channel, into-project, project-dir, paths, comment, open-pr, pr-branch, commit-message, pr-title, github-token, cairn-version, install-browsers) → mapped to `INPUT_*` env → `cairn ci`. Provider keys are **not** inputs; they come from job/step `env:` (repo secrets).
- **`action/README.md`** — usage, full input table, and the **secrets/permissions a repo admin must set** (the action never configures them).
- **`cairn ci`** CLI command (lazy, mirrors `cairn mcp`) → `src/ci/`:
  - `inputs.ts` — parse/validate inputs from env (clean fail-fast on missing `url` / bad bool / bad mode); build PR context (repo, PR number, refs, **fork detection**) from the event payload.
  - `github.ts` — `GitHubClient` seam + `RestGitHubClient` (built-in `fetch`, no Octokit dep): list changed files, **idempotent** comment upsert (hidden marker), follow-up PR via the Git Data API.
  - `summary.ts` — pure markdown summary composer.
  - `run.ts` — orchestrator: validate → optional **changed-surface gate** (`paths`) → reuse `resolveConfig` → `runExploration`/`runDesign` → write via **#51 project-fit** → comment → **opt-in** follow-up PR. Every effect injected for testability.

## DoD (mapped)
- ✅ Reusable action that on PR produces tests + a comment — `runCi` → core + `upsertComment`.
- ✅ Config via inputs — `action.yml` inputs → `INPUT_*` → `parseInputs`.
- ✅ Keys via repo secrets — read from env through `resolveConfig`, never hardcoded; documented in `action/README.md`.

## How verified (on mocks — no live run, no real posting)
- `npm run typecheck`, `npm run lint`, `npm run build` — clean.
- `npm test` — unit suite green (**565 passed**). New `tests/unit/ci.test.ts` (17 tests, GitHub API + core mocked) covers: valid inputs → correct core call + result shape; missing input → clean error; summary composition; comment idempotency (marker + REST upsert via mocked `fetch`); follow-up PR **only** when toggled; keys read from env (not hardcoded); generated tests routed through project-fit (#51); changed-surface no-op; fork/no-token effect-skipping.
  - Pre-existing **3 integration failures are environmental** (real Chromium not installed: `BrowsersNotInstalledError`) — unrelated to this change.
- `npm run smoke:pack` — 8/8 checks pass.
- `cairn ci` with no `url` → fails fast with `Required input "url" is missing.` (exit 1), before any network/browser.

## Edge cases handled
- **Fork PRs** (read-only token) and **missing token** → write effects skipped with a logged reason; core still runs.
- **No changed surfaces** (`paths` set, no match) → no-op comment, core not run.
- **Idempotency** — re-runs update the marked comment instead of duplicating.
- **Follow-up PR** — opt-in (`open-pr`), `explore` mode only, requires writable context + generated specs.

## Follow-ups (require a human / out of scope here)
- Set the actual **repo secrets** (`ANTHROPIC_API_KEY`, etc.) and grant `pull-requests: write` (+ `contents: write` for `open-pr`) — documented, **not** configured by this PR.
- Decide distribution: keep `uses: plune-ai/cairn/action@v1` (sub-path) **or** mirror `action/` to a dedicated `plune-ai/cairn-action` repo (a release step).
- Enable/trigger the live workflow against a target — intentionally not run here.
- Mapping a PR diff → concrete URLs (richer "changed surfaces") beyond the `paths` gate.
