### PR TITLE
feat: goal-directed exploration — cairn explore --goal (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Goal-directed exploration — `cairn explore --goal "..."` (#63, MEM-01).** Accept a natural-language
+  goal (e.g. `"test the checkout flow"`) and bias the run toward it instead of a blind crawl: the goal
+  threads into both observation (`identify-elements` prioritizes goal-relevant elements) and planning
+  (the case designer leads with goal-relevant cases). Passed per-run through the existing input path
+  (like `--checklist`, nothing hardcoded). Fully back-compatible — without `--goal` the prompts are
+  byte-identical and the crawl is unchanged.
+
 - **CI / PR bot — GitHub Action (#50).** A reusable composite action (`action/`) that runs Cairn on a
   pull request, posts (or updates) a **summary comment**, and **optionally opens a follow-up PR** with
   the generated tests. `v1` is generation-on-PR; maintenance/self-heal stays in epic #46. The action is

--- a/prompts/qa-testcase-from-ui.md
+++ b/prompts/qa-testcase-from-ui.md
@@ -4,6 +4,8 @@ IMPORTANT: write all title, steps, expected in {{language}} — do not mix langu
 Page purpose:
 {{pageSemantics}}
 
+{{goal}}
+
 Interactive elements (ref · role · name; ×N = repeated, several identical on the page — e.g. list rows). All REALLY present. In elementRefs use ONLY these refs — do not invent or change them:
 {{elements}}
 

--- a/src/agent/graph.ts
+++ b/src/agent/graph.ts
@@ -39,6 +39,8 @@ export interface ExploreDeps {
   /** #60: worker-tier invoker for setup planning (precondition extraction). Absent → no setup. */
   setupInvoke?: StructuredInvoke;
   useVision: boolean;
+  /** #63: pre-formatted goal directive ({@link formatGoal}) — biases observe (element pick) + design. "" → no bias. */
+  goalText?: string;
   checklistText?: string;
   knowledgeText?: string;
   experienceText?: string;
@@ -141,6 +143,7 @@ export async function runExploreGraph(
     invoke: deps.analyzeInvoke,
     prompts: deps.prompts,
     vision: deps.useVision,
+    goalText: deps.goalText,
   });
   // L1-05: a session was supplied but the first page looks like a login screen → the session
   // is likely expired. Fail fast with re-capture guidance BEFORE the expensive design/codegen
@@ -221,6 +224,7 @@ export async function runExploreGraph(
       study,
       pageSemantics: analysis.pageSemantics,
       checklistText: deps.checklistText,
+      goalText: deps.goalText,
       elements: verified.filter((v) => v.count >= 1),
       transitions,
       knowledge: deps.knowledgeText,

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -19,7 +19,7 @@ import { designGapCases } from "../eval/gap-cases.js";
 import { judgeTestCases, judgeChecklistCoverage } from "../eval/judge.js";
 import { pilotReview, type PilotVerdict } from "../eval/pilot.js";
 import { collectPriorRuns, unionPassedTitles, experienceForUrl } from "../eval/collect.js";
-import { ingestChecklist, formatChecklist, coverageScore, styleDirective } from "../checklist/index.js";
+import { ingestChecklist, formatChecklist, formatGoal, coverageScore, styleDirective } from "../checklist/index.js";
 import { loadKnowledge } from "../knowledge/index.js";
 import { validateSuite, type ValidationReport } from "../validate/index.js";
 import { SessionStore } from "../session/index.js";
@@ -44,6 +44,8 @@ export interface ExploreInput {
   url: string;
   config: AppConfig;
   checklistText?: string;
+  /** #63 (MEM-01): natural-language goal — biases observation + planning toward it instead of a blind crawl. */
+  goal?: string;
   /** Base directory for runs/ (default ./runs in the project — needed to resolve @playwright/test). */
   runsBaseDir?: string;
   /** Name of the saved session (cookies+localStorage) → .auth/<name>.storageState.json. */
@@ -250,6 +252,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
     // #60: setup planning runs on the worker tier (CAIRN_ROLE_WORKER); built only when opted in.
     setupInvoke: input.setup ? router.invoke("worker", router.tierFor("worker", cfg.models.bulk)) : undefined,
     useVision: analyzeTier.supportsVision,
+    goalText: formatGoal(input.goal),
     checklistText: checklistFormatted,
     knowledgeText,
     experienceText,

--- a/src/analyze/index.ts
+++ b/src/analyze/index.ts
@@ -18,6 +18,8 @@ export interface AnalyzeDeps {
   prompts: PromptRegistry;
   /** Send the screenshot (vision). If false or the model has no vision — aria-only mode (ADR-0002). */
   vision?: boolean;
+  /** #63: pre-formatted goal directive ({@link formatGoal}) — biases element selection. "" → no bias. */
+  goalText?: string;
 }
 
 /**
@@ -31,6 +33,7 @@ export async function analyzePage(study: PageStudy, deps: AnalyzeDeps): Promise<
   const prompt = await deps.prompts.getPrompt("identify-elements", {
     ariaYaml: study.ariaYaml,
     elements,
+    goal: deps.goalText ?? "",
   });
 
   const useVision = Boolean(deps.vision && study.screenshotB64);

--- a/src/checklist/index.ts
+++ b/src/checklist/index.ts
@@ -40,6 +40,22 @@ export function formatChecklist(items: ChecklistItem[]): string {
   );
 }
 
+/**
+ * Goal directive (#63 MEM-01): a natural-language goal that biases observation + planning toward
+ * one area instead of a blind crawl. Empty/blank → "" (no bias — unchanged default behavior).
+ * Used by BOTH identify-elements (prioritize goal-relevant elements) and the case designer
+ * (lead with goal-relevant cases), so the wording covers elements AND scenarios.
+ */
+export function formatGoal(goal?: string): string {
+  const g = goal?.trim();
+  if (!g) return "";
+  return (
+    `GOAL FOR THIS RUN — bias toward this user goal: "${g}".\n` +
+    "Prioritize the elements and scenarios relevant to this goal and lead with them; " +
+    "de-emphasize unrelated areas (do NOT ignore a critical issue you notice elsewhere)."
+  );
+}
+
 /** Detect the text language (for language-consistent design): Cyrillic → "Ukrainian", otherwise → "English". */
 export function detectLanguage(text: string): string {
   return /[Ѐ-ӿ]/i.test(text) ? "Ukrainian" : "English";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -110,6 +110,7 @@ export function buildProgram(): Command {
     .option("--session-file <path>", "direct path to a storageState file (any name)")
     .option("--headed", "visible browser (debug)")
     .option("--checklist <file>", "checklist file (md/text) — guides what to test")
+    .option("--goal <text>", "natural-language goal — bias observation + cases toward it (e.g. \"test the checkout flow\") instead of a blind crawl")
     .option("--style <s>", "planning style: happy | negative | coverage | all")
     .option("--fresh", "ignore prior runs for this URL — generate a full set, don't dedupe against past cases")
     .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) | volume-fast (Anthropic codegen, cheap judge on OpenRouter) (sets LLM_ROUTING)")

--- a/src/core/modalities/explore.ts
+++ b/src/core/modalities/explore.ts
@@ -24,6 +24,7 @@ interface ExploreFlags {
   sessionFile?: string;
   headed?: boolean;
   checklist?: string;
+  goal?: string;
   style?: string;
   routing?: string;
   fresh?: boolean;
@@ -48,7 +49,7 @@ export const exploreModality: Modality = {
     // else the built-in inline hint. Methodology / assertion-safety are never touched.
     const styleText = await resolveStyleText(opts.style);
     ctx.err(
-      `▸ Exploring ${opts.url}${opts.session ? ` (session: ${opts.session})` : ""}${opts.checklist ? ` (checklist: ${opts.checklist})` : ""}…\n`,
+      `▸ Exploring ${opts.url}${opts.session ? ` (session: ${opts.session})` : ""}${opts.checklist ? ` (checklist: ${opts.checklist})` : ""}${opts.goal ? ` (goal: "${opts.goal}")` : ""}…\n`,
     );
     // Progress UX: animate the current step in a TTY (long LLM steps emit no events for ~a minute, so the
     // CLI looked frozen). In a pipe/CI this falls back to one plain `  ▸ <event>` line per event.
@@ -60,6 +61,7 @@ export const exploreModality: Modality = {
       sessionFile: opts.sessionFile,
       headed: opts.headed,
       checklistText,
+      goal: opts.goal,
       style: opts.style,
       styleText,
       fresh: opts.fresh,

--- a/src/design/index.ts
+++ b/src/design/index.ts
@@ -20,6 +20,8 @@ export interface DesignInput {
   pageSemantics: string;
   /** Checklist text (Sprint 4); currently empty. */
   checklistText?: string;
+  /** #63: pre-formatted goal directive ({@link formatGoal}) — leads with goal-relevant cases. "" → no bias. */
+  goalText?: string;
   /** Discovered elements (count≥1) from verify; fallback — study.elements. */
   elements?: VerifiedElement[];
   /** Observed state transitions (act→observe, Stage B). */
@@ -59,6 +61,7 @@ export async function designTestCases(input: DesignInput, deps: DesignDeps): Pro
     pageSemantics: input.pageSemantics,
     elements,
     methodology,
+    goal: input.goalText ?? "",
     checklist: input.checklistText ?? "",
     transitions: formatTransitions(input.transitions ?? []),
     language: input.language ?? "English",

--- a/src/prompts/local/identify-elements.ts
+++ b/src/prompts/local/identify-elements.ts
@@ -10,10 +10,13 @@ ARIA snapshot:
 Detected elements (ref · role · name):
 {{elements}}
 
+{{goal}}
+
 Tasks:
 1. pageSemantics — briefly (1–2 sentences) describe what this screen is and its main purpose.
-2. primaryRefs — pick the refs of the most test-worthy elements. Use ONLY refs from the provided
-   list — do not invent new ones or change them.
+2. primaryRefs — pick the refs of the most test-worthy elements (when a GOAL is given above,
+   prioritize elements relevant to it). Use ONLY refs from the provided list — do not invent new
+   ones or change them.
 3. viewSwitchers — refs of view switchers: tabs, wizard steps, filter/mode toggles, form switchers —
    whose click OPENS DIFFERENT content (rather than performing an action). Only from the provided list; empty if none.
 

--- a/src/prompts/local/qa-testcase-from-ui.ts
+++ b/src/prompts/local/qa-testcase-from-ui.ts
@@ -8,6 +8,8 @@ IMPORTANT: write all title, steps, expected in {{language}} — do not mix langu
 Page purpose:
 {{pageSemantics}}
 
+{{goal}}
+
 Interactive elements (ref · role · name; ×N = repeated, several identical on the page — e.g. list rows). All REALLY present. In elementRefs use ONLY these refs — do not invent or change them:
 {{elements}}
 

--- a/tests/unit/__snapshots__/cli-modalities.test.ts.snap
+++ b/tests/unit/__snapshots__/cli-modalities.test.ts.snap
@@ -62,6 +62,9 @@ Options:
   --session-file <path>  direct path to a storageState file (any name)
   --headed               visible browser (debug)
   --checklist <file>     checklist file (md/text) — guides what to test
+  --goal <text>          natural-language goal — bias observation + cases toward
+                         it (e.g. "test the checkout flow") instead of a blind
+                         crawl
   --style <s>            planning style: happy | negative | coverage | all
   --fresh                ignore prior runs for this URL — generate a full set,
                          don't dedupe against past cases

--- a/tests/unit/analyze.test.ts
+++ b/tests/unit/analyze.test.ts
@@ -29,6 +29,25 @@ describe("analyzePage (identifyElements)", () => {
     expect(captured).not.toContain("image_url");
   });
 
+  it("goalText biases the element-pick prompt; absent → no goal directive (#63)", async () => {
+    let captured = "";
+    const fakeInvoke: StructuredInvoke = async (schema, messages) => {
+      captured = JSON.stringify(messages);
+      return schema.parse({ pageSemantics: "x", primaryRefs: [] });
+    };
+    await analyzePage(study, {
+      invoke: fakeInvoke,
+      prompts: new PromptRegistry(),
+      vision: false,
+      goalText: 'GOAL FOR THIS RUN — bias toward this user goal: "checkout flow".',
+    });
+    expect(captured).toContain("checkout flow");
+
+    captured = "";
+    await analyzePage(study, { invoke: fakeInvoke, prompts: new PromptRegistry(), vision: false });
+    expect(captured).not.toContain("GOAL FOR THIS RUN"); // back-compat: no goal → no directive
+  });
+
   it("vision=true → the message contains an image_url with the screenshot", async () => {
     let captured = "";
     const fakeInvoke: StructuredInvoke = async (schema, messages) => {

--- a/tests/unit/checklist.test.ts
+++ b/tests/unit/checklist.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   ingestChecklist,
   formatChecklist,
+  formatGoal,
   coverageScore,
   detectLanguage,
   styleDirective,
@@ -40,6 +41,15 @@ describe("checklist", () => {
   it("detectLanguage: Cyrillic → Ukrainian, Latin → English", () => {
     expect(detectLanguage("Перемикання вкладок")).toBe("Ukrainian");
     expect(detectLanguage("Switch between tabs")).toBe("English");
+  });
+
+  it("formatGoal: blank/undefined → '', otherwise a directive carrying the goal (#63)", () => {
+    expect(formatGoal()).toBe("");
+    expect(formatGoal("")).toBe("");
+    expect(formatGoal("   ")).toBe(""); // whitespace-only is no goal
+    const d = formatGoal("  test the checkout flow  ");
+    expect(d).toContain("test the checkout flow"); // trimmed, embedded
+    expect(d).toContain("GOAL FOR THIS RUN");
   });
 
   it("styleDirective: happy/negative/coverage → a directive; all/'' → ''", () => {

--- a/tests/unit/cli-modalities.test.ts
+++ b/tests/unit/cli-modalities.test.ts
@@ -109,6 +109,7 @@ describe("explore parity (C1-02)", () => {
       "--session-file",
       "--headed",
       "--checklist",
+      "--goal",
       "--style",
       "--fresh",
       "--routing",
@@ -121,7 +122,7 @@ describe("explore parity (C1-02)", () => {
     ]) {
       expect(longs, `explore should accept ${f}`).toContain(f);
     }
-    expect(longs).toHaveLength(16); // + --critique (#82) + --flow / --max-pages (#59) + --setup (#60) + --gaps (#61) + --into-project (#51)
+    expect(longs).toHaveLength(17); // + --critique (#82) + --flow / --max-pages (#59) + --setup (#60) + --gaps (#61) + --into-project (#51) + --goal (#63)
   });
 
   it("maps flags to runExploration the same way as before the refactor", async () => {
@@ -162,6 +163,17 @@ describe("explore parity (C1-02)", () => {
     runExploration.mockClear();
     await buildProgram().parseAsync(["node", "cairn", "explore", "--url", "https://app.test"]);
     expect(runExploration.mock.calls[0][0].fresh).toBeFalsy(); // default: dedupe against prior runs (unchanged)
+  });
+
+  it("--goal flows through to runExploration as goal (and is undefined when absent) (#63)", async () => {
+    await buildProgram().parseAsync([
+      "node", "cairn", "explore", "--url", "https://app.test", "--goal", "test the checkout flow",
+    ]);
+    expect(runExploration.mock.calls[0][0].goal).toBe("test the checkout flow");
+
+    runExploration.mockClear();
+    await buildProgram().parseAsync(["node", "cairn", "explore", "--url", "https://app.test"]);
+    expect(runExploration.mock.calls[0][0].goal).toBeUndefined(); // default: blind crawl (unchanged)
   });
 
   it("prints the same exploration / metrics / cost / summary structure", async () => {

--- a/tests/unit/design.test.ts
+++ b/tests/unit/design.test.ts
@@ -50,6 +50,26 @@ describe("designTestCases", () => {
     expect(captured).toContain("Sign In");
   });
 
+  it("goalText reaches the prompt; absent → no goal directive (#63)", async () => {
+    let captured = "";
+    const fakeInvoke: StructuredInvoke = async (schema, messages) => {
+      captured = JSON.stringify(messages);
+      return schema.parse({ testCases: [] });
+    };
+    await designTestCases(
+      { study, pageSemantics: "x", goalText: 'GOAL FOR THIS RUN — bias toward this user goal: "checkout flow".' },
+      { invoke: fakeInvoke, prompts: new PromptRegistry() },
+    );
+    expect(captured).toContain("checkout flow");
+
+    captured = "";
+    await designTestCases(
+      { study, pageSemantics: "x" },
+      { invoke: fakeInvoke, prompts: new PromptRegistry() },
+    );
+    expect(captured).not.toContain("GOAL FOR THIS RUN"); // back-compat: no goal → no directive
+  });
+
   it("empty result → []", async () => {
     const fakeInvoke: StructuredInvoke = async (schema) => schema.parse({ testCases: [] });
     const cases = await designTestCases(


### PR DESCRIPTION
Closes #63

## What

`cairn explore --goal "test the checkout flow"` — accept a natural-language goal and bias the run toward it instead of a blind crawl (MEM-01, epic #48).

The goal threads through the existing per-run input path (the same way `--checklist` does — nothing hardcoded) into a new `{{goal}}` prompt slot, biasing both halves the DoD names:

- **observation** — `analyzePage` / `identify-elements` prioritizes goal-relevant elements when picking `primaryRefs`.
- **planning / cases** — `designTestCases` / `qa-testcase-from-ui` leads with goal-relevant cases.

A single `formatGoal()` directive (in `src/checklist/index.ts`, next to `formatChecklist`/`styleDirective`) is reused by both prompts. The directive tells the model to lead with the goal but **not** ignore a critical issue it notices elsewhere, so an out-of-scope goal degrades gracefully.

## Back-compat

Without `--goal`, `formatGoal("")` → `""` → the `{{goal}}` slot renders empty and the prompts are byte-identical to before — the blind crawl is unchanged. Blank/whitespace goals are treated as no goal.

## How verified (against DoD)

DoD: *`cairn explore --goal "..."` biases observation/planning toward the stated goal and produces goal-relevant cases.*

- `lint` + `build` (tsc) clean.
- `vitest run tests/unit` — **569 passed, 1 skipped**. New tests:
  - `formatGoal`: blank/undefined → `""`; non-blank → trimmed directive carrying the goal.
  - `designTestCases` / `analyzePage`: `goalText` reaches the prompt; absent → no goal directive (back-compat).
  - CLI: `--goal` maps to `runExploration({ goal })`; undefined when absent; flag-surface parity (count 16→17) + `explore --help` snapshot.
- `npm run smoke:pack` — 8/8 checks pass (package builds + installs + CLI runs).
- Pre-existing integration failures (`playwright-lib`, `explore-hardening`) are environmental only — no Chromium installed in this env; they fail identically on clean `main` and are untouched by this change.

## Scope / follow-ups

- **Explore only** (per the issue). `cairn design` is intentionally not touched.
- `--flow` multi-page **journeys** (`designJourneys`) are **not** goal-biased here — left as a follow-up to avoid widening the diff into L2-01's shared flow/plan files.
- Goal is not yet biasing the opt-in `--critique` / `--gaps` passes (technique-driven, goal-agnostic by design).