### PR TITLE
feat: scope-aware knowledge injection — web | api | all (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Scope-aware knowledge injection — `scope: web | api | all` (#92, BORROW-03).** `knowledge/*.md`
+  files now declare a scope and are keyed by `url || path || endpoint`. Directory convention:
+  `knowledge/` = web (keyed by `url:`), `knowledge/api/` = api (keyed by `path:`/`endpoint:`), and an
+  explicit `scope:` front-matter overrides the directory default. A web run injects web+all, an api run
+  injects api+all, and a shared `scope: all` file (e.g. credentials) is available to both. Plumbing
+  ahead of the API surface (#22) — improves web runs today. Back-compatible: an existing base-dir
+  `url:` file with no `scope:` stays web-scoped and behaves exactly as before.
+
 - **Goal-directed exploration — `cairn explore --goal "..."` (#63, MEM-01).** Accept a natural-language
   goal (e.g. `"test the checkout flow"`) and bias the run toward it instead of a blind crawl: the goal
   threads into both observation (`identify-elements` prioritizes goal-relevant elements) and planning

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -220,7 +220,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
   // Checklist (Sprint 4): a human narrows down WHAT to test → steers the design + measures coverage.
   const checklistItems = input.checklistText ? ingestChecklist(input.checklistText) : [];
   const checklistFormatted = formatChecklist(checklistItems);
-  const knowledgeText = await loadKnowledge(resolve(input.knowledgeDir ?? "knowledge"), input.url);
+  const knowledgeText = await loadKnowledge(resolve(input.knowledgeDir ?? "knowledge"), { url: input.url });
   // `--fresh` skips this disk read entirely → no "previously STABLE cases" dedup block, so the run
   // generates a full set (clean A/B comparison) instead of only the delta vs. past runs of this URL.
   const experienceText = await experienceForUrl({
@@ -623,7 +623,7 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
   persistLog = () => void runWriter.writeLog(logLines.join("\n")).catch(() => undefined);
 
   const checklistItems = input.checklistText ? ingestChecklist(input.checklistText) : [];
-  const knowledgeText = await loadKnowledge(resolve(input.knowledgeDir ?? "knowledge"), input.url);
+  const knowledgeText = await loadKnowledge(resolve(input.knowledgeDir ?? "knowledge"), { url: input.url });
   // `--fresh` skips this disk read entirely → no "previously STABLE cases" dedup block, so the run
   // generates a full set (clean A/B comparison) instead of only the delta vs. past runs of this URL.
   const experienceText = await experienceForUrl({

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -1,38 +1,89 @@
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 
-/** url pattern from frontmatter (the `url: ...` line), if present. */
-function frontmatterUrl(raw: string): string | undefined {
+/** A knowledge file's scope (BORROW-03, #92): which run kind it applies to. */
+export type KnowledgeScope = "web" | "api" | "all";
+
+/** Run scope — a web run injects web+all, an api run injects api+all. */
+export type RunScope = "web" | "api";
+
+/** What a knowledge run is looking for: its kind + the target it matches file keys against. */
+export interface KnowledgeQuery {
+  /** Run scope. Default "web" (back-compat — existing `url:` files stay web-scoped). */
+  scope?: RunScope;
+  /** Web run target (page URL) — matched against a file's url/path/endpoint key. */
+  url?: string;
+  /** API run target (endpoint/path) — matched the same way for api-scoped files. #22 wires this. */
+  endpoint?: string;
+}
+
+/** Parsed front-matter we care about: an explicit scope + the match key (`url || path || endpoint`). */
+interface Frontmatter {
+  scope?: KnowledgeScope;
+  /** First present of `url:` / `path:` / `endpoint:` — the pattern matched against the run target. */
+  pattern?: string;
+}
+
+function parseFrontmatter(raw: string): Frontmatter {
   const fm = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!fm?.[1]) return undefined;
-  const line = fm[1].split(/\r?\n/).find((l) => /^url:/.test(l.trim()));
-  return line ? line.replace(/^\s*url:\s*/, "").trim() : undefined;
+  if (!fm?.[1]) return {};
+  const lines = fm[1].split(/\r?\n/).map((l) => l.trim());
+  const value = (key: string): string | undefined => {
+    const line = lines.find((l) => new RegExp(`^${key}:`).test(l));
+    return line ? line.replace(new RegExp(`^${key}:\\s*`), "").trim() : undefined;
+  };
+  const rawScope = value("scope")?.toLowerCase();
+  // Only a recognized value counts; an empty/unknown scope falls back to the directory default.
+  const scope = rawScope === "web" || rawScope === "api" || rawScope === "all" ? rawScope : undefined;
+  // Key precedence: url || path || endpoint (a single file declares one of them).
+  const pattern = value("url") ?? value("path") ?? value("endpoint");
+  return { scope, pattern };
 }
 
 function stripFrontmatter(raw: string): string {
   return raw.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "").trim();
 }
 
-/**
- * Load domain knowledge (.md with credentials/validation rules/notes), URL-matched (idea from explorbot).
- * A file without `url:` is global (always applied); with `url:` only when the pattern is contained in the page URL.
- * Injected into the design prompt → the bot knows facts not visible in the snapshot (reduces the oracle gap).
- */
-export async function loadKnowledge(dir: string, url: string): Promise<string> {
-  let files: string[] = [];
+/** List `*.md` under `dir` (non-recursive); missing dir → []. */
+async function mdFiles(dir: string): Promise<string[]> {
   try {
-    files = (await readdir(dir)).filter((f) => f.endsWith(".md"));
+    return (await readdir(dir)).filter((f) => f.endsWith(".md"));
   } catch {
-    return "";
+    return [];
   }
+}
+
+/**
+ * Load domain knowledge (.md with credentials/validation rules/notes), scope- and key-matched
+ * (idea from explorbot's `KnowledgeTracker`, #92). Directory convention: `dir/` = web (keyed by
+ * `url:`), `dir/api/` = api (keyed by `path:`/`endpoint:`); an explicit `scope:` front-matter
+ * (web | api | all) overrides the directory default. `scope: all` (e.g. shared credentials) is
+ * available to BOTH web and api runs.
+ *
+ * A file is injected when its scope matches the run (`run scope` or `all`) AND its key pattern is
+ * contained in the run target (web → url, api → endpoint); a file with no key is global within its
+ * scope. Back-compat: a base-dir file without `scope:` is web — existing `url:` files behave exactly
+ * as before. Injected into the design prompt → the bot knows facts not visible in the snapshot.
+ */
+export async function loadKnowledge(dir: string, query: KnowledgeQuery = {}): Promise<string> {
+  const runScope: RunScope = query.scope ?? "web";
+  const target = (runScope === "api" ? query.endpoint : query.url) ?? "";
+
+  // Candidates from the base dir (default web) and the api subdir (default api); scope: front-matter overrides.
+  const candidates: { dir: string; file: string; dirDefault: KnowledgeScope }[] = [
+    ...(await mdFiles(dir)).map((file) => ({ dir, file, dirDefault: "web" as const })),
+    ...(await mdFiles(join(dir, "api"))).map((file) => ({ dir: join(dir, "api"), file, dirDefault: "api" as const })),
+  ];
+
   const parts: string[] = [];
-  for (const f of files) {
-    const raw = await readFile(join(dir, f), "utf8");
-    const pattern = frontmatterUrl(raw);
-    if (!pattern || url.includes(pattern)) {
-      const body = stripFrontmatter(raw);
-      if (body.length > 0) parts.push(body);
-    }
+  for (const c of candidates) {
+    const raw = await readFile(join(c.dir, c.file), "utf8");
+    const { scope, pattern } = parseFrontmatter(raw);
+    const fileScope = scope ?? c.dirDefault;
+    if (fileScope !== "all" && fileScope !== runScope) continue; // wrong scope for this run
+    if (pattern && !target.includes(pattern)) continue; // keyed file: target must contain the pattern
+    const body = stripFrontmatter(raw);
+    if (body.length > 0) parts.push(body);
   }
   return parts.join("\n\n");
 }

--- a/tests/unit/knowledge.test.ts
+++ b/tests/unit/knowledge.test.ts
@@ -13,7 +13,7 @@ describe("loadKnowledge", () => {
       await writeFile(join(dir, "gen.md"), "---\nurl: /generate\n---\nSubmit вимкнено доки email невалідний");
       await writeFile(join(dir, "other.md"), "---\nurl: /admin\n---\nЛише для адмінів");
 
-      const text = await loadKnowledge(dir, "https://app/generate");
+      const text = await loadKnowledge(dir, { url: "https://app/generate" });
       expect(text).toContain("Креденшели"); // global always
       expect(text).toContain("Submit вимкнено"); // /generate matches
       expect(text).not.toContain("Лише для адмінів"); // /admin does not match
@@ -23,6 +23,68 @@ describe("loadKnowledge", () => {
   });
 
   it("no directory → ''", async () => {
-    expect(await loadKnowledge(join(tmpdir(), "no-knowledge-xyz"), "https://x")).toBe("");
+    expect(await loadKnowledge(join(tmpdir(), "no-knowledge-xyz"), { url: "https://x" })).toBe("");
+  });
+
+  // BORROW-03 (#92): scope-aware injection — web | api | all.
+  describe("scope-aware injection (#92)", () => {
+    async function fixture(): Promise<string> {
+      const dir = await mkdtemp(join(tmpdir(), "qa-know-scope-"));
+      await mkdir(join(dir, "api"), { recursive: true });
+      // base dir → web by default; explicit scope: all for shared creds; api subdir → api by default.
+      await writeFile(join(dir, "web-page.md"), "---\nurl: /generate\n---\nWEB-ONLY note");
+      await writeFile(join(dir, "creds.md"), "---\nscope: all\n---\nSHARED creds admin@test/secret");
+      await writeFile(join(dir, "api", "users.md"), "---\nendpoint: /users\n---\nAPI-ONLY note");
+      return dir;
+    }
+
+    it("web run injects web+all, NOT api", async () => {
+      const dir = await fixture();
+      try {
+        const text = await loadKnowledge(dir, { scope: "web", url: "https://app/generate" });
+        expect(text).toContain("WEB-ONLY"); // web file matched
+        expect(text).toContain("SHARED creds"); // all available to web
+        expect(text).not.toContain("API-ONLY"); // api hidden from web
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("api run injects api+all, NOT web", async () => {
+      const dir = await fixture();
+      try {
+        const text = await loadKnowledge(dir, { scope: "api", endpoint: "https://app/api/users" });
+        expect(text).toContain("API-ONLY"); // api file matched by endpoint
+        expect(text).toContain("SHARED creds"); // all available to api
+        expect(text).not.toContain("WEB-ONLY"); // web hidden from api
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("a base-dir file without scope: stays web (back-compat default)", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "qa-know-bc-"));
+      try {
+        await writeFile(join(dir, "legacy.md"), "---\nurl: /generate\n---\nLEGACY note");
+        // visible to a web run…
+        expect(await loadKnowledge(dir, { url: "https://app/generate" })).toContain("LEGACY");
+        // …and NOT to an api run (it is web-scoped by default, not all).
+        expect(await loadKnowledge(dir, { scope: "api", endpoint: "/generate" })).not.toContain("LEGACY");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("an unknown/empty scope: value falls back to the directory default", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "qa-know-bad-"));
+      try {
+        await writeFile(join(dir, "weird.md"), "---\nscope: nonsense\n---\nWEIRD note");
+        // unknown scope → directory default (base = web)
+        expect(await loadKnowledge(dir, { scope: "web" })).toContain("WEIRD");
+        expect(await loadKnowledge(dir, { scope: "api" })).not.toContain("WEIRD");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
   });
 });


### PR DESCRIPTION
Closes #92

## What

Extends `knowledge/*.md` from URL-keyed to a **scope-aware** model (BORROW-03, borrowed from explorbot's `KnowledgeTracker`, adapted to Cairn's style).

- Files declare `scope: web | api | all` and are keyed by `url || path || endpoint`.
- **Directory convention:** `knowledge/` = web (keyed by `url:`), `knowledge/api/` = api (keyed by `path:`/`endpoint:`). An explicit `scope:` front-matter overrides the directory default.
- A **web** run injects `web + all`; an **api** run injects `api + all`; a shared `scope: all` file (e.g. credentials) is available to **both**.

`loadKnowledge(dir, query)` now takes a `{ scope, url, endpoint }` query (scope defaults to `"web"`) and scans the base dir plus the `api/` subdir, filtering each file by run scope and by key pattern (web matches against the URL, api against the endpoint; a keyless file is global within its scope).

## Back-compat

Both current callers (`explore`, `design`) pass `{ url: input.url }` → web scope. A base-dir file with no `scope:` defaults to **web**, so existing `url:` knowledge files behave exactly as before. Verified by the original test (unchanged assertions) plus a dedicated back-compat test.

## How verified (against DoD)

DoD: *files declare a scope; web runs inject web+all, api runs inject api+all; a shared `all` file is available to both.*

- `lint` + `build` (tsc) clean.
- `vitest run tests/unit` — **573 passed, 1 skipped**. New `loadKnowledge` tests:
  - web run → web + all, **not** api
  - api run → api + all, **not** web
  - `scope: all` (creds) → visible to both
  - base-dir file without `scope:` → stays web (back-compat)
  - unknown/empty `scope:` value → falls back to the directory default
- `npm run smoke:pack` — 8/8 checks pass.

## Scope / follow-ups

- **Plumbing only.** The function now accepts `scope: "api"` + an endpoint, but no CLI wires an api run yet — the real **api-run injection wiring lands with `cairn api` (#22)**.
- **Injection logging** (which scope / which files were injected) intentionally deferred to #22: both callers are web today, so a log line would be constant now; it becomes useful once scope actually varies.
- Did not touch the documentarian knowledge work (#93) — kept the diff to the parser + injection path.