### PR TITLE
feat: documentarian — cached reusable page-understanding artifact (#93)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ blob-report/
 *.log
 .DS_Store
 .cache/
+.cairn-cache/
 coverage/
 
 # IDE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Documentarian — cached, reusable page-understanding artifact (#93, BORROW-06).** A run now emits a
+  strict-schema **interaction map** (element → locator + container + candidate actions) as a first-class
+  artifact (`runs/<id>/page-understanding.json`) and caches it cross-run under `.cairn-cache/understanding`,
+  keyed by `url + page fingerprint` (a hash of the ARIA snapshot). A second run on the **same** page reuses
+  the cached understanding and **skips the ground (`analyzePage`) LLM call** → fewer observe/ground calls;
+  a changed page misses the cache and re-grounds (deliberate invalidation). The map is assembled
+  deterministically from existing observe/verify/probe outputs — no extra LLM call is introduced. `--fresh`
+  bypasses the cache. Cross-run/per-app semantic memory stays out of scope (that is MEM-02, #64).
+
 - **Scope-aware knowledge injection — `scope: web | api | all` (#92, BORROW-03).** `knowledge/*.md`
   files now declare a scope and are keyed by `url || path || endpoint`. Directory convention:
   `knowledge/` = web (keyed by `url:`), `knowledge/api/` = api (keyed by `path:`/`endpoint:`), and an

--- a/src/agent/graph.ts
+++ b/src/agent/graph.ts
@@ -11,6 +11,14 @@ import type { JourneyCase } from "../design/schema.js";
 import { generateSuite, type GeneratedSuite } from "../codegen/index.js";
 import { probeTransitions, type Transition } from "../probe/index.js";
 import { looksLikeLoginPage, expiredSessionMessage } from "../session/index.js";
+import {
+  fingerprintPage,
+  loadUnderstanding,
+  saveUnderstanding,
+  buildInteractionMap,
+  analysisFromMap,
+  type InteractionMap,
+} from "../documentarian/index.js";
 import { findConsentDismiss, describeObserveError } from "./observe-guard.js";
 import { runRepairLoop } from "./repair-loop.js";
 import type { ValidationReport } from "../validate/index.js";
@@ -65,6 +73,20 @@ export interface ExploreDeps {
    * suite label the final write uses, so the early and final writes produce identical files.
    */
   onTestCases?: (testCases: TestCase[], verified: VerifiedElement[], studyUrl: string) => void | Promise<void>;
+  /**
+   * #93: cross-run cache dir for the page-understanding artifact. When set, a run on a page whose
+   * fingerprint matches a cached map REUSES it and skips the ground (analyzePage) LLM call. Undefined
+   * → caching off (behavior unchanged). The dir is keyed internally by url + page fingerprint.
+   */
+  understandingCacheDir?: string;
+  /** #93: ignore a cached understanding for this run (forces a fresh ground call). Mirrors `--fresh`. */
+  fresh?: boolean;
+  /**
+   * #93: called with the freshly built interaction map (mirrors onStudy/onTestCases) so the caller can
+   * persist it as the run's first-class artifact (page-understanding.json). Best-effort: a throw here
+   * must not break the run.
+   */
+  onUnderstanding?: (map: InteractionMap) => void | Promise<void>;
   /** Codeless mode: stop after designTestCases (cases only, no codegen/validate). */
   codeless?: boolean;
   /**
@@ -137,14 +159,29 @@ export async function runExploreGraph(
   }
   deps.onProgress?.(`observe — done: ${study.elements.length} elements, screenshot taken`);
 
+  // ── documentarian: reuse cached page-understanding when the page is unchanged (#93) ──────────
+  // The fingerprint is the ARIA hash → an identical page reuses its cached map and SKIPS the ground
+  // (analyzePage) LLM call; a changed page misses and re-grounds (deliberate invalidation).
+  const fingerprint = fingerprintPage(study);
+  const cached =
+    deps.understandingCacheDir && !deps.fresh
+      ? await loadUnderstanding(deps.understandingCacheDir, study.url, fingerprint)
+      : undefined;
+
   // ── identifyElements ──────────────────────────────────────────────────────
-  deps.onProgress?.("identifyElements — page analysis (LLM)…");
-  const analysis = await analyzePage(study, {
-    invoke: deps.analyzeInvoke,
-    prompts: deps.prompts,
-    vision: deps.useVision,
-    goalText: deps.goalText,
-  });
+  let analysis: PageAnalysis;
+  if (cached) {
+    analysis = analysisFromMap(cached, new Set(study.elements.map((e) => e.ref)));
+    deps.onProgress?.("documentarian — cache HIT: reusing page understanding (skipped ground LLM call)");
+  } else {
+    deps.onProgress?.("identifyElements — page analysis (LLM)…");
+    analysis = await analyzePage(study, {
+      invoke: deps.analyzeInvoke,
+      prompts: deps.prompts,
+      vision: deps.useVision,
+      goalText: deps.goalText,
+    });
+  }
   // L1-05: a session was supplied but the first page looks like a login screen → the session
   // is likely expired. Fail fast with re-capture guidance BEFORE the expensive design/codegen
   // steps, instead of silently exploring the sign-in page.
@@ -216,6 +253,20 @@ export async function runExploreGraph(
   deps.onProgress?.("probeInteractions — act→observe of safe elements…");
   const transitions = await probeTransitions(deps.gateway, verified.filter((v) => v.verified));
   deps.onProgress?.(`probeInteractions — transitions observed: ${transitions.length}`);
+
+  // ── documentarian: build + cache + persist the reusable interaction map (#93) ─────────────────
+  // Deterministic assembly from this run's observe/ground/verify/probe outputs — no extra LLM call.
+  // Always refreshed (even on a cache hit) so a re-run keeps the artifact current.
+  const interactionMap = buildInteractionMap(study, analysis, verified, transitions, fingerprint);
+  if (deps.understandingCacheDir) await saveUnderstanding(deps.understandingCacheDir, interactionMap);
+  try {
+    await deps.onUnderstanding?.(interactionMap);
+  } catch {
+    // persisting the artifact is best-effort — never let it break the run.
+  }
+  deps.onProgress?.(
+    `documentarian — interaction map: ${interactionMap.elements.length} elements (${cached ? "reused" : "fresh"} understanding)`,
+  );
 
   // ── designTestCases ───────────────────────────────────────────────────────
   deps.onProgress?.("designTestCases — designing cases (LLM reasoning, may take ~a minute)…");

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -21,6 +21,7 @@ import { pilotReview, type PilotVerdict } from "../eval/pilot.js";
 import { collectPriorRuns, unionPassedTitles, experienceForUrl } from "../eval/collect.js";
 import { ingestChecklist, formatChecklist, formatGoal, coverageScore, styleDirective } from "../checklist/index.js";
 import { loadKnowledge } from "../knowledge/index.js";
+import type { InteractionMap } from "../documentarian/index.js";
 import { validateSuite, type ValidationReport } from "../validate/index.js";
 import { SessionStore } from "../session/index.js";
 import { resolveRunDir, defaultRunsBaseDir } from "../fs/run-dir.js";
@@ -56,6 +57,8 @@ export interface ExploreInput {
   sessionsDir?: string;
   /** Directory of domain knowledge (.md, URL-matched; default ./knowledge). */
   knowledgeDir?: string;
+  /** #93: cross-run cache dir for the page-understanding artifact (default ./.cairn-cache/understanding). */
+  understandingCacheDir?: string;
   /** Planning style: happy | negative | coverage | all (default all). */
   style?: string;
   /** #80: pre-resolved text for the prompt's {{style}} slot (a house-style pack). Wins over `style`. */
@@ -221,6 +224,11 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
   const checklistItems = input.checklistText ? ingestChecklist(input.checklistText) : [];
   const checklistFormatted = formatChecklist(checklistItems);
   const knowledgeText = await loadKnowledge(resolve(input.knowledgeDir ?? "knowledge"), { url: input.url });
+  // #93: cross-run page-understanding cache (keyed by url + page fingerprint) — a re-run on the same
+  // page reuses it and skips the ground LLM call. Persist the artifact into the run dir too (durability).
+  const understandingCacheDir = resolve(input.understandingCacheDir ?? ".cairn-cache/understanding");
+  const onUnderstanding = (map: InteractionMap): void =>
+    void runWriter.writeUnderstanding(map).catch(() => undefined);
   // `--fresh` skips this disk read entirely → no "previously STABLE cases" dedup block, so the run
   // generates a full set (clean A/B comparison) instead of only the delta vs. past runs of this URL.
   const experienceText = await experienceForUrl({
@@ -253,6 +261,9 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
     setupInvoke: input.setup ? router.invoke("worker", router.tierFor("worker", cfg.models.bulk)) : undefined,
     useVision: analyzeTier.supportsVision,
     goalText: formatGoal(input.goal),
+    understandingCacheDir,
+    fresh: input.fresh,
+    onUnderstanding,
     checklistText: checklistFormatted,
     knowledgeText,
     experienceText,
@@ -624,6 +635,11 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
 
   const checklistItems = input.checklistText ? ingestChecklist(input.checklistText) : [];
   const knowledgeText = await loadKnowledge(resolve(input.knowledgeDir ?? "knowledge"), { url: input.url });
+  // #93: cross-run page-understanding cache (keyed by url + page fingerprint) — a re-run on the same
+  // page reuses it and skips the ground LLM call. Persist the artifact into the run dir too (durability).
+  const understandingCacheDir = resolve(input.understandingCacheDir ?? ".cairn-cache/understanding");
+  const onUnderstanding = (map: InteractionMap): void =>
+    void runWriter.writeUnderstanding(map).catch(() => undefined);
   // `--fresh` skips this disk read entirely → no "previously STABLE cases" dedup block, so the run
   // generates a full set (clean A/B comparison) instead of only the delta vs. past runs of this URL.
   const experienceText = await experienceForUrl({
@@ -655,6 +671,9 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
     // #60: setup planning runs on the worker tier (CAIRN_ROLE_WORKER); built only when opted in.
     setupInvoke: input.setup ? router.invoke("worker", router.tierFor("worker", cfg.models.bulk)) : undefined,
     useVision: analyzeTier.supportsVision,
+    understandingCacheDir,
+    fresh: input.fresh,
+    onUnderstanding,
     checklistText: formatChecklist(checklistItems),
     knowledgeText,
     experienceText,

--- a/src/artifacts/index.ts
+++ b/src/artifacts/index.ts
@@ -48,6 +48,8 @@ export interface RunWriter {
   writeJourneySpecs(files: { path: string; content: string }[]): Promise<string[]>;
   /** #103: per-page crawl snapshots — each page's aria.yaml + screenshot.png under its own dir. */
   writeFlowSnapshots(pages: { dir: string; ariaYaml: string; screenshotB64: string }[]): Promise<void>;
+  /** #93: the run's reusable page-understanding artifact → page-understanding.json. */
+  writeUnderstanding(map: unknown): Promise<void>;
 }
 
 /** Local trail of each run: runs/<id>/ (study, tests, snapshots, report). */
@@ -138,6 +140,9 @@ export class ArtifactStore {
             await writeFile(join(pdir, "screenshot.png"), Buffer.from(p.screenshotB64, "base64"));
           }
         }
+      },
+      writeUnderstanding: async (map) => {
+        await writeFile(join(dir, "page-understanding.json"), JSON.stringify(map, null, 2), "utf8");
       },
     };
   }

--- a/src/documentarian/index.ts
+++ b/src/documentarian/index.ts
@@ -1,0 +1,150 @@
+/**
+ * BORROW-06 (#93) — Documentarian: a cached, reusable page-understanding artifact.
+ *
+ * Decouples "understand the page" from "generate tests": a run turns the live page into a strict-schema
+ * {@link InteractionMap} (element → locator + container + candidate actions) and caches it keyed by
+ * `url + page fingerprint`. A second run on the SAME page (identical ARIA → identical fingerprint) reuses
+ * the cached understanding and SKIPS the ground LLM call (`analyzePage`), so it makes fewer observe/ground
+ * LLM calls. The map is assembled DETERMINISTICALLY from what observe/verify/probe already produce — no
+ * extra LLM call is introduced (idea borrowed from explorbot's doc-collector; strict schema per #89).
+ *
+ * Cache invalidation is deliberate: the key embeds a fingerprint of the page's ARIA snapshot, so any
+ * structural change to the page misses the cache and re-grounds. Cross-run / per-app memory (semantic
+ * retrieval) is OUT of scope here — that is MEM-02 (#64).
+ */
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import type { PageStudy } from "../observe/index.js";
+import type { PageAnalysis } from "../analyze/index.js";
+import type { VerifiedElement } from "../browser/types.js";
+import type { Transition } from "../probe/index.js";
+import { locatorFor } from "../artifacts/report.js";
+
+/** Bump when the artifact shape changes → older cached files are treated as a miss. */
+export const UNDERSTANDING_SCHEMA_VERSION = 1;
+
+/** One interactive element, distilled for reuse: a stable locator + how it can be driven. */
+export const InteractionElementSchema = z.object({
+  ref: z.string(),
+  role: z.string(),
+  name: z.string().optional(),
+  /** Playwright locator expression (getByRole(...), `.first()` for repeated elements). */
+  locator: z.string(),
+  /** The view/tab this element lives behind, when known (multi-state pages). */
+  container: z.string().optional(),
+  /** Actions the element affords: click | fill | check | assertVisible. */
+  candidateActions: z.array(z.string()),
+});
+export type InteractionElement = z.infer<typeof InteractionElementSchema>;
+
+/** The cached page-understanding artifact: page semantics + the interaction map. */
+export const InteractionMapSchema = z.object({
+  schemaVersion: z.number(),
+  url: z.string(),
+  /** Hash of the page's ARIA snapshot — the cache key for deliberate invalidation on page change. */
+  fingerprint: z.string(),
+  pageSemantics: z.string(),
+  primaryRefs: z.array(z.string()),
+  viewSwitchers: z.array(z.string()),
+  elements: z.array(InteractionElementSchema),
+});
+export type InteractionMap = z.infer<typeof InteractionMapSchema>;
+
+/** Page fingerprint = hash of the ARIA snapshot. Same ARIA ⇒ same refs ⇒ cached understanding is valid. */
+export function fingerprintPage(study: PageStudy): string {
+  return createHash("sha256").update(study.ariaYaml).digest("hex").slice(0, 16);
+}
+
+/** Actions an element affords — from its role, plus any observed act→observe transition. */
+function candidateActionsFor(el: VerifiedElement, transitions: Transition[]): string[] {
+  const acts = new Set<string>();
+  const r = el.role.toLowerCase();
+  if (/button|link|tab|menuitem|option/.test(r)) acts.add("click");
+  if (/textbox|searchbox|combobox|spinbutton/.test(r)) acts.add("fill");
+  if (/checkbox|switch|radio/.test(r)) acts.add("check");
+  if (transitions.some((t) => t.ref === el.ref)) acts.add("click"); // a real observed transition
+  if (acts.size === 0) acts.add("assertVisible"); // non-interactive → static check only
+  return [...acts];
+}
+
+/**
+ * Assemble the interaction map deterministically from this run's observe/ground/verify/probe outputs.
+ * No LLM call: locators come from {@link locatorFor}, actions from role + observed transitions, and the
+ * container from the element's tab/view switcher when present.
+ */
+export function buildInteractionMap(
+  study: PageStudy,
+  analysis: PageAnalysis,
+  verified: VerifiedElement[],
+  transitions: Transition[],
+  fingerprint: string,
+): InteractionMap {
+  const elements: InteractionElement[] = verified
+    .filter((v) => v.count >= 1)
+    .map((v) => ({
+      ref: v.ref,
+      role: v.role,
+      name: v.name,
+      locator: `${locatorFor(v)}${v.count > 1 ? ".first()" : ""}`,
+      // ponytail: container = the tab/view the element sits behind (known deterministically). Richer
+      // landmark/region inference from the ARIA tree is a follow-up if reviewers want it.
+      container: v.viaSwitcher ? `${v.viaSwitcher.role} "${v.viaSwitcher.name ?? ""}"` : undefined,
+      candidateActions: candidateActionsFor(v, transitions),
+    }));
+  return {
+    schemaVersion: UNDERSTANDING_SCHEMA_VERSION,
+    url: study.url,
+    fingerprint,
+    pageSemantics: analysis.pageSemantics,
+    primaryRefs: analysis.primaryRefs,
+    viewSwitchers: analysis.viewSwitchers,
+    elements,
+  };
+}
+
+/** Re-derive a {@link PageAnalysis} from a cached map (grounded against the current refs). */
+export function analysisFromMap(map: InteractionMap, currentRefs: Set<string>): PageAnalysis {
+  return {
+    pageSemantics: map.pageSemantics,
+    primaryRefs: map.primaryRefs.filter((r) => currentRefs.has(r)),
+    viewSwitchers: map.viewSwitchers.filter((r) => currentRefs.has(r)),
+  };
+}
+
+/** Stable, filesystem-safe cache filename for a URL (the page is disambiguated by the fingerprint inside). */
+function cacheFile(cacheDir: string, url: string): string {
+  return join(cacheDir, `${createHash("sha256").update(url).digest("hex").slice(0, 16)}.json`);
+}
+
+/**
+ * Load a cached understanding for `url` IFF it matches the current page `fingerprint` and schema version.
+ * A miss (no file, stale fingerprint, old/corrupt shape) returns undefined → the caller re-grounds.
+ */
+export async function loadUnderstanding(
+  cacheDir: string,
+  url: string,
+  fingerprint: string,
+): Promise<InteractionMap | undefined> {
+  try {
+    const parsed = InteractionMapSchema.safeParse(JSON.parse(await readFile(cacheFile(cacheDir, url), "utf8")));
+    if (!parsed.success) return undefined; // old/corrupt shape → miss
+    const map = parsed.data;
+    if (map.schemaVersion !== UNDERSTANDING_SCHEMA_VERSION) return undefined;
+    if (map.url !== url || map.fingerprint !== fingerprint) return undefined; // page changed → invalidate
+    return map;
+  } catch {
+    return undefined; // no cache yet → miss
+  }
+}
+
+/** Persist the understanding to the cross-run cache. Best-effort: a write failure never breaks a run. */
+export async function saveUnderstanding(cacheDir: string, map: InteractionMap): Promise<void> {
+  try {
+    await mkdir(cacheDir, { recursive: true });
+    await writeFile(cacheFile(cacheDir, map.url), JSON.stringify(map, null, 2), "utf8");
+  } catch {
+    // cache write is best-effort
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export type { BudgetReport, RunSummaryInput } from "./agent/summary.js";
 // Domain types (output contracts).
 export type { TestCase, DesignedCase } from "./design/index.js";
 export type { PageStudy } from "./observe/index.js";
+export type { InteractionMap, InteractionElement } from "./documentarian/index.js";
 export type { GeneratedSuite } from "./codegen/index.js";
 export type { Score } from "./eval/scorers.js";
 export type { PilotVerdict } from "./eval/pilot.js";

--- a/tests/unit/documentarian.test.ts
+++ b/tests/unit/documentarian.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  fingerprintPage,
+  buildInteractionMap,
+  analysisFromMap,
+  loadUnderstanding,
+  saveUnderstanding,
+  InteractionMapSchema,
+  UNDERSTANDING_SCHEMA_VERSION,
+} from "../../src/documentarian/index.js";
+import type { PageStudy } from "../../src/observe/index.js";
+import type { PageAnalysis } from "../../src/analyze/index.js";
+import type { VerifiedElement } from "../../src/browser/types.js";
+
+const study: PageStudy = {
+  url: "https://app/generate",
+  screenshotB64: "",
+  ariaYaml: '- button "Go"\n- textbox "Email"',
+  capturedBy: "lib",
+  elements: [
+    { ref: "e1", role: "button", name: "Go", interactive: true, rank: 3 },
+    { ref: "e2", role: "textbox", name: "Email", interactive: true, rank: 3 },
+  ],
+};
+const analysis: PageAnalysis = { pageSemantics: "Generate page", primaryRefs: ["e1"], viewSwitchers: [] };
+const verified: VerifiedElement[] = [
+  { ref: "e1", role: "button", name: "Go", interactive: true, rank: 3, count: 1, verified: true },
+  { ref: "e2", role: "textbox", name: "Email", interactive: true, rank: 3, count: 1, verified: true },
+];
+
+describe("documentarian — interaction map (#93)", () => {
+  it("builds a strict-schema map: locators + role-derived candidate actions", () => {
+    const fp = fingerprintPage(study);
+    const map = buildInteractionMap(study, analysis, verified, [], fp);
+    expect(InteractionMapSchema.safeParse(map).success).toBe(true);
+    expect(map.schemaVersion).toBe(UNDERSTANDING_SCHEMA_VERSION);
+    expect(map.fingerprint).toBe(fp);
+    const go = map.elements.find((e) => e.ref === "e1");
+    const email = map.elements.find((e) => e.ref === "e2");
+    expect(go?.locator).toContain("getByRole('button'");
+    expect(go?.candidateActions).toContain("click");
+    expect(email?.candidateActions).toContain("fill");
+  });
+
+  it("fingerprint changes when the page (ARIA) changes — deliberate invalidation", () => {
+    const fp1 = fingerprintPage(study);
+    const fp2 = fingerprintPage({ ...study, ariaYaml: '- button "Different"' });
+    expect(fp1).not.toBe(fp2);
+  });
+
+  it("analysisFromMap re-grounds primaryRefs against the current refs", () => {
+    const map = buildInteractionMap(study, { ...analysis, primaryRefs: ["e1", "eGONE"] }, verified, [], "fp");
+    const back = analysisFromMap(map, new Set(["e1"])); // eGONE no longer present
+    expect(back.primaryRefs).toEqual(["e1"]);
+    expect(back.pageSemantics).toBe("Generate page");
+  });
+});
+
+describe("documentarian — cache load/save (#93)", () => {
+  it("round-trips, hits on matching fingerprint, misses on a changed page", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "qa-doc-"));
+    try {
+      const fp = fingerprintPage(study);
+      const map = buildInteractionMap(study, analysis, verified, [], fp);
+      await saveUnderstanding(dir, map);
+
+      // hit: same url + same fingerprint
+      const hit = await loadUnderstanding(dir, study.url, fp);
+      expect(hit?.pageSemantics).toBe("Generate page");
+
+      // miss: page changed → fingerprint differs
+      expect(await loadUnderstanding(dir, study.url, "deadbeef")).toBeUndefined();
+      // miss: different url
+      expect(await loadUnderstanding(dir, "https://app/other", fp)).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("missing cache dir → undefined (no throw)", async () => {
+    expect(await loadUnderstanding(join(tmpdir(), "no-cache-xyz"), "https://x", "fp")).toBeUndefined();
+  });
+
+  it("an old schemaVersion on disk is treated as a miss", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "qa-doc-ver-"));
+    try {
+      const fp = fingerprintPage(study);
+      const stale = { ...buildInteractionMap(study, analysis, verified, [], fp), schemaVersion: 0 };
+      await saveUnderstanding(dir, stale);
+      expect(await loadUnderstanding(dir, study.url, fp)).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/graph.test.ts
+++ b/tests/unit/graph.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { runExploreGraph } from "../../src/agent/graph.js";
+import { InteractionMapSchema } from "../../src/documentarian/index.js";
 import { PromptRegistry } from "../../src/prompts/index.js";
 import type { BrowserGateway } from "../../src/browser/index.js";
 import type { StructuredInvoke } from "../../src/llm/structured.js";
@@ -148,6 +152,77 @@ describe("runExploreGraph (full pipeline + repair, fake deps)", () => {
     const out = await runExploreGraph({ ...baseDeps, validate, maxRepair: 1 }, { url: "http://x", runId: "r1" });
     expect(out.bestValidation?.greenRatio).toBe(0.5); // keeps 0.5, does not drop to 0
     expect(out.attempts).toBe(1); // repair ran, but the best result was preserved
+  });
+});
+
+describe("documentarian cache reuse (#93)", () => {
+  const countingAnalyze = (counter: { n: number }): StructuredInvoke => async (schema) => {
+    counter.n += 1;
+    return schema.parse({ pageSemantics: "Сторінка", primaryRefs: ["e1"] });
+  };
+
+  it("run 1 emits a valid-schema understanding artifact; run 2 on the same page reuses it (fewer ground calls)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "qa-graph-doc-"));
+    try {
+      const c = { n: 0 };
+      let emitted: unknown;
+      const deps = {
+        ...baseDeps,
+        analyzeInvoke: countingAnalyze(c),
+        understandingCacheDir: dir,
+        onUnderstanding: (m: unknown) => {
+          emitted = m;
+        },
+        validate: async () => green,
+        maxRepair: 0,
+      };
+      await runExploreGraph(deps, { url: "http://x", runId: "r1" });
+      expect(c.n).toBe(1); // cold cache → grounded once
+      expect(InteractionMapSchema.safeParse(emitted).success).toBe(true); // DoD (a): valid artifact emitted
+
+      await runExploreGraph(deps, { url: "http://x", runId: "r2" });
+      expect(c.n).toBe(1); // DoD (b): same page → cache HIT, NO extra ground LLM call
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("a changed page (different ARIA) invalidates the cache → grounds again", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "qa-graph-doc2-"));
+    try {
+      const c = { n: 0 };
+      const gwChanged: BrowserGateway = {
+        ...fakeGateway,
+        observe: async () => ({ url: "http://x", screenshotB64: "", ariaSnapshot: '- button "Changed"', capturedBy: "lib" }),
+      };
+      const base = { ...baseDeps, analyzeInvoke: countingAnalyze(c), understandingCacheDir: dir, validate: async () => green, maxRepair: 0 };
+      await runExploreGraph(base, { url: "http://x", runId: "r1" });
+      await runExploreGraph({ ...base, gateway: gwChanged }, { url: "http://x", runId: "r2" });
+      expect(c.n).toBe(2); // DoD (c): page changed → re-grounded
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fresh:true bypasses a present cache → grounds anyway", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "qa-graph-doc3-"));
+    try {
+      const c = { n: 0 };
+      const base = { ...baseDeps, analyzeInvoke: countingAnalyze(c), understandingCacheDir: dir, validate: async () => green, maxRepair: 0 };
+      await runExploreGraph(base, { url: "http://x", runId: "r1" });
+      await runExploreGraph({ ...base, fresh: true }, { url: "http://x", runId: "r2" });
+      expect(c.n).toBe(2); // fresh ignored the hit
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("no cache dir → documentarian is off, behavior unchanged (grounds every run)", async () => {
+    const c = { n: 0 };
+    const base = { ...baseDeps, analyzeInvoke: countingAnalyze(c), validate: async () => green, maxRepair: 0 };
+    await runExploreGraph(base, { url: "http://x", runId: "r1" });
+    await runExploreGraph(base, { url: "http://x", runId: "r2" });
+    expect(c.n).toBe(2); // no caching → back-compat
   });
 });
 


### PR DESCRIPTION
Closes #93

## What

A dedicated **documentarian** step that decouples "understand the page" from "generate tests": a run turns the live page into a strict-schema **interaction map** (`element → locator + container + candidate actions`), emits it as a first-class artifact, and **caches it cross-run** so a re-run on the same page reuses the understanding and makes fewer LLM calls. (Borrowed from explorbot's doc-collector; strict schema per #89, adapted to Cairn's style.)

- **Artifact:** `runs/<id>/page-understanding.json` (per-run, durable) + cross-run cache under `.cairn-cache/understanding`.
- **Cache key:** `url + page fingerprint`, where the fingerprint is a hash of the ARIA snapshot. Same page ⇒ same fingerprint ⇒ cached map is valid (identical ARIA ⇒ identical refs).
- **Reuse:** on a cache hit the run reuses the cached page-understanding and **skips the ground (`analyzePage`) LLM call** → fewer observe/ground calls.
- **Invalidation is deliberate:** a changed page ⇒ different fingerprint ⇒ cache miss ⇒ re-ground. `--fresh` bypasses the cache.
- **No new LLM call:** the map is assembled **deterministically** from existing observe/verify/probe outputs (`locatorFor`, role-derived actions, observed transitions). First-run LLM cost is unchanged; the win is on reuse.

Wiring: new `src/documentarian/` module; `ExploreDeps` gains `understandingCacheDir` / `fresh` / `onUnderstanding`; graph reuses-or-grounds after observe and builds+caches the map after probe; both `runExploration` and `runDesign` pass a default cache dir (overridable via `ExploreInput.understandingCacheDir`). `RunWriter.writeUnderstanding` persists the per-run artifact. `InteractionMap`/`InteractionElement` exported from the public API.

## How verified (against DoD)

DoD: *a run emits a reusable page-understanding artifact; a second run on the same page reuses it and shows fewer observe/ground LLM calls.*

- `lint` + `build` (tsc) clean.
- `vitest run tests/unit` — **583 passed, 1 skipped**. New tests:
  - **documentarian unit:** strict-schema map build (locators + role-derived candidate actions); fingerprint changes on ARIA change; `analysisFromMap` re-grounds refs; cache round-trip (hit on matching fingerprint, miss on changed page / different url / missing dir / stale schemaVersion).
  - **graph reuse (the DoD):** run 1 emits a valid-schema artifact and grounds once; run 2 on the same page is a **cache hit with no extra ground call**; a changed page re-grounds; `--fresh` bypasses; **no cache dir → off (back-compat, grounds every run)**.
- `npm run smoke:pack` — 8/8 checks pass.
- Pre-existing integration failures (real-browser, no Chromium installed) are environmental and unchanged by this PR.

## Scope / follow-ups

- **Cross-run / per-app semantic memory (retrieval) is intentionally NOT here** — that is MEM-02 (#64). This PR is local, deterministic caching only.
- **Fingerprint = ARIA hash** (pragmatic): a page whose ARIA is identical but whose *vision-only* semantics changed could serve slightly stale `pageSemantics` on reuse — `--fresh` is the escape hatch; a richer fingerprint is a possible follow-up.
- **`container`** is populated from the element's tab/view switcher when known; richer ARIA landmark/region inference is a follow-up (marked with a `ponytail:` comment).
- Caching is **on by default** for `explore`/`design`; undefined `understandingCacheDir` turns it off (used by the back-compat test).