### PR TITLE
chore: add Dependabot config (npm + GitHub Actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependabot — automated dependency-update PRs (https://docs.github.com/code-security/dependabot).
+# Tracks npm deps and the GitHub Actions used by CI + the composite action. Minor/patch bumps are
+# grouped into one PR per ecosystem to keep the noise down; majors come as their own PRs to review.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # CI / publish workflows (.github/workflows/*.yml).
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # The reusable composite action (action/action.yml) and the actions it pins.
+  - package-ecosystem: github-actions
+    directory: "/action"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` so dependency updates are tracked automatically (per the request to keep an eye on the dependency situation).

Three update streams, all **weekly**:
- **npm** (`/`) — runtime + dev deps from `package-lock.json`.
- **github-actions** (`/`) — actions pinned in `.github/workflows/{ci,publish}.yml`.
- **github-actions** (`/action`) — actions pinned in the reusable composite action (`action/action.yml`).

Minor/patch bumps are **grouped** into one PR per ecosystem to reduce noise; majors arrive as their own PRs for deliberate review. The default `dependencies` label (auto-created by Dependabot) is applied; no custom labels are required.

## Notes

- Config-only; no code, no workflow logic, no secrets/permissions touched. Dependabot is enabled at the repo level by GitHub once this file is on the default branch.
- Separate from the feature PRs (#114/#115/#116) by design — one concern per PR.