### PR TITLE
feat: per-scenario screencast recording for the review gate (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-scenario screencast recording — `--screencast` (#94, BORROW-05).** Validation can now record a
+  `.webm` per scenario (Playwright's built-in video) into `runs/<id>/screencasts/`, with a
+  `screencasts.json` sidecar mapping each scenario's **step chapters** (step title → timecode) — a
+  review-gate affordance so a human can *watch* what the agent did before approving. Opt-in
+  (`cairn explore --screencast` · `cairn automate --validate --screencast`); off by default, so existing
+  runs are unchanged. The `.webm` paths + chapter counts are linked from the run summary and the TUI result
+  screen. Recording is best-effort: a recorder/IO failure logs nothing fatal and never sinks the run.
+
 - **Documentarian — cached, reusable page-understanding artifact (#93, BORROW-06).** A run now emits a
   strict-schema **interaction map** (element → locator + container + candidate actions) as a first-class
   artifact (`runs/<id>/page-understanding.json`) and caches it cross-run under `.cairn-cache/understanding`,

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ cairn explore --url https://app.example.com/page --session myapp --checklist pla
 `--style <pack>` to restyle cases ([Prompts & styles](docs/prompts-and-styles.md)), or `--critique` to
 prune weak cases and top up technique gaps. (Git Bash: quote `--run 'runs/<id>'` or use the bare id.)
 
+Add `--screencast` (to `explore`, or `automate --validate`) to record a **`.webm` per scenario** during
+validation into `runs/<id>/screencasts/`, with a `screencasts.json` sidecar mapping each scenario's step
+chapters (step → timecode). It's a review-gate affordance — watch what the agent did before approving a
+case. Off by default; the recorded `.webm` paths are linked from the run summary and the TUI result screen.
+
 ## Interactive TUI
 
 Run `cairn` with **no arguments** in a terminal for a guided UI (launcher → form → live dashboard →
@@ -95,9 +100,9 @@ result summary → past-run browser). Ink/React are optional deps — see **[doc
 | `cairn session capture --url <loginUrl> --name <s>` | Capture a login session → `.auth/` (`cairn login` is a shorthand; `session ls` / `rm`) |
 | `cairn observe --url <u> [--session <s>]` | ARIA snapshot + interactive elements + screenshot |
 | `cairn design --url <u> --session <s> [--checklist <f>] [--style <s>] [--fresh] [--critique]` | Test cases only (ATC/MTC `.md` + selectors), no code |
-| `cairn automate --run <dir> [--validate --session <s>]` | `@playwright/test` from `ATC-*` cases |
+| `cairn automate --run <dir> [--validate --session <s>] [--screencast]` | `@playwright/test` from `ATC-*` cases |
 | `cairn promote --run <dir> --cases <ids> [--session <s>]` | Promote manual MTC case(s) to ATC (.md only; then `automate`) |
-| `cairn explore --url <u> --session <s> [--checklist <f>] [--fresh] [--critique]` | Full pipeline (cases → code → validate → repair → Pilot) |
+| `cairn explore --url <u> --session <s> [--checklist <f>] [--fresh] [--critique] [--screencast]` | Full pipeline (cases → code → validate → repair → Pilot) |
 | `cairn experiment --dataset <d> --candidate name=file` | Compare prompt versions on a dataset |
 
 > `lex-bot <command>` still runs every command above (deprecated alias — prints a notice, then runs `cairn`).

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -85,6 +85,8 @@ export interface ExploreInput {
   intoProject?: boolean;
   /** #51: explicit project dir for --into-project; when omitted, detection searches from cwd upward. */
   projectDir?: string;
+  /** #94 (BORROW-05): record a `.webm` per scenario during validation (review-gate affordance). Default off. */
+  screencast?: boolean;
 }
 
 export interface ExploreResult {
@@ -270,7 +272,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
     styleText,
     languageText,
     runWriter,
-    validate: (runDir: string) => validateSuite(runDir, { storageStatePath: sessionPath, channel: cfg.browser.channel, workers: cfg.playwrightWorkers }),
+    validate: (runDir: string) => validateSuite(runDir, { storageStatePath: sessionPath, channel: cfg.browser.channel, workers: cfg.playwrightWorkers, screencast: input.screencast }),
     maxRepair: cfg.maxRepair,
     onProgress,
     // #38: persist study + snapshots the moment observe succeeds, so a mid-run kill still leaves
@@ -887,6 +889,8 @@ export async function runAutomate(input: {
   intoProject?: boolean;
   /** #51: explicit project dir for --into-project (detection searches from cwd upward when omitted). */
   projectDir?: string;
+  /** #94 (BORROW-05): record a `.webm` per scenario during --validate (review-gate affordance). Default off. */
+  screencast?: boolean;
   onProgress?: (event: string) => void;
 }): Promise<AutomateResult> {
   const cfg = input.config;
@@ -950,7 +954,7 @@ export async function runAutomate(input: {
         await runWriter.writeSuite(s);
         return s;
       },
-      validate: () => validateSuite(runWriter.dir, { storageStatePath: sessionPath, channel: cfg.browser.channel, workers: cfg.playwrightWorkers }),
+      validate: () => validateSuite(runWriter.dir, { storageStatePath: sessionPath, channel: cfg.browser.channel, workers: cfg.playwrightWorkers, screencast: input.screencast }),
       maxRepair: cfg.maxRepair,
       onProgress,
       lint: (s) => lintHint(lintSuite(s)), // #57: feed fragile-pattern findings into repair

--- a/src/agent/summary.ts
+++ b/src/agent/summary.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import type { ValidationReport } from "../validate/index.js";
 import type { CostReport } from "../llm/cost.js";
 
@@ -50,6 +51,11 @@ export function renderRunSummary(s: RunSummaryInput): string[] {
     const flaky = r.filter((x) => x.status === "flaky").length;
     const green = Math.round(s.validation.greenRatio * 100);
     lines.push(`  Tests:     ${passed} passed · ${failed} failed · ${flaky} flaky (${green}% green)`);
+    // #94 (BORROW-05): point the reviewer at the per-scenario screencasts (.webm + step chapters).
+    const casts = s.validation.screencasts;
+    if (casts && casts.length > 0) {
+      lines.push(`  Screencasts: ${casts.length} .webm recorded → ${displayPath(join(s.runDir, "screencasts"))}/`);
+    }
   }
   if (typeof s.testCaseCount === "number") lines.push(`  Test cases: ${s.testCaseCount}`);
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -120,6 +120,7 @@ export function buildProgram(): Command {
     .option("--setup", "for journeys (--flow): plan + emit starting-state setup (fixture / API seed; manual fallback)")
     .option("--gaps", "suggest cases for the top untested surface (the coverage view is always emitted)")
     .option("--into-project [dir]", "write specs into an existing Playwright project's testDir (detect playwright.config.*; respects testDir/naming) instead of runs/<id>/tests")
+    .option("--screencast", "record a .webm per scenario (with step chapters) during validation → runs/<id>/screencasts/ for the review gate")
     .action(async (opts: Record<string, unknown>) => {
       await runModality("explore", opts);
     });
@@ -310,8 +311,9 @@ export function buildProgram(): Command {
     .option("--channel <channel>", "system browser channel, e.g. chrome — validate on your installed Chrome (no bundled-Chromium download)")
     .option("--routing <preset>", "role-routing preset: fast (Groq worker) | volume (OpenRouter worker) | volume-fast (Anthropic codegen, cheap judge on OpenRouter) (sets LLM_ROUTING)")
     .option("--into-project [dir]", "write specs into an existing Playwright project's testDir (detect playwright.config.*; respects testDir/naming) instead of runs/<id>/tests")
+    .option("--screencast", "with --validate: record a .webm per scenario (with step chapters) → runs/<id>/screencasts/ for the review gate")
     .action(
-      async (opts: { run: string; validate?: boolean; session?: string; sessionFile?: string; channel?: string; routing?: string; intoProject?: boolean | string }) => {
+      async (opts: { run: string; validate?: boolean; session?: string; sessionFile?: string; channel?: string; routing?: string; intoProject?: boolean | string; screencast?: boolean }) => {
         const config = resolveConfig({ routing: opts.routing, channel: opts.channel });
         process.stderr.write(`▸ Automating cases from ${displayPath(opts.run)}…\n`);
         const progress = makeCliProgress({
@@ -327,6 +329,7 @@ export function buildProgram(): Command {
           sessionFile: opts.sessionFile,
           intoProject: opts.intoProject !== undefined && opts.intoProject !== false,
           projectDir: typeof opts.intoProject === "string" ? opts.intoProject : undefined,
+          screencast: opts.screencast,
           onProgress: progress.event,
         }).finally(() => progress.stop());
         const dest = result.projectTestDir ? displayPath(result.projectTestDir) : `${displayPath(result.runDir)}/tests/`;

--- a/src/core/modalities/explore.ts
+++ b/src/core/modalities/explore.ts
@@ -34,6 +34,7 @@ interface ExploreFlags {
   setup?: boolean;
   gaps?: boolean;
   intoProject?: boolean | string;
+  screencast?: boolean;
 }
 
 export const exploreModality: Modality = {
@@ -72,6 +73,7 @@ export const exploreModality: Modality = {
       gaps: opts.gaps,
       intoProject: opts.intoProject !== undefined && opts.intoProject !== false,
       projectDir: typeof opts.intoProject === "string" ? opts.intoProject : undefined,
+      screencast: opts.screencast,
       onProgress: progress.event,
     }).finally(() => progress.stop());
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,6 @@ export type { InteractionMap, InteractionElement } from "./documentarian/index.j
 export type { GeneratedSuite } from "./codegen/index.js";
 export type { Score } from "./eval/scorers.js";
 export type { PilotVerdict } from "./eval/pilot.js";
-export type { ValidationReport } from "./validate/index.js";
+export type { ValidationReport, ScreencastEntry, ScreencastChapter } from "./validate/index.js";
 export type { ChecklistItem } from "./checklist/index.js";
 export type { ElementRef, VerifiedElement, StorageState, BackendKind } from "./browser/index.js";

--- a/src/tui/screens/summary-screen.tsx
+++ b/src/tui/screens/summary-screen.tsx
@@ -84,6 +84,17 @@ export function SummaryScreen({ command, result }: { command: Command; result: A
           <Text dimColor> · flaky: {validation.flakyCount}</Text>
         </Box>
       ) : null}
+      {validation?.screencasts?.length ? (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color="magenta">▶ Screencasts ({validation.screencasts.length}) — watch before approving:</Text>
+          {validation.screencasts.map((c) => (
+            <Text key={c.test} dimColor>
+              {"  "}
+              {c.test}: {c.video} ({c.chapters.length} chapters)
+            </Text>
+          ))}
+        </Box>
+      ) : null}
       {specs !== undefined ? (
         <Box marginTop={1}>
           <Text>{specs} spec file(s) generated</Text>

--- a/src/validate/index.ts
+++ b/src/validate/index.ts
@@ -1,7 +1,9 @@
-import { runSpecs, type RawTestResult } from "./runner.js";
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { runSpecs, type RawTestResult, type ScreencastEntry } from "./runner.js";
 
-export { runSpecs } from "./runner.js";
-export type { RawTestResult, TestStatus } from "./runner.js";
+export { runSpecs, screencastsFromJson, screencastsFromRunnerOutput } from "./runner.js";
+export type { RawTestResult, TestStatus, ScreencastEntry, ScreencastChapter } from "./runner.js";
 
 export interface TestResult {
   test: string;
@@ -15,6 +17,8 @@ export interface ValidationReport {
   /** Share of consistently green tests (flaky does NOT count as green). */
   greenRatio: number;
   flakyCount: number;
+  /** #94: per-scenario screencasts (.webm + step chapters), present only when recording was enabled. */
+  screencasts?: ScreencastEntry[];
 }
 
 /**
@@ -58,6 +62,8 @@ export interface ValidateOptions {
   channel?: string;
   /** Parallel Playwright workers (default 5; from cfg.playwrightWorkers / PLAYWRIGHT_WORKERS). */
   workers?: number;
+  /** #94 (BORROW-05): record a `.webm` per scenario for the review gate. Off by default. */
+  screencast?: boolean;
 }
 
 /**
@@ -69,9 +75,29 @@ export async function validateSuite(
   opts: ValidateOptions = {},
 ): Promise<ValidationReport> {
   const reruns = Math.max(1, opts.reruns ?? 2);
+  // #94: record under <runDir>/screencasts. Each rerun's run overwrites it (Playwright clears the output
+  // dir), so the surviving .webm files + sidecar match the LAST run — read back once after the loop.
+  const screencastDir = opts.screencast ? join(resolve(runDir), "screencasts") : undefined;
   const runs: RawTestResult[][] = [];
   for (let i = 0; i < reruns; i += 1) {
-    runs.push(await runSpecs(runDir, { storageStatePath: opts.storageStatePath, channel: opts.channel, workers: opts.workers }));
+    runs.push(
+      await runSpecs(runDir, {
+        storageStatePath: opts.storageStatePath,
+        channel: opts.channel,
+        workers: opts.workers,
+        screencastDir,
+      }),
+    );
   }
-  return classifyRuns(runs);
+  const report = classifyRuns(runs);
+  if (screencastDir) {
+    try {
+      report.screencasts = JSON.parse(
+        await readFile(join(screencastDir, "screencasts.json"), "utf8"),
+      ) as ScreencastEntry[];
+    } catch {
+      // no sidecar (recorder produced nothing) — leave screencasts undefined, don't fail validation
+    }
+  }
+  return report;
 }

--- a/src/validate/runner.ts
+++ b/src/validate/runner.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { createRequire } from "node:module";
 import { writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { isMissingBrowserError, missingBrowsersError } from "../browser/preflight.js";
 
 const execFileAsync = promisify(execFile);
@@ -20,22 +20,32 @@ export interface RawTestResult {
   error?: string;
 }
 
-export function configContent(runDir: string, storageStatePath?: string, channel?: string, workers = 5): string {
+export function configContent(
+  runDir: string,
+  storageStatePath?: string,
+  channel?: string,
+  workers = 5,
+  screencastDir?: string,
+): string {
   const launchOpts = `launchOptions: { args: ['--disable-blink-features=AutomationControlled'] }`;
   const parts = ["headless: true"];
   if (storageStatePath) parts.push(`storageState: ${JSON.stringify(storageStatePath)}`);
   // FIX B (0.3.3): when a channel is set, the runner drives the SYSTEM browser (chrome/msedge) —
   // no bundled Chromium needed, so cairn works inside projects that already have their own Playwright.
   if (channel) parts.push(`channel: ${JSON.stringify(channel)}`);
+  // #94 (BORROW-05): opt-in per-scenario screencast — Playwright's built-in video. One .webm per test,
+  // landing under <screencastDir> (the JSON reporter then carries the path + steps → chapter sidecar).
+  if (screencastDir) parts.push(`video: 'on'`);
   parts.push(launchOpts);
   const use = `{ ${parts.join(", ")} }`;
+  const outputDir = screencastDir ? `\n  outputDir: ${JSON.stringify(screencastDir)},` : "";
   return `const { defineConfig } = require(${JSON.stringify(PW_TEST)});
 module.exports = defineConfig({
   testDir: ${JSON.stringify(join(runDir, "tests"))},
   fullyParallel: true,
   workers: ${workers},
   retries: 0,
-  reporter: 'json',
+  reporter: 'json',${outputDir}
   use: ${use},
 });
 `;
@@ -48,12 +58,41 @@ export interface RunSpecsOptions {
   channel?: string;
   /** Parallel Playwright workers (default 5; from cfg.playwrightWorkers / PLAYWRIGHT_WORKERS). */
   workers?: number;
+  /**
+   * #94 (BORROW-05): when set, record a `.webm` per test into this dir (Playwright video) and write a
+   * step-chapter sidecar (`<dir>/screencasts.json`) for the review gate. Opt-in; off when undefined.
+   */
+  screencastDir?: string;
 }
 
+/** #94: one chapter marker — a scenario step title at its offset (ms) from the start of the `.webm`. */
+export interface ScreencastChapter {
+  title: string;
+  atMs: number;
+}
+/** #94: a recorded scenario screencast — the `.webm` (relative to runDir) + its step chapters. */
+export interface ScreencastEntry {
+  test: string;
+  /** Path to the `.webm`, relative to runDir (the artifact travels with the run dir). */
+  video: string;
+  chapters: ScreencastChapter[];
+}
+
+interface PwAttachment {
+  name?: string;
+  path?: string;
+  contentType?: string;
+}
+interface PwStep {
+  title?: string;
+  duration?: number;
+}
 interface PwResult {
   status?: string;
   error?: { message?: string };
   errors?: { message?: string }[];
+  steps?: PwStep[];
+  attachments?: PwAttachment[];
 }
 interface PwSpec {
   title: string;
@@ -65,6 +104,49 @@ interface PwSuite {
 }
 interface PwJson {
   suites?: PwSuite[];
+}
+
+/** Playwright's two fixed top-level hook step titles — kept out of the reviewer's chapter list. */
+const HOOK_STEP_TITLES = new Set(["Before Hooks", "After Hooks"]);
+
+/**
+ * #94: build the screencast index from the JSON reporter output. For each spec's first result, pair its
+ * `video` attachment with chapter markers from `steps`. The JSON reporter omits per-step startTime, so the
+ * offset is the cumulative duration of preceding top-level steps — hook steps advance the clock but are
+ * dropped from the visible chapters (they aren't scenario steps). Pure (no IO) so it unit-tests cleanly.
+ */
+export function screencastsFromJson(json: PwJson, runDir: string): ScreencastEntry[] {
+  const out: ScreencastEntry[] = [];
+  const walk = (s: PwSuite): void => {
+    for (const spec of s.specs ?? []) {
+      const result = spec.tests?.[0]?.results?.[0];
+      const videoPath = result?.attachments?.find((a) => a.name === "video" && a.path)?.path;
+      if (!videoPath) continue; // no recording for this test → nothing to link
+      const chapters: ScreencastChapter[] = [];
+      let atMs = 0;
+      for (const step of result?.steps ?? []) {
+        if (!HOOK_STEP_TITLES.has(step.title ?? "")) {
+          chapters.push({ title: step.title ?? "(step)", atMs });
+        }
+        atMs += step.duration ?? 0; // hooks still advance the clock so offsets stay aligned to the video
+      }
+      out.push({ test: spec.title, video: relative(runDir, videoPath), chapters });
+    }
+    for (const child of s.suites ?? []) walk(child);
+  };
+  for (const s of json.suites ?? []) walk(s);
+  return out;
+}
+
+/** #94: parse the reporter stdout into screencast entries (empty on no/garbled JSON). Pure. */
+export function screencastsFromRunnerOutput(stdout: string, runDir: string): ScreencastEntry[] {
+  const start = stdout.indexOf("{");
+  if (start < 0) return [];
+  try {
+    return screencastsFromJson(JSON.parse(stdout.slice(start)) as PwJson, runDir);
+  } catch {
+    return [];
+  }
 }
 
 function extract(json: PwJson): RawTestResult[] {
@@ -89,7 +171,12 @@ function extract(json: PwJson): RawTestResult[] {
 export async function runSpecs(runDir: string, opts: RunSpecsOptions = {}): Promise<RawTestResult[]> {
   const absRunDir = resolve(runDir); // testDir in the config must be absolute
   const configPath = join(absRunDir, "playwright.config.cjs");
-  await writeFile(configPath, configContent(absRunDir, opts.storageStatePath, opts.channel, opts.workers), "utf8");
+  const screencastDir = opts.screencastDir ? resolve(opts.screencastDir) : undefined;
+  await writeFile(
+    configPath,
+    configContent(absRunDir, opts.storageStatePath, opts.channel, opts.workers, screencastDir),
+    "utf8",
+  );
 
   // Do not inherit the parent runner's NODE_OPTIONS (vitest/tsx loader) — otherwise the child
   // playwright process tries to apply a foreign loader and crashes.
@@ -112,6 +199,18 @@ export async function runSpecs(runDir: string, opts: RunSpecsOptions = {}): Prom
     const err = e as { stdout?: string; stderr?: string };
     stdout = err.stdout ?? "";
     stderr = err.stderr ?? "";
+  }
+
+  // #94: when recording, drop the step-chapter sidecar next to the .webm files. The reporter writes the
+  // video paths into stdout AFTER the run, so this runs post-parse. Best-effort: a recorder/IO failure
+  // logs nothing-fatal and never sinks the run (the tests still ran — only the review affordance is lost).
+  if (screencastDir) {
+    try {
+      const entries = screencastsFromRunnerOutput(stdout, absRunDir);
+      await writeFile(join(screencastDir, "screencasts.json"), JSON.stringify(entries, null, 2), "utf8");
+    } catch {
+      // screencast is an optional review affordance — never fail the run over it
+    }
   }
 
   return resultsFromRunnerOutput(stdout, stderr);

--- a/tests/unit/__snapshots__/cli-modalities.test.ts.snap
+++ b/tests/unit/__snapshots__/cli-modalities.test.ts.snap
@@ -83,6 +83,8 @@ Options:
   --into-project [dir]   write specs into an existing Playwright project's
                          testDir (detect playwright.config.*; respects
                          testDir/naming) instead of runs/<id>/tests
+  --screencast           record a .webm per scenario (with step chapters) during
+                         validation → runs/<id>/screencasts/ for the review gate
   -h, --help             display help for command
 "
 `;

--- a/tests/unit/cli-modalities.test.ts
+++ b/tests/unit/cli-modalities.test.ts
@@ -119,10 +119,11 @@ describe("explore parity (C1-02)", () => {
       "--setup",
       "--gaps",
       "--into-project",
+      "--screencast",
     ]) {
       expect(longs, `explore should accept ${f}`).toContain(f);
     }
-    expect(longs).toHaveLength(17); // + --critique (#82) + --flow / --max-pages (#59) + --setup (#60) + --gaps (#61) + --into-project (#51) + --goal (#63)
+    expect(longs).toHaveLength(18); // + --critique (#82) + --flow / --max-pages (#59) + --setup (#60) + --gaps (#61) + --into-project (#51) + --goal (#63) + --screencast (#94)
   });
 
   it("maps flags to runExploration the same way as before the refactor", async () => {

--- a/tests/unit/run-summary.test.ts
+++ b/tests/unit/run-summary.test.ts
@@ -38,6 +38,19 @@ describe("renderRunSummary (L1-04, Box 4 — first-run UX)", () => {
     expect(text).toMatch(/8\s*\/\s*80/); // budget used / max
   });
 
+  it("#94: links the screencasts dir when scenarios were recorded, and omits it otherwise", () => {
+    const recorded = renderRunSummary({
+      runDir: "/tmp/runs/abc123",
+      validation: { ...validation, screencasts: [{ test: "loads", video: "screencasts/loads/video.webm", chapters: [] }] },
+    }).join("\n");
+    expect(recorded).toMatch(/Screencasts:\s*1 \.webm recorded/);
+    expect(recorded).toContain("/tmp/runs/abc123/screencasts/");
+
+    // default run (no screencasts) — no Screencasts line, no regression
+    const plain = renderRunSummary({ runDir: "/tmp/runs/abc123", validation }).join("\n");
+    expect(plain).not.toMatch(/Screencasts:/);
+  });
+
   it("renders unknown cost gracefully (some prices missing)", () => {
     const text = renderRunSummary({
       runDir: "/x",

--- a/tests/unit/screencast.test.ts
+++ b/tests/unit/screencast.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { sep } from "node:path";
+import {
+  configContent,
+  screencastsFromRunnerOutput,
+  screencastsFromJson,
+} from "../../src/validate/runner.js";
+
+// A Playwright JSON-reporter result with a recorded video + step timeline. The top-level steps include
+// the two fixed hook steps (which advance the clock but are NOT scenario chapters) plus two test.step()s.
+const RECORDED_JSON = JSON.stringify({
+  suites: [
+    {
+      specs: [
+        {
+          title: "login flow",
+          tests: [
+            {
+              results: [
+                {
+                  status: "passed",
+                  steps: [
+                    { title: "Before Hooks", duration: 500 },
+                    { title: "Navigate to login", duration: 1200 },
+                    { title: "Submit credentials", duration: 800 },
+                    { title: "After Hooks", duration: 100 },
+                  ],
+                  attachments: [
+                    { name: "video", contentType: "video/webm", path: "/runs/abc/screencasts/login/video.webm" },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+describe("#94 configContent — opt-in screencast recording", () => {
+  it("default (no screencastDir): no video, no outputDir — zero regression", () => {
+    const cfg = configContent("/runs/x");
+    expect(cfg).not.toMatch(/video:/);
+    expect(cfg).not.toMatch(/outputDir:/);
+  });
+
+  it("enables Playwright video + a stable outputDir when recording is on", () => {
+    const cfg = configContent("/runs/x", undefined, undefined, 5, "/runs/x/screencasts");
+    expect(cfg).toMatch(/video:\s*'on'/);
+    expect(cfg).toMatch(/outputDir:\s*"\/runs\/x\/screencasts"/);
+  });
+});
+
+describe("#94 screencastsFromJson — .webm + step chapters", () => {
+  it("registers the .webm (relative to runDir) and maps chapters to scenario steps", () => {
+    const entries = screencastsFromJson(JSON.parse(RECORDED_JSON), "/runs/abc");
+    expect(entries).toHaveLength(1);
+    const e = entries[0]!;
+    expect(e.test).toBe("login flow");
+    // path is stored relative to the run dir so the artifact travels with it
+    expect(e.video).toBe(["screencasts", "login", "video.webm"].join(sep));
+    // hook steps are dropped from chapters; the two scenario steps remain, in order
+    expect(e.chapters.map((c) => c.title)).toEqual(["Navigate to login", "Submit credentials"]);
+  });
+
+  it("offsets are cumulative and hook duration still advances the clock (timecodes stay aligned)", () => {
+    const e = screencastsFromJson(JSON.parse(RECORDED_JSON), "/runs/abc")[0]!;
+    // 'Navigate' starts after the 500ms Before-Hooks; 'Submit' after Before-Hooks + Navigate (1200ms).
+    expect(e.chapters[0]!.atMs).toBe(500);
+    expect(e.chapters[1]!.atMs).toBe(500 + 1200);
+  });
+
+  it("skips a test with no video attachment (nothing to link)", () => {
+    const json = {
+      suites: [{ specs: [{ title: "no recording", tests: [{ results: [{ status: "passed", steps: [] }] }] }] }],
+    };
+    expect(screencastsFromJson(json, "/runs/abc")).toEqual([]);
+  });
+});
+
+describe("#94 screencastsFromRunnerOutput — tolerant parsing (recorder failure must not crash)", () => {
+  it("returns [] on garbled / empty reporter output instead of throwing", () => {
+    expect(screencastsFromRunnerOutput("", "/runs/abc")).toEqual([]);
+    expect(screencastsFromRunnerOutput("not json {oops", "/runs/abc")).toEqual([]);
+  });
+
+  it("parses the video + chapters out of real reporter stdout", () => {
+    const out = screencastsFromRunnerOutput(`noise before json\n${RECORDED_JSON}`, "/runs/abc");
+    expect(out[0]?.chapters).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Closes #94 (BORROW-05).

## What

Record a `.webm` **per scenario** during validation (Playwright's built-in `video`, not a custom recorder) into `runs/<id>/screencasts/`, with a `screencasts.json` sidecar mapping each scenario's **step chapters** (step title → timecode). A review-gate affordance: a human can *watch* what the agent did before approving a case.

- **Opt-in** via `--screencast` (`cairn explore --screencast` · `cairn automate --validate --screencast`). **Off by default** → existing runs unchanged.
- **Chapters** come from the JSON reporter's per-test `steps[]`: cumulative duration → offset; the two fixed hook steps advance the clock but are dropped from the visible chapters (they aren't scenario steps). The reporter omits per-step `startTime`, so offsets are cumulative-duration (good enough for chapter navigation).
- **Linked** from the run summary (CLI, one line) and the TUI result screen (per-scenario `.webm` + chapter count).
- **Failure-isolated**: a recorder/IO failure is best-effort and never sinks the run — the tests still ran, only the review affordance is lost. Matches the repo's existing best-effort artifact-write convention.

## How it flows

`--screencast` → `ExploreInput`/`runAutomate` → `validateSuite({screencast})` → `runSpecs({screencastDir})` → `configContent` adds `video:'on'` + `outputDir`. After the run, `screencastsFromJson` builds the sidecar; `validateSuite` reads it back onto `ValidationReport.screencasts`, which flows through the existing summary/TUI plumbing. Reruns overwrite the output dir (Playwright clears it), so the surviving `.webm` + sidecar match the last run.

## Verified against DoD

- ✅ each scenario optionally produces a `.webm` with step markers — `tests/unit/screencast.test.ts`
- ✅ linked from run summary — `tests/unit/run-summary.test.ts` (#94 case)
- ✅ linked from TUI — `summary-screen.tsx` lists per-scenario `.webm`
- ✅ default (off) = no recording, no regression — covered
- ✅ recorder failure tolerated — `screencastsFromRunnerOutput` returns `[]` on garbled output; sidecar write/read are best-effort
- `npm run build` · `npm run lint` · unit tests (591 passed) · `npm run smoke:pack` (8 checks) all green
- Pre-existing integration failures (`playwright-lib`, `explore-hardening`) are missing-browser in this env — confirmed identical on clean `main`, unrelated to this change.

## Scope / follow-ups

- Link only, **no video-player UI** (per the issue's scope note).
- **Follow-up:** surface screencast links in the *past-run* TUI artifact viewer (`run-detail`) too — currently only the post-run summary screen links them.
- **Follow-up:** retention/cleanup policy for large `.webm` across many runs (out of scope; `runs/` retention is a pre-existing concern).