### PR TITLE
feat: cairn api — OpenAPI ingest into endpoint model (API-1, part of #22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`cairn api` — OpenAPI ingest (#22, C1-04 / API-1).** The `api` modality leaves the gate one slice
+  at a time. This first slice registers `cairn api --spec <path|url>` (parity with `cairn explore`) and
+  ingests an **OpenAPI 3.x** spec — JSON or YAML, local file or `http(s)` URL — into an internal
+  endpoint model (method, path, params, request/response schemas, `operationId`, security), then prints
+  a verifiable summary (*"N endpoints across M tags"* + the endpoint list). `$ref`s (incl. circular)
+  and 3.0/3.1 are handled via `@apidevtools/swagger-parser`; a malformed/unsupported spec fails with a
+  clear message and a non-zero exit, never a crash. **No case generation yet** — that, the runner and
+  the report are API-2 (#137); the Plune-record write + methodological rigor are API-3 (#138).
+
 - **Per-scenario screencast recording — `--screencast` (#94, BORROW-05).** Validation can now record a
   `.webm` per scenario (Playwright's built-in video) into `runs/<id>/screencasts/`, with a
   `screencasts.json` sidecar mapping each scenario's **step chapters** (step title → timecode) — a

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ result summary → past-run browser). Ink/React are optional deps — see **[doc
 | `cairn automate --run <dir> [--validate --session <s>] [--screencast]` | `@playwright/test` from `ATC-*` cases |
 | `cairn promote --run <dir> --cases <ids> [--session <s>]` | Promote manual MTC case(s) to ATC (.md only; then `automate`) |
 | `cairn explore --url <u> --session <s> [--checklist <f>] [--fresh] [--critique] [--screencast]` | Full pipeline (cases → code → validate → repair → Pilot) |
+| `cairn api --spec <path\|url>` | Ingest an OpenAPI 3.x spec (JSON/YAML, file or URL) into the endpoint model and print a summary — _API-1: parse only, no generation yet (#22)_ |
 | `cairn experiment --dataset <d> --candidate name=file` | Compare prompt versions on a dataset |
 
 > `lex-bot <command>` still runs every command above (deprecated alias — prints a notice, then runs `cairn`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@apidevtools/swagger-parser": "^10.1.1",
         "@langchain/anthropic": "^1.4.0",
         "@langchain/core": "^1.1.48",
         "@langchain/openai": "^1.4.7",
-        "@modelcontextprotocol/sdk": "^1",
         "@playwright/test": "^1.60.0",
         "commander": "^15.0.0",
         "dotenv": "^17.4.2",
@@ -118,6 +118,92 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.7.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.2.tgz",
+      "integrity": "sha512-4gY54eEGEstClvEkGnwVkTkrx0sqwemEFG5OSRRn3tD91XH0+Q8XIkYIfo7IwEWPpJZwILb9GUXeShtplRc/eA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.1.1.tgz",
+      "integrity": "sha512-u/kozRnsPO/x8QtKYJOqoGtC4kH6yg1lfYkB9Au0WhYB0FNLpyFusttQtvhlwjtG3rOwiRz4D8DnnXa8iEpIKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "11.7.2",
+        "@apidevtools/openapi-schemas": "^2.1.0",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.2"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
@@ -927,6 +1013,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
     },
     "node_modules/@langchain/anthropic": {
       "version": "1.5.0",
@@ -3716,7 +3808,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -4269,6 +4360,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4426,6 +4523,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -5293,7 +5396,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -5330,8 +5432,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -6002,6 +6103,28 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -6689,6 +6812,13 @@
         }
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7068,7 +7198,6 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "spike:s6-parity": "tsx scripts/spike-s6-parity.ts"
   },
   "dependencies": {
+    "@apidevtools/swagger-parser": "^10.1.1",
     "@langchain/anthropic": "^1.4.0",
     "@langchain/core": "^1.1.48",
     "@langchain/openai": "^1.4.7",
@@ -88,13 +89,27 @@
     "@playwright/cli": "^0.1.13"
   },
   "peerDependenciesMeta": {
-    "@langfuse/client": { "optional": true },
-    "@langfuse/langchain": { "optional": true },
-    "@langfuse/otel": { "optional": true },
-    "@langfuse/tracing": { "optional": true },
-    "@opentelemetry/api": { "optional": true },
-    "@opentelemetry/sdk-node": { "optional": true },
-    "@playwright/cli": { "optional": true }
+    "@langfuse/client": {
+      "optional": true
+    },
+    "@langfuse/langchain": {
+      "optional": true
+    },
+    "@langfuse/otel": {
+      "optional": true
+    },
+    "@langfuse/tracing": {
+      "optional": true
+    },
+    "@opentelemetry/api": {
+      "optional": true
+    },
+    "@opentelemetry/sdk-node": {
+      "optional": true
+    },
+    "@playwright/cli": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@langfuse/client": "^5.4.1",

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -1,0 +1,200 @@
+/**
+ * C1-04 / API-1 (#22) — OpenAPI ingest into Cairn's internal endpoint model.
+ *
+ * This is the FIRST vertical slice of the `api` modality: it only *reads* an OpenAPI v3 spec
+ * (JSON or YAML, from a file path or a URL) and flattens it into a small, generation-ready model
+ * (one entry per method × path). Case generation, the runner, the report and the Plune-record write
+ * are later slices (API-2 #137 / API-3 #138) — nothing here generates or executes anything.
+ *
+ * Parsing, YAML support, `$ref` resolution (incl. circular refs) and 3.0/3.1 handling are delegated
+ * to the maintained `@apidevtools/swagger-parser` (lazy-loaded so it stays off every non-api path).
+ */
+
+/** One parameter of an endpoint (query/path/header/cookie). */
+export interface ApiParam {
+  name: string;
+  in: "query" | "path" | "header" | "cookie";
+  required: boolean;
+  /** Dereferenced JSON schema for the parameter value (may be absent). */
+  schema?: unknown;
+}
+
+/** One response of an endpoint, keyed by status code (or "default"). */
+export interface ApiResponse {
+  status: string;
+  description?: string;
+  /** Schema of the first response media type, if the response carries a body. */
+  schema?: unknown;
+}
+
+/** The request body of an endpoint (absent for GET/DELETE-style ops without a body). */
+export interface ApiRequestBody {
+  required: boolean;
+  mediaTypes: string[];
+  /** Schema of the first request media type, if any. */
+  schema?: unknown;
+}
+
+/** One operation: a single HTTP method on a single path. */
+export interface ApiEndpoint {
+  /** Upper-case HTTP method, e.g. "GET", "POST". */
+  method: string;
+  /** Templated path, e.g. "/users/{id}". */
+  path: string;
+  operationId?: string;
+  summary?: string;
+  tags: string[];
+  parameters: ApiParam[];
+  requestBody?: ApiRequestBody;
+  responses: ApiResponse[];
+  /** Names of the security schemes this op requires (operation-level, else the spec default). */
+  security: string[];
+}
+
+/** The flattened spec: everything a later slice (API-2) needs to design + run cases. */
+export interface ApiModel {
+  title?: string;
+  /** info.version of the described API (not the OpenAPI version). */
+  version?: string;
+  /** The `openapi:` field, e.g. "3.0.3" / "3.1.0". */
+  openapiVersion: string;
+  endpoints: ApiEndpoint[];
+  /** Distinct tags across all endpoints, sorted. */
+  tags: string[];
+  /** Names declared under components.securitySchemes. */
+  securitySchemes: string[];
+}
+
+/** Minimal structural view of a dereferenced OpenAPI 3.x document (we read it loosely). */
+interface RawDoc {
+  openapi?: string;
+  swagger?: string;
+  info?: { title?: string; version?: string };
+  paths?: Record<string, RawPathItem | undefined>;
+  components?: { securitySchemes?: Record<string, unknown> };
+  security?: RawSecurityRequirement[];
+}
+interface RawPathItem {
+  parameters?: RawParam[];
+  [method: string]: unknown;
+}
+interface RawOperation {
+  operationId?: string;
+  summary?: string;
+  tags?: string[];
+  parameters?: RawParam[];
+  requestBody?: { required?: boolean; content?: Record<string, { schema?: unknown }> };
+  responses?: Record<string, { description?: string; content?: Record<string, { schema?: unknown }> }>;
+  security?: RawSecurityRequirement[];
+}
+interface RawParam {
+  name: string;
+  in: string;
+  required?: boolean;
+  schema?: unknown;
+}
+type RawSecurityRequirement = Record<string, string[]>;
+
+const HTTP_METHODS = ["get", "put", "post", "delete", "options", "head", "patch", "trace"] as const;
+
+/**
+ * Read an OpenAPI 3.x spec (JSON or YAML; file path or URL) and flatten it into an {@link ApiModel}.
+ *
+ * Throws a single, message-clear `Error` on anything we can't use — unreadable/invalid spec,
+ * unresolvable `$ref`, or an unsupported version (Swagger 2.0 / non-3.x) — so the command can report
+ * it instead of crashing.
+ */
+export async function ingestOpenApi(spec: string): Promise<ApiModel> {
+  // Lazy: keep swagger-parser (and its YAML/ref-resolver deps) off every non-`api` code path.
+  const { default: SwaggerParser } = await import("@apidevtools/swagger-parser");
+
+  let doc: RawDoc;
+  try {
+    // dereference = parse (JSON/YAML, file/URL) + resolve every $ref (circular refs become object
+    // cycles rather than throwing), so the walk below sees concrete params/schemas.
+    doc = (await SwaggerParser.dereference(spec)) as unknown as RawDoc;
+  } catch (e) {
+    throw new Error(`Could not read OpenAPI spec "${spec}": ${(e as Error).message}`);
+  }
+
+  const version = doc.openapi;
+  if (!version || !/^3\./.test(version)) {
+    throw new Error(
+      doc.swagger
+        ? `Unsupported spec: Swagger/OpenAPI 2.0 ("swagger: ${doc.swagger}") — provide an OpenAPI 3.x spec.`
+        : `Unsupported spec: expected an "openapi: 3.x" document (got ${version ? `"${version}"` : "no openapi/swagger field"}).`,
+    );
+  }
+
+  const endpoints: ApiEndpoint[] = [];
+  for (const [path, item] of Object.entries(doc.paths ?? {})) {
+    if (!item) continue;
+    const pathParams = item.parameters ?? [];
+    for (const method of HTTP_METHODS) {
+      const op = item[method] as RawOperation | undefined;
+      if (!op || typeof op !== "object") continue;
+      endpoints.push({
+        method: method.toUpperCase(),
+        path,
+        operationId: op.operationId,
+        summary: op.summary,
+        tags: op.tags ?? [],
+        parameters: mergeParams(pathParams, op.parameters ?? []).map(toApiParam),
+        requestBody: toRequestBody(op.requestBody),
+        responses: toResponses(op.responses),
+        // Operation security overrides the spec default; [] means "explicitly public".
+        security: securityNames(op.security ?? doc.security ?? []),
+      });
+    }
+  }
+
+  const tags = [...new Set(endpoints.flatMap((e) => e.tags))].sort();
+  const securitySchemes = Object.keys(doc.components?.securitySchemes ?? {});
+
+  return {
+    title: doc.info?.title,
+    version: doc.info?.version,
+    openapiVersion: version,
+    endpoints,
+    tags,
+    securitySchemes,
+  };
+}
+
+/** Merge path-level params with operation params; an op param overrides a path param of same (name,in). */
+function mergeParams(pathParams: RawParam[], opParams: RawParam[]): RawParam[] {
+  const byKey = new Map<string, RawParam>();
+  for (const p of pathParams) byKey.set(`${p.in}:${p.name}`, p);
+  for (const p of opParams) byKey.set(`${p.in}:${p.name}`, p);
+  return [...byKey.values()];
+}
+
+function toApiParam(p: RawParam): ApiParam {
+  const where: ApiParam["in"] =
+    p.in === "query" || p.in === "path" || p.in === "header" || p.in === "cookie" ? p.in : "query";
+  return { name: p.name, in: where, required: p.required ?? where === "path", schema: p.schema };
+}
+
+function toRequestBody(rb: RawOperation["requestBody"]): ApiRequestBody | undefined {
+  if (!rb) return undefined;
+  const content = rb.content ?? {};
+  const mediaTypes = Object.keys(content);
+  const first = mediaTypes[0];
+  return { required: rb.required ?? false, mediaTypes, schema: first ? content[first]?.schema : undefined };
+}
+
+function toResponses(responses: RawOperation["responses"]): ApiResponse[] {
+  return Object.entries(responses ?? {}).map(([status, r]) => {
+    const first = Object.keys(r.content ?? {})[0];
+    return {
+      status,
+      description: r.description,
+      schema: first ? r.content?.[first]?.schema : undefined,
+    };
+  });
+}
+
+/** Flatten security requirement objects to the distinct set of scheme names they reference. */
+function securityNames(reqs: RawSecurityRequirement[]): string[] {
+  return [...new Set(reqs.flatMap((r) => Object.keys(r)))];
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -125,6 +125,16 @@ export function buildProgram(): Command {
       await runModality("explore", opts);
     });
 
+  // api = the second REAL modality (C1-04 / #22), shipped one slice at a time. API-1 ingests an
+  // OpenAPI 3.x spec into the internal endpoint model and prints a summary — no generation yet.
+  program
+    .command("api")
+    .description("Ingest an OpenAPI 3.x spec into the endpoint model (API-1: parse + summary, no code yet)")
+    .requiredOption("--spec <path|url>", "OpenAPI 3.x spec — JSON or YAML, a local file path or an http(s) URL")
+    .action(async (opts: Record<string, unknown>) => {
+      await runModality("api", opts);
+    });
+
   program
     .command("dataset-add")
     .description("Add a run (study.json) to an experiment dataset")

--- a/src/core/modalities/api.ts
+++ b/src/core/modalities/api.ts
@@ -1,0 +1,65 @@
+/**
+ * C1-04 / API-1 (#22) — the `api` modality, first slice.
+ *
+ * Scope of THIS slice: register the command and ingest an OpenAPI v3 spec into the internal model,
+ * then print a verifiable summary of what was parsed ("N endpoints across M tags"). It does NOT
+ * generate cases, run anything, or write to Plune — those are API-2 (#137) and API-3 (#138).
+ */
+import { resolve } from "node:path";
+import { ingestOpenApi, type ApiModel } from "../../api/openapi.js";
+import type { Modality, ModalityContext } from "../modality.js";
+
+/** Parsed flags for `cairn api` (mirrors the command's option definitions). */
+interface ApiFlags {
+  spec?: string;
+}
+
+/** Is this a remote spec we hand to swagger-parser as-is, vs a local file path we resolve? */
+function isUrl(spec: string): boolean {
+  return /^https?:\/\//i.test(spec);
+}
+
+/** Print the parsed-model summary — the verifiable artifact of this slice. */
+export function renderApiSummary(model: ApiModel, source: string): string[] {
+  const lines = [
+    `=== API spec: ${model.title ?? "(untitled)"}${model.version ? ` v${model.version}` : ""} (OpenAPI ${model.openapiVersion}) ===`,
+    `Source: ${source}`,
+    `${model.endpoints.length} endpoint(s) across ${model.tags.length} tag(s)` +
+      (model.securitySchemes.length ? ` · ${model.securitySchemes.length} security scheme(s)` : ""),
+  ];
+  if (model.tags.length) lines.push(`Tags: ${model.tags.join(", ")}`);
+  for (const e of model.endpoints) {
+    const op = e.operationId ? ` (${e.operationId})` : "";
+    const tag = e.tags.length ? ` [${e.tags.join(", ")}]` : "";
+    lines.push(`  ${e.method.padEnd(6)} ${e.path}${op}${tag}`);
+  }
+  lines.push("");
+  lines.push("Note: ingest only (API-1). Case generation + runner land in API-2 (#137).");
+  return lines;
+}
+
+export const apiModality: Modality = {
+  name: "api",
+  gated: false,
+  summary: "Generate API / contract tests from an OpenAPI spec",
+  async run(ctx: ModalityContext): Promise<void> {
+    const opts = ctx.flags as ApiFlags;
+    const spec = opts.spec;
+    if (!spec) {
+      // commander enforces requiredOption in the CLI; this guards programmatic/test callers.
+      throw new Error("`cairn api` requires --spec <path|url> (an OpenAPI 3.x JSON/YAML spec).");
+    }
+    const source = isUrl(spec) ? spec : resolve(spec);
+    ctx.err(`▸ Ingesting OpenAPI spec from ${source}…\n`);
+    let model: ApiModel;
+    try {
+      model = await ingestOpenApi(source);
+    } catch (e) {
+      // Clean, non-crashing failure (acceptance): clear message, exit non-zero.
+      ctx.err(`✗ ${(e as Error).message}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    for (const line of renderApiSummary(model, source)) ctx.out(`${line}\n`);
+  },
+};

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -8,6 +8,7 @@
 import { defaultIO, gatedNotice } from "./modality.js";
 import type { IO, Modality } from "./modality.js";
 import { exploreModality } from "./modalities/explore.js";
+import { apiModality } from "./modalities/api.js";
 
 export const MODALITIES: Modality[] = [
   exploreModality,
@@ -18,7 +19,9 @@ export const MODALITIES: Modality[] = [
     summary: "Generate UI / end-to-end tests",
     hint: "For UI test generation today, use: cairn explore --url <url>",
   },
-  { name: "api", gated: true, summary: "Generate API / contract tests" },
+  // `api` is being built one slice at a time (#22): API-1 ships OpenAPI ingest + summary (no
+  // generation yet). It is a REAL modality now — registered with its own `--spec` command below.
+  apiModality,
   { name: "unit", gated: true, summary: "Generate unit tests" },
   { name: "docs", gated: true, summary: "Generate docs / doctest examples" },
 ];

--- a/tests/fixtures/api/malformed.yaml
+++ b/tests/fixtures/api/malformed.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.0
+info:
+  title: Broken
+  version: 1.0.0
+paths:
+  /x:
+    get:
+      parameters: [unclosed
+      responses:
+        '200':
+          description: ok

--- a/tests/fixtures/api/petstore.yaml
+++ b/tests/fixtures/api/petstore.yaml
@@ -1,0 +1,85 @@
+openapi: 3.0.3
+info:
+  title: Pet Store
+  version: 1.2.0
+security:
+  - apiKey: []
+tags:
+  - name: pets
+  - name: store
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      tags: [pets]
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+    post:
+      operationId: createPet
+      tags: [pets]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Created
+  /pets/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getPet
+      tags: [pets]
+      responses:
+        '200':
+          description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '404':
+          description: Not found
+    delete:
+      operationId: deletePet
+      tags: [store]
+      security: []
+      responses:
+        '204':
+          description: Deleted
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-API-Key
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        friends:
+          type: array
+          items:
+            $ref: '#/components/schemas/Pet'

--- a/tests/fixtures/api/swagger2.json
+++ b/tests/fixtures/api/swagger2.json
@@ -1,0 +1,5 @@
+{
+  "swagger": "2.0",
+  "info": { "title": "Old API", "version": "1.0.0" },
+  "paths": {}
+}

--- a/tests/fixtures/api/tiny.json
+++ b/tests/fixtures/api/tiny.json
@@ -1,0 +1,13 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Tiny API", "version": "0.1.0" },
+  "paths": {
+    "/health": {
+      "get": {
+        "operationId": "health",
+        "tags": ["ops"],
+        "responses": { "200": { "description": "ok" } }
+      }
+    }
+  }
+}

--- a/tests/unit/__snapshots__/cli-modalities.test.ts.snap
+++ b/tests/unit/__snapshots__/cli-modalities.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CLI surface lock (C1-02) > cairn --help lists the four gated stubs, marked coming-soon 1`] = `
+exports[`CLI surface lock (C1-02) > cairn --help lists the gated stubs (coming-soon) plus the real api command 1`] = `
 "Usage: cairn [options] [command]
 
 @plune-ai/cairn — autonomous UI test generator
@@ -14,6 +14,8 @@ Commands:
                          screenshot
   explore [options]      Explore a page and generate methodology-based test
                          cases (Sprint 2: no code)
+  api [options]          Ingest an OpenAPI 3.x spec into the endpoint model
+                         (API-1: parse + summary, no code yet)
   dataset-add [options]  Add a run (study.json) to an experiment dataset
   experiment [options]   Compare prompt versions on a dataset (B2
                          self-improvement)
@@ -32,8 +34,6 @@ Commands:
                          session interactively
   ui|e2e                 Generate UI / end-to-end tests — coming soon (gated;
                          see L-G2)
-  api                    Generate API / contract tests — coming soon (gated; see
-                         L-G2)
   unit                   Generate unit tests — coming soon (gated; see L-G2)
   docs                   Generate docs / doctest examples — coming soon (gated;
                          see L-G2)

--- a/tests/unit/api-modality.test.ts
+++ b/tests/unit/api-modality.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+/**
+ * C1-04 / API-1 (#22): the `cairn api` command — registration, the parsed-model summary, the
+ * file-path-vs-URL source, and clean (non-crashing) failure on a bad spec. The real ingest is
+ * exercised in api-openapi.test.ts; here we mock it where we only care about the wiring.
+ */
+const fixtures = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "api");
+
+let outChunks: string[];
+let errChunks: string[];
+let outSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  outChunks = [];
+  errChunks = [];
+  outSpy = vi.spyOn(process.stdout, "write").mockImplementation((c) => (outChunks.push(c.toString()), true));
+  errSpy = vi.spyOn(process.stderr, "write").mockImplementation((c) => (errChunks.push(c.toString()), true));
+  process.exitCode = 0;
+});
+afterEach(() => {
+  outSpy.mockRestore();
+  errSpy.mockRestore();
+  process.exitCode = 0;
+  vi.resetModules();
+  vi.doUnmock("../../src/api/openapi.js");
+});
+
+describe("cairn api command (real ingest)", () => {
+  it("is registered with a required --spec option", async () => {
+    const { buildProgram } = await import("../../src/cli/index.js");
+    const api = buildProgram().commands.find((c) => c.name() === "api");
+    expect(api).toBeDefined();
+    const spec = api?.options.find((o) => o.long === "--spec");
+    expect(spec?.required).toBe(true);
+  });
+
+  it("ingests a YAML spec and prints the parsed-model summary", async () => {
+    const { buildProgram } = await import("../../src/cli/index.js");
+    await buildProgram().parseAsync(["node", "cairn", "api", "--spec", join(fixtures, "petstore.yaml")]);
+    const out = outChunks.join("");
+    expect(out).toContain("API spec: Pet Store v1.2.0 (OpenAPI 3.0.3)");
+    expect(out).toContain("4 endpoint(s) across 2 tag(s)");
+    expect(out).toContain("1 security scheme(s)");
+    expect(out).toContain("GET    /pets");
+    expect(out).toContain("DELETE /pets/{id}");
+    expect(process.exitCode ?? 0).toBe(0);
+  });
+
+  it("fails cleanly (stderr + exit 1, no throw) on a malformed spec", async () => {
+    const { buildProgram } = await import("../../src/cli/index.js");
+    await buildProgram().parseAsync(["node", "cairn", "api", "--spec", join(fixtures, "malformed.yaml")]);
+    expect(errChunks.join("")).toMatch(/✗ Could not read OpenAPI spec/);
+    expect(process.exitCode).toBe(1);
+  });
+});
+
+describe("cairn api source resolution (mocked ingest)", () => {
+  it("passes an http(s) URL through verbatim, but resolves a local path to absolute", async () => {
+    const ingestOpenApi = vi.fn().mockResolvedValue({
+      openapiVersion: "3.0.0",
+      endpoints: [],
+      tags: [],
+      securitySchemes: [],
+    });
+    vi.doMock("../../src/api/openapi.js", () => ({ ingestOpenApi }));
+    vi.resetModules();
+    const { buildProgram } = await import("../../src/cli/index.js");
+
+    await buildProgram().parseAsync(["node", "cairn", "api", "--spec", "https://example.com/openapi.yaml"]);
+    expect(ingestOpenApi).toHaveBeenLastCalledWith("https://example.com/openapi.yaml");
+
+    await buildProgram().parseAsync(["node", "cairn", "api", "--spec", "./spec.json"]);
+    expect(ingestOpenApi).toHaveBeenLastCalledWith(resolve("./spec.json"));
+  });
+});

--- a/tests/unit/api-openapi.test.ts
+++ b/tests/unit/api-openapi.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { ingestOpenApi } from "../../src/api/openapi.js";
+
+/**
+ * C1-04 / API-1 (#22): OpenAPI ingest → internal endpoint model.
+ * All fixtures are local files (no network): YAML 3.0 (+ $ref, circular $ref, path-level params,
+ * security override) and JSON 3.1; malformed / unsupported specs surface a clean error.
+ */
+const fixtures = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "api");
+
+describe("ingestOpenApi", () => {
+  it("parses a YAML 3.0 spec into the endpoint model (methods, paths, params, security, tags)", async () => {
+    const model = await ingestOpenApi(join(fixtures, "petstore.yaml"));
+
+    expect(model.title).toBe("Pet Store");
+    expect(model.version).toBe("1.2.0");
+    expect(model.openapiVersion).toBe("3.0.3");
+    expect(model.tags).toEqual(["pets", "store"]); // distinct, sorted
+    expect(model.securitySchemes).toEqual(["apiKey"]);
+
+    // 4 endpoints across 2 paths.
+    const sig = model.endpoints.map((e) => `${e.method} ${e.path}`).sort();
+    expect(sig).toEqual(["DELETE /pets/{id}", "GET /pets", "GET /pets/{id}", "POST /pets"]);
+
+    const getPet = model.endpoints.find((e) => e.operationId === "getPet")!;
+    // path-level `id` param is merged onto the operation.
+    expect(getPet.parameters).toEqual([{ name: "id", in: "path", required: true, schema: { type: "string" } }]);
+    // $ref response schema is dereferenced (concrete object, not a $ref).
+    const ok = getPet.responses.find((r) => r.status === "200")!;
+    expect((ok.schema as { type?: string }).type).toBe("object");
+
+    // global security applies; the operation-level `security: []` makes DELETE explicitly public.
+    expect(model.endpoints.find((e) => e.operationId === "listPets")!.security).toEqual(["apiKey"]);
+    expect(model.endpoints.find((e) => e.operationId === "deletePet")!.security).toEqual([]);
+
+    // request body is captured with its media type.
+    const createPet = model.endpoints.find((e) => e.operationId === "createPet")!;
+    expect(createPet.requestBody?.required).toBe(true);
+    expect(createPet.requestBody?.mediaTypes).toEqual(["application/json"]);
+  });
+
+  it("parses a JSON 3.1 spec", async () => {
+    const model = await ingestOpenApi(join(fixtures, "tiny.json"));
+    expect(model.openapiVersion).toBe("3.1.0");
+    expect(model.endpoints).toHaveLength(1);
+    expect(model.endpoints[0]).toMatchObject({ method: "GET", path: "/health", operationId: "health", tags: ["ops"] });
+    expect(model.tags).toEqual(["ops"]);
+  });
+
+  it("does not crash on a circular $ref (recursive schema)", async () => {
+    const model = await ingestOpenApi(join(fixtures, "petstore.yaml"));
+    const created = model.endpoints.find((e) => e.operationId === "createPet")!;
+    // Pet.friends → array of Pet (cycle). The cycle is resolved to an object reference, not thrown.
+    const schema = created.requestBody?.schema as { properties?: { friends?: unknown } };
+    expect(schema.properties?.friends).toBeDefined();
+  });
+
+  it("rejects a malformed spec with a clear error (no crash)", async () => {
+    await expect(ingestOpenApi(join(fixtures, "malformed.yaml"))).rejects.toThrow(/Could not read OpenAPI spec/);
+  });
+
+  it("rejects an unsupported (Swagger 2.0) spec with a clear error", async () => {
+    await expect(ingestOpenApi(join(fixtures, "swagger2.json"))).rejects.toThrow(/Swagger\/OpenAPI 2\.0/);
+  });
+
+  it("rejects a missing file with a clear error", async () => {
+    await expect(ingestOpenApi(join(fixtures, "nope.yaml"))).rejects.toThrow(/Could not read OpenAPI spec/);
+  });
+});

--- a/tests/unit/cli-modalities.test.ts
+++ b/tests/unit/cli-modalities.test.ts
@@ -200,7 +200,8 @@ describe("explore parity (C1-02)", () => {
 });
 
 describe("gated modality stubs (C1-02)", () => {
-  for (const name of ["ui", "e2e", "api", "unit", "docs"]) {
+  // `api` is no longer gated — it ships OpenAPI ingest in API-1 (#22); see api-modality.test.ts.
+  for (const name of ["ui", "e2e", "unit", "docs"]) {
     it(`cairn ${name} prints coming-soon, exits 0, and calls NO runner`, async () => {
       await buildProgram().parseAsync(["node", "cairn", name]);
       expect(outChunks.join("")).toContain("coming soon — gated (see L-G2). Build by demand, one at a time.");
@@ -218,12 +219,12 @@ describe("gated modality stubs (C1-02)", () => {
 });
 
 describe("CLI surface lock (C1-02)", () => {
-  it("cairn --help lists the four gated stubs, marked coming-soon", () => {
+  it("cairn --help lists the gated stubs (coming-soon) plus the real api command", () => {
     const program = buildProgram();
     program.configureHelp({ helpWidth: 80 });
     const help = program.helpInformation();
     expect(help).toContain("ui|e2e");
-    expect(help).toContain("api");
+    expect(help).toContain("api"); // now a real command (API-1, #22), not a gated stub
     expect(help).toContain("unit");
     expect(help).toContain("docs");
     expect(help).toMatch(/coming soon|gated/i);

--- a/tests/unit/core-modality.test.ts
+++ b/tests/unit/core-modality.test.ts
@@ -3,9 +3,9 @@ import { gatedNotice } from "../../src/core/modality.js";
 import { MODALITIES, getModality, runModality } from "../../src/core/registry.js";
 
 /**
- * C1-01: a `Modality` is one kind of test artifact Cairn can generate. Today only `explore` (UI)
- * is real; ui/api/unit/docs are GATED stubs (L-G2 / #25) — discoverable placeholders with ZERO
- * generation logic. The registry is the seam every modality reuses.
+ * C1-01: a `Modality` is one kind of test artifact Cairn can generate. `explore` (UI) and `api`
+ * (OpenAPI ingest, API-1 #22) are real; ui/unit/docs are GATED stubs (L-G2 / #25) — discoverable
+ * placeholders with ZERO generation logic. The registry is the seam every modality reuses.
  */
 
 /** Collect what a modality would write to stdout/stderr. */
@@ -35,12 +35,14 @@ describe("gatedNotice (pure)", () => {
 });
 
 describe("registry (C1-01)", () => {
-  it("registers explore as the only REAL modality (has a run); ui/api/unit/docs are gated stubs", () => {
-    const explore = getModality("explore");
-    expect(explore?.gated).toBe(false);
-    expect(typeof explore?.run).toBe("function");
+  it("registers explore + api as REAL modalities (have a run); ui/unit/docs are gated stubs", () => {
+    for (const real of ["explore", "api"]) {
+      const m = getModality(real);
+      expect(m?.gated, `${real} should be real`).toBe(false);
+      expect(typeof m?.run, `${real} should carry a runner`).toBe("function");
+    }
 
-    for (const name of ["ui", "api", "unit", "docs"]) {
+    for (const name of ["ui", "unit", "docs"]) {
       const m = getModality(name);
       expect(m, `modality ${name} should exist`).toBeDefined();
       expect(m?.gated, `${name} should be gated`).toBe(true);
@@ -61,17 +63,17 @@ describe("registry (C1-01)", () => {
     expect(getModality("nope")).toBeUndefined();
   });
 
-  it("exposes exactly the four gated stubs (build-by-demand discipline)", () => {
+  it("exposes exactly the gated stubs (build-by-demand discipline)", () => {
     const gated = MODALITIES.filter((m) => m.gated).map((m) => m.name).sort();
-    expect(gated).toEqual(["api", "docs", "ui", "unit"]);
+    expect(gated).toEqual(["docs", "ui", "unit"]); // api left the gate in API-1 (#22)
   });
 });
 
 describe("runModality dispatch (C1-01)", () => {
   it("a gated modality prints the coming-soon notice and does NOT throw", async () => {
     const { io, out } = capture();
-    await runModality("api", {}, io);
-    expect(out.join("")).toContain("api: coming soon — gated (see L-G2). Build by demand, one at a time.");
+    await runModality("unit", {}, io);
+    expect(out.join("")).toContain("unit: coming soon — gated (see L-G2). Build by demand, one at a time.");
   });
 
   it("dispatches through an alias (e2e → ui notice, incl. the explore pointer)", async () => {


### PR DESCRIPTION
**Part of #22** (umbrella stays open — this is the first vertical slice, **API-1**).

`cairn api` leaves the gate one slice at a time. This PR does **only** subcommand registration + OpenAPI ingest — **no case generation, runner, report or Plune write** (those are follow-up slices).

## What changed
- **`cairn api --spec <path|url>`** registered in the umbrella router (parity with `cairn explore`): help text, arg parsing, required `--spec`. `api` is now a REAL modality (`src/core/modalities/api.ts`), not a gated stub.
- **OpenAPI 3.x ingest** (`src/api/openapi.ts`, `ingestOpenApi → ApiModel`): JSON **and** YAML, local file **and** `http(s)` URL → internal endpoint model — `method, path, params, request/response schemas, operationId, security, tags`. `$ref` (incl. **circular**) and **3.0 vs 3.1** handled via `@apidevtools/swagger-parser` (lazy-loaded, so it stays off every non-`api` path).
- **Clean failure:** a malformed / unsupported (e.g. Swagger 2.0) / unreachable spec → clear `✗` message + non-zero exit, **never a crash**.
- **Verifiable output:** prints `N endpoint(s) across M tag(s)` + the endpoint list, then a note that generation lands in API-2.

## Acceptance (agreed for this slice) — all met
- [x] `cairn api` registered with parity to `explore`, min `--spec <path|url>`
- [x] Ingest OpenAPI v3 (JSON+YAML, file+URL) → endpoint model (method/path/params/req+resp schemas/operationId/security)
- [x] Invalid/unsupported spec → clear error, no crash
- [x] No generation — command prints a parsed-model summary

## How verified (against acceptance)
- `tests/unit/api-openapi.test.ts` — ingest of a YAML 3.0 spec (`$ref`, **circular** `$ref`, path-level param merge, `security: []` override, request body) **and** a JSON 3.1 spec; malformed / Swagger-2.0 / missing-file → clean error. No network (local fixtures).
- `tests/unit/api-modality.test.ts` — command registered with required `--spec`; YAML spec → summary; malformed → stderr + exit 1; URL passed through verbatim while a local path is resolved to absolute (mocked ingest, no network).
- Updated the C1-02 surface lock + C1-01 registry tests (un-gating `api` deliberately trips both).
- `npm run lint` · `typecheck` · `build` · `npm test` green (the only failures are the 3 pre-existing real-Chromium integration tests, which fail on `main` too in this env). `npm run smoke:pack` ✓ (8 checks) — packed install includes the new runtime dep. Ran the built CLI against the fixtures end-to-end (summary + clean error).

## Follow-ups (out of scope here)
- **API-2 — #137:** happy-path case generation + runner + report.
- **API-3 — #138:** Plune-record write + methodological rigor.
- Then **#95** (BORROW-07, adversarial) builds on top of this model.

## Notes for reviewers
- New runtime dependency: `@apidevtools/swagger-parser@^10` (maintained, de-facto standard; handles YAML/`$ref`/circular/3.0+3.1 — no hand-rolled parser).
- `dereference` stores possibly-circular schema objects in the model; the summary never serializes them (API-2 should avoid blind `JSON.stringify` of a schema).
- #92 api-scope knowledge injection is design-time → wired in API-2, not here.
- Version in `package.json` intentionally untouched (release is separate).
