### PR TITLE
feat: cairn api — baseline happy-path case generation (API-2) (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`cairn api` — baseline happy-path cases (#132, C1-04 / API-2).** From the ingested endpoint model,
+  `cairn api` now generates **one nominal happy-path case per operation**: required params and a
+  request body are synthesised straight from the (dereferenced) JSON schema — respecting
+  `example` → `default` → `enum` → type, `required`, `format`, `allOf`/`oneOf`, and circular `$ref`s —
+  paired with the operation's declared success response (lowest `2xx`, else `default`). Synthesis is
+  **pure and deterministic** (no LLM, so the same spec yields byte-identical cases); the command prints
+  the generated cases beneath the model summary. **Still no runner** — execution + assertions are
+  API-3 (#138).
+
 - **`cairn api` — OpenAPI ingest (#22, C1-04 / API-1).** The `api` modality leaves the gate one slice
   at a time. This first slice registers `cairn api --spec <path|url>` (parity with `cairn explore`) and
   ingests an **OpenAPI 3.x** spec — JSON or YAML, local file or `http(s)` URL — into an internal

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ result summary → past-run browser). Ink/React are optional deps — see **[doc
 | `cairn automate --run <dir> [--validate --session <s>] [--screencast]` | `@playwright/test` from `ATC-*` cases |
 | `cairn promote --run <dir> --cases <ids> [--session <s>]` | Promote manual MTC case(s) to ATC (.md only; then `automate`) |
 | `cairn explore --url <u> --session <s> [--checklist <f>] [--fresh] [--critique] [--screencast]` | Full pipeline (cases → code → validate → repair → Pilot) |
-| `cairn api --spec <path\|url>` | Ingest an OpenAPI 3.x spec (JSON/YAML, file or URL) into the endpoint model and print a summary — _API-1: parse only, no generation yet (#22)_ |
+| `cairn api --spec <path\|url>` | Ingest an OpenAPI 3.x spec (JSON/YAML, file or URL) and generate one happy-path case per operation (params + body synthesised from the schema, paired with the success response) — _API-2: cases, no runner yet (#132)_ |
 | `cairn experiment --dataset <d> --candidate name=file` | Compare prompt versions on a dataset |
 
 > `lex-bot <command>` still runs every command above (deprecated alias — prints a notice, then runs `cairn`).

--- a/src/api/cases.ts
+++ b/src/api/cases.ts
@@ -1,0 +1,174 @@
+/**
+ * C1-04 / API-2 (#132) — baseline happy-path case generation from the {@link ApiModel} (API-1).
+ *
+ * One nominal case per operation: required params + a request body synthesised straight from the
+ * (already-dereferenced) JSON schema, paired with the operation's declared success response.
+ *
+ * No LLM here — and that is the point. Happy-path values follow mechanically from the schema
+ * (`example` → `default` → `enum` → type), so synthesis is pure and deterministic (same spec → same
+ * cases). The provider abstraction (`StructuredInvoke`) stays available for later, fuzzier slices
+ * (negative / boundary cases, API-3+); the DoD's "any LLM use is mockable" holds vacuously because
+ * this slice uses none. No runner either — that is API-3.
+ */
+import type { ApiEndpoint, ApiModel } from "./openapi.js";
+
+/** Values synthesised for an operation's parameters, grouped by location. */
+export interface ApiCaseParams {
+  path: Record<string, unknown>;
+  query: Record<string, unknown>;
+  header: Record<string, unknown>;
+  cookie: Record<string, unknown>;
+}
+
+/** One generated happy-path case: what to send, and the success response to expect. */
+export interface ApiCase {
+  /** `operationId` if present, else `METHOD path` — stable per operation. */
+  name: string;
+  method: string;
+  path: string;
+  operationId?: string;
+  /** Required params with schema-synthesised values (optional params are omitted — nominal path). */
+  params: ApiCaseParams;
+  /** Request body synthesised from the body schema, if the operation declares one. */
+  body?: unknown;
+  /** Declared success status this case expects ("200"/"201"/"204"/"default"…). */
+  expectedStatus: string;
+  /** Schema of the expected success body, if that response carries one. */
+  expectedSchema?: unknown;
+}
+
+/** Generate one baseline happy-path case per operation, in the model's (deterministic) order. */
+export function generateApiCases(model: ApiModel): ApiCase[] {
+  return model.endpoints.map(toCase);
+}
+
+function toCase(e: ApiEndpoint): ApiCase {
+  const params: ApiCaseParams = { path: {}, query: {}, header: {}, cookie: {} };
+  for (const p of e.parameters) {
+    // Nominal happy-path: send the required params; leave optional ones unset.
+    if (!p.required) continue;
+    params[p.in][p.name] = synth(p.schema);
+  }
+
+  const success = pickSuccess(e);
+  return {
+    name: e.operationId ?? `${e.method} ${e.path}`,
+    method: e.method,
+    path: e.path,
+    operationId: e.operationId,
+    params,
+    body: e.requestBody?.schema !== undefined ? synth(e.requestBody.schema) : undefined,
+    expectedStatus: success?.status ?? "200",
+    expectedSchema: success?.schema,
+  };
+}
+
+/** The declared success response: the lowest 2xx, else `default`, else the first declared. */
+function pickSuccess(e: ApiEndpoint): ApiEndpoint["responses"][number] | undefined {
+  const twoXX = e.responses.filter((r) => /^2\d\d$/.test(r.status)).sort((a, b) => a.status.localeCompare(b.status));
+  return twoXX[0] ?? e.responses.find((r) => r.status === "default") ?? e.responses[0];
+}
+
+interface Schema {
+  type?: string | string[];
+  format?: string;
+  example?: unknown;
+  default?: unknown;
+  enum?: unknown[];
+  properties?: Record<string, Schema>;
+  required?: string[];
+  items?: Schema;
+  minimum?: number;
+  allOf?: Schema[];
+  oneOf?: Schema[];
+  anyOf?: Schema[];
+}
+
+/**
+ * Synthesise one valid value for a (dereferenced) JSON schema, respecting `example`/`default`/`enum`,
+ * types, `required` and `format`. `seen` guards the object cycles swagger-parser leaves behind for
+ * circular `$ref`s (e.g. `Pet.friends: Pet[]`) so recursion terminates.
+ */
+function synth(schema: unknown, seen: Set<object> = new Set()): unknown {
+  if (!schema || typeof schema !== "object") return undefined;
+  const s = schema as Schema;
+
+  // Explicit values win, in spec-precedence order.
+  if (s.example !== undefined) return s.example;
+  if (s.default !== undefined) return s.default;
+  if (s.enum && s.enum.length) return s.enum[0];
+
+  // Composition: allOf = merge all subschemas; one/anyOf = take the first branch.
+  if (s.allOf?.length) return synth(mergeAllOf(s.allOf), seen);
+  if (s.oneOf?.length) return synth(s.oneOf[0], seen);
+  if (s.anyOf?.length) return synth(s.anyOf[0], seen);
+
+  const type = Array.isArray(s.type) ? s.type.find((t) => t !== "null") : s.type;
+
+  // Objects/arrays recurse — stop if we re-enter the same schema node (circular ref).
+  if (type === "object" || s.properties) {
+    if (seen.has(s)) return undefined;
+    return synthObject(s, new Set(seen).add(s));
+  }
+  if (type === "array") {
+    if (seen.has(s)) return [];
+    return s.items ? [synth(s.items, new Set(seen).add(s))].filter((v) => v !== undefined) : [];
+  }
+
+  switch (type) {
+    case "string":
+      return synthString(s.format);
+    case "integer":
+    case "number":
+      return s.minimum ?? 0;
+    case "boolean":
+      return true;
+    default:
+      return undefined; // untyped/unknown schema → omit
+  }
+}
+
+function synthObject(s: Schema, seen: Set<object>): Record<string, unknown> {
+  const required = new Set(s.required ?? []);
+  const out: Record<string, unknown> = {};
+  for (const [key, sub] of Object.entries(s.properties ?? {})) {
+    const v = synth(sub, seen);
+    if (v !== undefined) out[key] = v;
+    // A required field whose schema we couldn't synthesise (e.g. circular) still has to be present.
+    else if (required.has(key)) out[key] = null;
+  }
+  return out;
+}
+
+/** Shallow-merge `allOf` members into one object schema (enough for happy-path bodies). */
+function mergeAllOf(parts: Schema[]): Schema {
+  const merged: Schema = { type: "object", properties: {}, required: [] };
+  for (const p of parts) {
+    Object.assign(merged.properties!, p.properties ?? {});
+    if (p.required) merged.required!.push(...p.required);
+  }
+  return merged;
+}
+
+/** A format-appropriate sample string (valid for the common OpenAPI string formats). */
+function synthString(format?: string): string {
+  switch (format) {
+    case "email":
+      return "user@example.com";
+    case "uuid":
+      return "00000000-0000-0000-0000-000000000000";
+    case "date":
+      return "2024-01-01";
+    case "date-time":
+      return "2024-01-01T00:00:00Z";
+    case "uri":
+    case "url":
+      return "https://example.com";
+    case "hostname":
+      return "example.com";
+    case "ipv4":
+      return "127.0.0.1";
+    default:
+      return "string";
+  }
+}

--- a/src/core/modalities/api.ts
+++ b/src/core/modalities/api.ts
@@ -1,12 +1,13 @@
 /**
- * C1-04 / API-1 (#22) — the `api` modality, first slice.
+ * C1-04 — the `api` modality.
  *
- * Scope of THIS slice: register the command and ingest an OpenAPI v3 spec into the internal model,
- * then print a verifiable summary of what was parsed ("N endpoints across M tags"). It does NOT
- * generate cases, run anything, or write to Plune — those are API-2 (#137) and API-3 (#138).
+ * API-1 (#22): register the command and ingest an OpenAPI v3 spec into the internal model.
+ * API-2 (#132): from that model, generate one nominal happy-path case per operation and print them.
+ * Still NO runner / no Plune write — that is API-3 (#138).
  */
 import { resolve } from "node:path";
 import { ingestOpenApi, type ApiModel } from "../../api/openapi.js";
+import { generateApiCases, type ApiCase } from "../../api/cases.js";
 import type { Modality, ModalityContext } from "../modality.js";
 
 /** Parsed flags for `cairn api` (mirrors the command's option definitions). */
@@ -33,8 +34,27 @@ export function renderApiSummary(model: ApiModel, source: string): string[] {
     const tag = e.tags.length ? ` [${e.tags.join(", ")}]` : "";
     lines.push(`  ${e.method.padEnd(6)} ${e.path}${op}${tag}`);
   }
+  return lines;
+}
+
+/** Render the generated baseline cases — the verifiable artifact of API-2. */
+export function renderApiCases(cases: ApiCase[]): string[] {
+  const lines = [
+    "",
+    "=== Baseline cases (happy-path · 1 per operation) ===",
+    `${cases.length} case(s) generated`,
+  ];
+  for (const c of cases) {
+    lines.push(`  ▸ ${c.name} → ${c.expectedStatus}`);
+    const sent: Record<string, unknown> = {};
+    for (const [where, vals] of Object.entries(c.params)) {
+      if (Object.keys(vals as object).length) sent[where] = vals;
+    }
+    if (c.body !== undefined) sent.body = c.body;
+    if (Object.keys(sent).length) lines.push(`      ${JSON.stringify(sent)}`);
+  }
   lines.push("");
-  lines.push("Note: ingest only (API-1). Case generation + runner land in API-2 (#137).");
+  lines.push("Note: cases only (API-2). The runner + assertions land in API-3 (#138).");
   return lines;
 }
 
@@ -61,5 +81,6 @@ export const apiModality: Modality = {
       return;
     }
     for (const line of renderApiSummary(model, source)) ctx.out(`${line}\n`);
+    for (const line of renderApiCases(generateApiCases(model))) ctx.out(`${line}\n`);
   },
 };

--- a/tests/unit/api-cases.test.ts
+++ b/tests/unit/api-cases.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { ingestOpenApi, type ApiModel } from "../../src/api/openapi.js";
+import { generateApiCases } from "../../src/api/cases.js";
+
+/**
+ * C1-04 / API-2 (#132): baseline happy-path case generation. The synthesis is pure/deterministic
+ * (no LLM, no network), so we drive it straight from real-ingested specs and from hand-built models
+ * for the schema-keyword edge cases.
+ */
+const fixtures = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "api");
+
+/** Tiny ApiModel builder so we can exercise one schema keyword at a time. */
+function model(...endpoints: ApiModel["endpoints"]): ApiModel {
+  return { openapiVersion: "3.0.0", endpoints, tags: [], securitySchemes: [] };
+}
+
+describe("generateApiCases — one case per operation (a)", () => {
+  it("emits exactly one case per ingested operation, with valid params and body", async () => {
+    const m = await ingestOpenApi(join(fixtures, "petstore.yaml"));
+    const cases = generateApiCases(m);
+
+    expect(cases).toHaveLength(m.endpoints.length); // 4 operations → 4 cases
+
+    // GET /pets/{id}: the required path param is synthesised; nothing else.
+    const getPet = cases.find((c) => c.name === "getPet")!;
+    expect(getPet.params.path).toEqual({ id: "string" });
+    expect(getPet.body).toBeUndefined();
+
+    // POST /pets carries a body synthesised from the Pet schema (cyclic `friends` → []).
+    const createPet = cases.find((c) => c.name === "createPet")!;
+    expect(createPet.body).toEqual({ id: "string", name: "string", friends: [] });
+    expect(createPet.expectedStatus).toBe("201");
+  });
+
+  it("omits optional params (nominal happy-path) — listPets.limit is not sent", async () => {
+    const m = await ingestOpenApi(join(fixtures, "petstore.yaml"));
+    const listPets = generateApiCases(m).find((c) => c.name === "listPets")!;
+    expect(listPets.params.query).toEqual({});
+    expect(listPets.expectedStatus).toBe("200");
+  });
+});
+
+describe("respects required / enum / types / example / format (b)", () => {
+  it("prefers example, then enum, then type/format", () => {
+    const m = model({
+      method: "POST",
+      path: "/x",
+      tags: [],
+      parameters: [],
+      requestBody: {
+        required: true,
+        mediaTypes: ["application/json"],
+        schema: {
+          type: "object",
+          required: ["status", "count"],
+          properties: {
+            id: { type: "string", example: "abc-123" },
+            status: { type: "string", enum: ["active", "archived"] },
+            count: { type: "integer", minimum: 5 },
+            ok: { type: "boolean" },
+            email: { type: "string", format: "email" },
+          },
+        },
+      },
+      responses: [{ status: "200" }],
+      security: [],
+    });
+    expect(generateApiCases(m)[0].body).toEqual({
+      id: "abc-123", // example wins
+      status: "active", // first enum
+      count: 5, // minimum
+      ok: true,
+      email: "user@example.com", // format
+    });
+  });
+
+  it("keeps a required field present even when its schema yields nothing", () => {
+    const m = model({
+      method: "POST",
+      path: "/x",
+      tags: [],
+      parameters: [],
+      requestBody: {
+        required: true,
+        mediaTypes: ["application/json"],
+        schema: { type: "object", required: ["mystery"], properties: { mystery: {} } },
+      },
+      responses: [{ status: "200" }],
+      security: [],
+    });
+    expect(generateApiCases(m)[0].body).toEqual({ mystery: null });
+  });
+
+  it("resolves allOf (merge) and oneOf (first branch)", () => {
+    const m = model({
+      method: "POST",
+      path: "/x",
+      tags: [],
+      parameters: [],
+      requestBody: {
+        required: true,
+        mediaTypes: ["application/json"],
+        schema: {
+          allOf: [
+            { type: "object", properties: { a: { type: "string" } } },
+            { type: "object", properties: { b: { type: "integer" } } },
+          ],
+        },
+      },
+      responses: [{ status: "200" }],
+      security: [],
+    });
+    expect(generateApiCases(m)[0].body).toEqual({ a: "string", b: 0 });
+  });
+});
+
+describe("determinism (c)", () => {
+  it("same model → identical synthesised cases across runs", async () => {
+    const m = await ingestOpenApi(join(fixtures, "petstore.yaml"));
+    // expectedSchema is a passthrough pointer to the (possibly cyclic) model schema; the *synthesised*
+    // output — name/params/body/status — is what must be byte-stable, so compare that projection.
+    const project = (m2: ApiModel) =>
+      JSON.stringify(generateApiCases(m2).map((c) => ({ ...c, expectedSchema: undefined })));
+    expect(project(m)).toEqual(project(m));
+  });
+});
+
+describe("no body / multiple responses (d)", () => {
+  it("a bodyless op has no body and picks the lowest 2xx as success", async () => {
+    const tiny = await ingestOpenApi(join(fixtures, "tiny.json"));
+    const [health] = generateApiCases(tiny);
+    expect(health.body).toBeUndefined();
+    expect(health.expectedStatus).toBe("200");
+  });
+
+  it("with several declared responses, the lowest 2xx is the expected success", () => {
+    const m = model({
+      method: "GET",
+      path: "/x",
+      tags: [],
+      parameters: [],
+      responses: [{ status: "404" }, { status: "204" }, { status: "200" }, { status: "500" }],
+      security: [],
+    });
+    expect(generateApiCases(m)[0].expectedStatus).toBe("200");
+  });
+
+  it("falls back to `default` when no 2xx is declared", () => {
+    const m = model({
+      method: "GET",
+      path: "/x",
+      tags: [],
+      parameters: [],
+      responses: [{ status: "404" }, { status: "default" }],
+      security: [],
+    });
+    expect(generateApiCases(m)[0].expectedStatus).toBe("default");
+  });
+});


### PR DESCRIPTION
Closes #132 · advances #22 (`cairn api` modality) · slice **API-2** (builds on API-1 #139).

## What changed
From the ingested OpenAPI endpoint model (API-1), `cairn api` now generates **one nominal happy-path case per operation** and prints them beneath the model summary.

- **`src/api/cases.ts`** — `generateApiCases(model): ApiCase[]`. A pure, deterministic schema-driven value synthesiser:
  - value precedence `example` → `default` → `enum` → type/`format`;
  - respects `required` (required params/props are present; optional params are omitted — nominal path);
  - `allOf` merge, `oneOf`/`anyOf` first-branch, `format` samples (email/uuid/date/date-time/uri/…);
  - **circular `$ref` guard** (e.g. `Pet.friends: Pet[]` → `[]`) so recursion terminates;
  - pairs each case with the declared success response (**lowest `2xx`**, else `default`, else first).
- **`src/core/modalities/api.ts`** — `renderApiCases()` prints the generated cases; wired after the summary.
- README + CHANGELOG updated.

**No LLM is used** — happy-path values follow mechanically from the schema, which is exactly what makes the output deterministic. The provider abstraction (`StructuredInvoke`) stays available for the fuzzier negative/boundary slices; the DoD's "any LLM use is mockable" holds vacuously here. **No runner** — execution + assertions are API-3.

## How verified
- `npm run lint` · `npm run build` — clean.
- `npm test` — green (the only failures are pre-existing `Playwright browsers are not installed` integration tests, unrelated to this API-only change).
- New `tests/unit/api-cases.test.ts` (9 tests): one case per operation with valid params/body; precedence example/enum/type/format + required-present; allOf/oneOf; determinism; bodyless op; multiple responses (lowest 2xx) + `default` fallback. LLM/network: none to mock.
- `npm run smoke:pack` — 8 checks pass.
- Manual: `cairn api --spec tests/fixtures/api/petstore.yaml` → 4 cases (createPet body, getPet/deletePet path param, listPets bare → 200/201/204).

## Follow-up (out of this slice)
- **API-3 (#138):** runner + assertions + Plune-record write.
- Boundary/negative value coverage (`exclusiveMinimum`, `minLength`, `const`) belongs with the negative-case slice, not this nominal happy-path one.