### PR TITLE
feat: cairn api — runner + response assertions (API-3) (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`cairn api` — runner + response assertions (#133, C1-04 / API-3).** With `--base-url <url>`,
+  `cairn api` now **executes** the generated happy-path cases (API-2) and, per case, asserts the HTTP
+  **status** matches the declared success code and the response **body conforms** to the declared
+  success schema (a minimal structural check: type/required/properties/items/enum/nullable +
+  `allOf`/`oneOf`/`anyOf`). Auth/headers come from **config** (`--header "Name: Value"`, repeatable)
+  layered over **api-scope knowledge** (#92 — `header.*` front-matter in `all`/`api` files, with
+  `${ENV}` resolved so the secret stays in the environment, not the file); config wins. Transient
+  faults (connection reset / timeout / `429` / `5xx`) **retry with backoff** before failing, reusing
+  the tiered-recovery pattern from #90; DNS/refused and `4xx` fail fast. Per-case request/response
+  **evidence** (sensitive headers redacted) is written to `runs/api-<id>/api-evidence.json`, and any
+  failed assertion exits non-zero. Network is fully injectable (mocked in tests). **The rich report /
+  Plune-record write are API-4.**
+
 - **`cairn api` — baseline happy-path cases (#132, C1-04 / API-2).** From the ingested endpoint model,
   `cairn api` now generates **one nominal happy-path case per operation**: required params and a
   request body are synthesised straight from the (dereferenced) JSON schema — respecting

--- a/docs/runbooks/run-api-cases.md
+++ b/docs/runbooks/run-api-cases.md
@@ -1,0 +1,45 @@
+# Runbook: run API cases against a base URL (API-3)
+
+> Execute the happy-path cases `cairn api` generates from an OpenAPI spec and assert each response
+> (status + schema). Builds on API-1 (ingest) / API-2 (case generation). The rich report is API-4.
+
+## Steps
+1. **Generate only (no execution)** — sanity-check the cases first:
+   ```
+   cairn api --spec ./openapi.yaml
+   ```
+   → prints the model summary + one happy-path case per operation.
+2. **Run + assert** — add `--base-url`:
+   ```
+   cairn api --spec ./openapi.yaml --base-url https://api.example.com/v1
+   ```
+   Each case is sent; per case Cairn asserts the **status** matches the declared success code and the
+   **response body** conforms to the declared success schema. Any failed assertion → non-zero exit.
+
+## Auth / headers (nothing hardcoded)
+- **Config (per run):** `--header "Authorization: Bearer $TOKEN"` — repeatable. Config headers win.
+- **Knowledge (#92):** in an `api`/`all`-scope file under `./knowledge/` (e.g. `knowledge/api/auth.md`),
+  declare headers in front-matter:
+  ```
+  ---
+  scope: all
+  header.Authorization: Bearer ${API_TOKEN}
+  header.X-Api-Key: ${API_KEY}
+  ---
+  ```
+  `${ENV}` resolves from the environment, so the **secret lives in env, never in the committed file**.
+  An `endpoint:`-keyed file only applies when its key is contained in the base URL.
+
+## Output
+- **Evidence:** `runs/api-<id>/api-evidence.json` (override the dir with `--out`) — per-case request +
+  response, status/schema verdicts, attempt count. **Sensitive headers are redacted** (`***`).
+- **Console:** `N/M case(s) passed`, then a ✓/✗ line per case with the status and any schema errors.
+
+## Robustness
+- **Transient faults** (connection reset / timeout / `429` / `5xx`) retry with backoff before failing,
+  reusing the tiered-recovery pattern (#90); DNS/refused and `4xx` fail fast (no retry).
+- **Per-request timeout:** 30s (an abort counts as transient).
+
+## Do NOT
+- Do NOT commit `.env` or any knowledge file containing a literal token — use `${ENV}` placeholders.
+- The schema check is structural (happy-path conformance), not a strict contract validator.

--- a/src/api/runner.ts
+++ b/src/api/runner.ts
@@ -1,0 +1,291 @@
+/**
+ * C1-04 / API-3 (#133) — execute the generated happy-path cases (API-2) against a configurable
+ * base URL and assert each response.
+ *
+ * Per case we: build the request (path/query/header/cookie params + auth headers from config and
+ * api-scope knowledge, #92), send it, assert the HTTP status matches the case's declared success
+ * code, and assert the response body conforms to the declared success schema. Request/response
+ * evidence is captured per case (with sensitive headers redacted) for the report slice (API-4).
+ *
+ * Transient transport faults (connection reset / timeout) and transient responses (429 / 5xx) reuse
+ * the tiered-recovery pattern from BORROW-02 (#90) / `retryInvoke`: a positively-recognised transient
+ * fault earns a cheap backoff + retry of the SAME request; everything else fails fast (we never mask a
+ * real 4xx / assertion failure behind a retry). `fetch` is injected so tests never touch the network.
+ */
+import type { ApiCase } from "./cases.js";
+
+/** Minimal response shape we read — satisfied by the global `fetch` Response. */
+export interface ResponseLike {
+  status: number;
+  headers: { get(name: string): string | null };
+  text(): Promise<string>;
+}
+export type FetchLike = (url: string, init: RequestInit) => Promise<ResponseLike>;
+
+/** Auth/headers applied to every request (assembled from config + api-scope knowledge). */
+export interface ApiAuth {
+  headers: Record<string, string>;
+}
+
+export interface RunnerOptions {
+  /** Configured base URL the relative case paths are resolved against. */
+  baseUrl: string;
+  auth?: ApiAuth;
+  /** Injected for tests; defaults to the global `fetch`. */
+  fetch?: FetchLike;
+  /** Transient retries before giving up (default 2 — mirrors #90's nav ladder). */
+  retries?: number;
+  /** Backoff base (ms); delay = baseDelayMs * 2**attempt (default 300). */
+  baseDelayMs?: number;
+  /** Per-request timeout (ms); 0 disables it (default 30s). */
+  timeoutMs?: number;
+}
+
+/** What we sent and got back for one case — the evidence the report (API-4) renders. */
+export interface ApiCaseResult {
+  name: string;
+  method: string;
+  url: string;
+  request: { headers: Record<string, string>; body?: unknown };
+  response?: { status: number; bodyText: string; json?: unknown };
+  /** How many sends it took (1 = first try; >1 = a transient retry happened). */
+  attempts: number;
+  expectedStatus: string;
+  /** status matched the declared success code. */
+  statusOk: boolean;
+  /** body conformed to the declared success schema (true when no schema is declared). */
+  schemaOk: boolean;
+  schemaErrors: string[];
+  /** Transport error after retries were exhausted (no response received). */
+  error?: string;
+  /** statusOk && schemaOk && no transport error. */
+  passed: boolean;
+}
+
+/** Header names whose values are secrets — masked in captured evidence so tokens never hit disk/logs. */
+const SENSITIVE = /authorization|cookie|api[-_]?key|token|secret|password/i;
+
+function redactHeaders(headers: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) out[k] = SENSITIVE.test(k) ? "***" : v;
+  return out;
+}
+
+/**
+ * Transient transport faults worth a backoff + retry. Mirrors #90's stance: only positively-recognised
+ * transient errors retry; unknown faults and DNS/refused (a real misconfig) fail fast.
+ */
+const TRANSIENT_THROW = /ECONNRESET|ETIMEDOUT|EAI_AGAIN|socket hang up|network.?changed|the operation was aborted|aborted|timed? ?out/i;
+
+/** A response status is transient (worth a retry) when it's a 429 or any 5xx. */
+function isTransientStatus(status: number): boolean {
+  return status === 429 || (status >= 500 && status <= 599);
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Execute every case against `baseUrl`, asserting status + schema; returns per-case evidence. */
+export async function runApiCases(cases: ApiCase[], opts: RunnerOptions): Promise<ApiCaseResult[]> {
+  const results: ApiCaseResult[] = [];
+  for (const c of cases) results.push(await runOne(c, opts));
+  return results;
+}
+
+async function runOne(c: ApiCase, opts: RunnerOptions): Promise<ApiCaseResult> {
+  const doFetch = opts.fetch ?? (globalThis.fetch as unknown as FetchLike);
+  const retries = opts.retries ?? 2;
+  const baseDelayMs = opts.baseDelayMs ?? 300;
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+
+  const url = buildUrl(opts.baseUrl, c);
+  const headers = buildHeaders(c, opts.auth);
+  const hasBody = c.body !== undefined;
+  const init: RequestInit = {
+    method: c.method,
+    headers,
+    ...(hasBody ? { body: JSON.stringify(c.body) } : {}),
+  };
+
+  const evidence: ApiCaseResult = {
+    name: c.name,
+    method: c.method,
+    url,
+    request: { headers: redactHeaders(headers), ...(hasBody ? { body: c.body } : {}) },
+    attempts: 0,
+    expectedStatus: c.expectedStatus,
+    statusOk: false,
+    schemaOk: false,
+    schemaErrors: [],
+    passed: false,
+  };
+
+  // Tiered recovery ladder (#90): send → transient (throw or 429/5xx) with retries left → backoff + resend
+  // the SAME request → else stop. A non-transient response (4xx, or a status mismatch) is a real result.
+  let res: ResponseLike | undefined;
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    evidence.attempts = attempt + 1;
+    try {
+      res = await withTimeout(doFetch, url, init, timeoutMs);
+      if (isTransientStatus(res.status) && attempt < retries) {
+        await sleep(baseDelayMs * 2 ** attempt);
+        continue; // transient response — retry the same request
+      }
+      break; // a result we can assert on
+    } catch (e) {
+      lastErr = e;
+      const msg = e instanceof Error ? e.message : String(e);
+      if (attempt === retries || !TRANSIENT_THROW.test(msg)) break; // exhausted or fatal → give up
+      await sleep(baseDelayMs * 2 ** attempt);
+    }
+  }
+
+  if (!res) {
+    evidence.error = lastErr instanceof Error ? lastErr.message : String(lastErr);
+    return evidence; // no response → not passed
+  }
+
+  const bodyText = await res.text();
+  const json = parseJson(bodyText);
+  evidence.response = { status: res.status, bodyText, ...(json.ok ? { json: json.value } : {}) };
+
+  evidence.statusOk = statusMatches(c.expectedStatus, res.status);
+
+  if (c.expectedSchema === undefined) {
+    evidence.schemaOk = true; // nothing declared to conform to
+  } else if (!json.ok) {
+    evidence.schemaOk = false;
+    evidence.schemaErrors = [`response body is not valid JSON (${json.error})`];
+  } else {
+    evidence.schemaErrors = validateAgainstSchema(json.value, c.expectedSchema);
+    evidence.schemaOk = evidence.schemaErrors.length === 0;
+  }
+
+  evidence.passed = evidence.statusOk && evidence.schemaOk;
+  return evidence;
+}
+
+/**
+ * A status matches when it equals the declared code. Two OpenAPI forms beyond an exact code:
+ * `default` accepts any non-error (<400) status, and a range like `2XX` matches its whole class.
+ */
+function statusMatches(expected: string, actual: number): boolean {
+  if (expected === "default") return actual < 400;
+  if (/^\dXX$/i.test(expected)) return String(actual)[0] === expected[0];
+  return String(actual) === expected;
+}
+
+async function withTimeout(doFetch: FetchLike, url: string, init: RequestInit, timeoutMs: number): Promise<ResponseLike> {
+  if (timeoutMs <= 0) return doFetch(url, init);
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    return await doFetch(url, { ...init, signal: ctrl.signal });
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function parseJson(text: string): { ok: true; value: unknown } | { ok: false; error: string } {
+  if (text.trim() === "") return { ok: true, value: undefined }; // empty body (e.g. 204) is valid
+  try {
+    return { ok: true, value: JSON.parse(text) };
+  } catch (e) {
+    return { ok: false, error: (e as Error).message };
+  }
+}
+
+/** Build the request URL: substitute `{path}` params, append `query` params, join onto the base URL. */
+function buildUrl(baseUrl: string, c: ApiCase): string {
+  let path = c.path;
+  for (const [k, v] of Object.entries(c.params.path)) {
+    path = path.replace(`{${k}}`, encodeURIComponent(String(v)));
+  }
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(c.params.query)) qs.append(k, String(v));
+  const query = qs.toString();
+  const base = baseUrl.replace(/\/+$/, "");
+  const sep = path.startsWith("/") ? "" : "/";
+  return `${base}${sep}${path}${query ? `?${query}` : ""}`;
+}
+
+/** Merge auth headers, case header-params and a Cookie header from cookie-params; add JSON content-type. */
+function buildHeaders(c: ApiCase, auth?: ApiAuth): Record<string, string> {
+  const headers: Record<string, string> = { ...(auth?.headers ?? {}) };
+  for (const [k, v] of Object.entries(c.params.header)) headers[k] = String(v);
+  const cookies = Object.entries(c.params.cookie);
+  if (cookies.length) headers["Cookie"] = cookies.map(([k, v]) => `${k}=${v}`).join("; ");
+  if (c.body !== undefined && !Object.keys(headers).some((h) => h.toLowerCase() === "content-type")) {
+    headers["Content-Type"] = "application/json";
+  }
+  return headers;
+}
+
+/**
+ * Minimal JSON-Schema instance check for happy-path response conformance. The schema is already
+ * dereferenced (API-1), so there are no `$ref`s to follow. Returns path-qualified error strings.
+ *
+ * ponytail: covers the keywords real success-response schemas use — type (incl. 3.1 type-arrays +
+ * 3.0 `nullable`), required, properties, items, enum, and allOf/oneOf/anyOf composition. It does NOT
+ * enforce format/pattern/min/max/additionalProperties — upgrade to ajv if strict contract checks are
+ * ever needed (none of the happy-path slices require it).
+ */
+export function validateAgainstSchema(value: unknown, schema: unknown, path = "$"): string[] {
+  if (!schema || typeof schema !== "object") return [];
+  const s = schema as Record<string, unknown>;
+
+  if (Array.isArray(s.allOf)) return s.allOf.flatMap((sub) => validateAgainstSchema(value, sub, path));
+  for (const key of ["oneOf", "anyOf"] as const) {
+    const branches = s[key];
+    if (Array.isArray(branches) && branches.length) {
+      const anyOk = branches.some((b) => validateAgainstSchema(value, b, path).length === 0);
+      return anyOk ? [] : [`${path}: matches none of ${key}`];
+    }
+  }
+
+  if (s.enum && Array.isArray(s.enum)) {
+    return s.enum.some((e) => deepEqual(e, value)) ? [] : [`${path}: ${JSON.stringify(value)} not in enum`];
+  }
+
+  const types = normaliseTypes(s);
+  if (types.length === 0) return []; // untyped schema — nothing to check
+  if (value === null) return types.includes("null") ? [] : [`${path}: null is not ${types.join("|")}`];
+
+  const actual = jsonType(value);
+  if (!types.includes(actual)) return [`${path}: expected ${types.join("|")}, got ${actual}`];
+
+  const errors: string[] = [];
+  if (actual === "object") {
+    const obj = value as Record<string, unknown>;
+    for (const req of (s.required as string[]) ?? []) {
+      if (!(req in obj)) errors.push(`${path}.${req}: required property missing`);
+    }
+    const props = (s.properties as Record<string, unknown>) ?? {};
+    for (const [k, sub] of Object.entries(props)) {
+      if (k in obj) errors.push(...validateAgainstSchema(obj[k], sub, `${path}.${k}`));
+    }
+  } else if (actual === "array" && s.items) {
+    (value as unknown[]).forEach((item, i) => errors.push(...validateAgainstSchema(item, s.items, `${path}[${i}]`)));
+  }
+  return errors;
+}
+
+/** Declared types as a list, folding OpenAPI 3.0 `nullable: true` into an implicit `null` member. */
+function normaliseTypes(s: Record<string, unknown>): string[] {
+  const raw = s.type;
+  const list = Array.isArray(raw) ? raw : typeof raw === "string" ? [raw] : [];
+  if (s.nullable === true && !list.includes("null")) list.push("null");
+  // `integer` is satisfied by a JSON number — collapse it so jsonType() comparison lines up.
+  return list.map((t) => (t === "integer" ? "number" : t)) as string[];
+}
+
+function jsonType(v: unknown): string {
+  if (v === null) return "null";
+  if (Array.isArray(v)) return "array";
+  if (Number.isInteger(v as number) || typeof v === "number") return "number";
+  return typeof v; // string | boolean | object | undefined
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -129,8 +129,15 @@ export function buildProgram(): Command {
   // OpenAPI 3.x spec into the internal endpoint model and prints a summary — no generation yet.
   program
     .command("api")
-    .description("Ingest an OpenAPI 3.x spec into the endpoint model (API-1: parse + summary, no code yet)")
+    .description("Generate API tests from an OpenAPI 3.x spec; with --base-url, run them and assert responses")
     .requiredOption("--spec <path|url>", "OpenAPI 3.x spec — JSON or YAML, a local file path or an http(s) URL")
+    .option("--base-url <url>", "API-3: base URL to execute the generated cases against (assert status + schema)")
+    .option(
+      "--header <header>",
+      "API-3: extra request header 'Name: Value' (repeatable); overrides knowledge-supplied headers",
+      (val: string, prev: string[] = []) => [...prev, val],
+    )
+    .option("--out <dir>", "API-3: where to write run evidence (default runs/api-<id>/)")
     .action(async (opts: Record<string, unknown>) => {
       await runModality("api", opts);
     });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -138,6 +138,7 @@ export function buildProgram(): Command {
       (val: string, prev: string[] = []) => [...prev, val],
     )
     .option("--out <dir>", "API-3: where to write run evidence (default runs/api-<id>/)")
+    .option("--knowledge-dir <dir>", "API-3: dir holding api-scope auth/headers knowledge (default knowledge/)")
     .action(async (opts: Record<string, unknown>) => {
       await runModality("api", opts);
     });

--- a/src/core/modalities/api.ts
+++ b/src/core/modalities/api.ts
@@ -3,16 +3,56 @@
  *
  * API-1 (#22): register the command and ingest an OpenAPI v3 spec into the internal model.
  * API-2 (#132): from that model, generate one nominal happy-path case per operation and print them.
- * Still NO runner / no Plune write — that is API-3 (#138).
+ * API-3 (#133): with `--base-url`, execute those cases (auth from config + api-scope knowledge),
+ *   assert status + response-schema per case, and capture request/response evidence to disk.
  */
-import { resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
 import { ingestOpenApi, type ApiModel } from "../../api/openapi.js";
 import { generateApiCases, type ApiCase } from "../../api/cases.js";
+import { runApiCases, type ApiCaseResult } from "../../api/runner.js";
+import { loadApiCreds } from "../../knowledge/index.js";
+import { defaultRunsBaseDir } from "../../fs/run-dir.js";
 import type { Modality, ModalityContext } from "../modality.js";
 
 /** Parsed flags for `cairn api` (mirrors the command's option definitions). */
 interface ApiFlags {
   spec?: string;
+  /** API-3: configured base URL to run cases against. Absent → ingest + generate only (API-1/2). */
+  baseUrl?: string;
+  /** API-3: extra request headers `Name: Value` (repeatable); override knowledge-supplied headers. */
+  header?: string[];
+  /** API-3: where to write run evidence (default runs/api-<id>/). */
+  out?: string;
+  /** API-3: knowledge dir for api-scope auth/headers (#92). Default `knowledge`. */
+  knowledgeDir?: string;
+}
+
+/** Parse repeated `--header "Name: Value"` flags into a header map (config auth). */
+function parseHeaderFlags(flags: string[] | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const h of flags ?? []) {
+    const i = h.indexOf(":");
+    if (i > 0) out[h.slice(0, i).trim()] = h.slice(i + 1).trim();
+  }
+  return out;
+}
+
+/** Render the runner's per-case verdicts — the verifiable artifact of API-3. */
+export function renderApiRun(results: ApiCaseResult[], evidencePath: string): string[] {
+  const passed = results.filter((r) => r.passed).length;
+  const lines = ["", "=== Run results (status + schema asserts) ===", `${passed}/${results.length} case(s) passed`];
+  for (const r of results) {
+    const mark = r.passed ? "✓" : "✗";
+    const got = r.error ? `error: ${r.error}` : `${r.response?.status ?? "—"} (want ${r.expectedStatus})`;
+    const retries = r.attempts > 1 ? ` ·${r.attempts} attempts` : "";
+    lines.push(`  ${mark} ${r.name} → ${got}${retries}`);
+    if (!r.statusOk && !r.error) lines.push(`      status mismatch`);
+    for (const e of r.schemaErrors) lines.push(`      schema: ${e}`);
+  }
+  lines.push("", `Evidence: ${evidencePath}`);
+  return lines;
 }
 
 /** Is this a remote spec we hand to swagger-parser as-is, vs a local file path we resolve? */
@@ -54,7 +94,6 @@ export function renderApiCases(cases: ApiCase[]): string[] {
     if (Object.keys(sent).length) lines.push(`      ${JSON.stringify(sent)}`);
   }
   lines.push("");
-  lines.push("Note: cases only (API-2). The runner + assertions land in API-3 (#138).");
   return lines;
 }
 
@@ -81,6 +120,29 @@ export const apiModality: Modality = {
       return;
     }
     for (const line of renderApiSummary(model, source)) ctx.out(`${line}\n`);
-    for (const line of renderApiCases(generateApiCases(model))) ctx.out(`${line}\n`);
+    const cases = generateApiCases(model);
+    for (const line of renderApiCases(cases)) ctx.out(`${line}\n`);
+
+    // API-3: without --base-url we stop at the generated cases (API-1/2 behaviour, unchanged).
+    if (!opts.baseUrl) {
+      ctx.out("Note: cases only. Pass --base-url <url> to execute them and assert responses (API-3).\n");
+      return;
+    }
+
+    // Auth/headers: api-scope knowledge (#92) as the base, config --header flags on top (config wins).
+    const knowledgeDir = resolve(opts.knowledgeDir ?? "knowledge");
+    const fromKnowledge = await loadApiCreds(knowledgeDir, { scope: "api", endpoint: opts.baseUrl });
+    const headers = { ...fromKnowledge, ...parseHeaderFlags(opts.header) };
+
+    ctx.err(`▸ Running ${cases.length} case(s) against ${opts.baseUrl}…\n`);
+    const results = await runApiCases(cases, { baseUrl: opts.baseUrl, auth: { headers } });
+
+    const outDir = opts.out ? resolve(opts.out) : join(defaultRunsBaseDir(), `api-${randomUUID()}`);
+    await mkdir(outDir, { recursive: true });
+    const evidencePath = join(outDir, "api-evidence.json");
+    await writeFile(evidencePath, JSON.stringify(results, null, 2), "utf8");
+
+    for (const line of renderApiRun(results, evidencePath)) ctx.out(`${line}\n`);
+    if (results.some((r) => !r.passed)) process.exitCode = 1; // any failed assertion → non-zero exit
   },
 };

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -17,16 +17,18 @@ export interface KnowledgeQuery {
   endpoint?: string;
 }
 
-/** Parsed front-matter we care about: an explicit scope + the match key (`url || path || endpoint`). */
+/** Parsed front-matter we care about: an explicit scope, the match key, and api auth headers. */
 interface Frontmatter {
   scope?: KnowledgeScope;
   /** First present of `url:` / `path:` / `endpoint:` — the pattern matched against the run target. */
   pattern?: string;
+  /** `header.<Name>:` keys — request headers the API runner (#133) applies. `${ENV}` is resolved. */
+  headers: Record<string, string>;
 }
 
 function parseFrontmatter(raw: string): Frontmatter {
   const fm = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!fm?.[1]) return {};
+  if (!fm?.[1]) return { headers: {} };
   const lines = fm[1].split(/\r?\n/).map((l) => l.trim());
   const value = (key: string): string | undefined => {
     const line = lines.find((l) => new RegExp(`^${key}:`).test(l));
@@ -37,7 +39,19 @@ function parseFrontmatter(raw: string): Frontmatter {
   const scope = rawScope === "web" || rawScope === "api" || rawScope === "all" ? rawScope : undefined;
   // Key precedence: url || path || endpoint (a single file declares one of them).
   const pattern = value("url") ?? value("path") ?? value("endpoint");
-  return { scope, pattern };
+
+  // `header.<Name>: <value>` — collect auth/headers; resolve `${ENV}` so secrets stay out of the file.
+  const headers: Record<string, string> = {};
+  for (const l of lines) {
+    const m = l.match(/^header\.([^:]+):\s*(.*)$/);
+    if (m) headers[m[1]!.trim()] = expandEnv(m[2]!.trim());
+  }
+  return { scope, pattern, headers };
+}
+
+/** Replace `${VAR}` with `process.env.VAR` (empty if unset) so credentials live in env, not files. */
+function expandEnv(v: string): string {
+  return v.replace(/\$\{([^}]+)\}/g, (_, name) => process.env[name] ?? "");
 }
 
 function stripFrontmatter(raw: string): string {
@@ -66,6 +80,32 @@ async function mdFiles(dir: string): Promise<string[]> {
  * as before. Injected into the design prompt → the bot knows facts not visible in the snapshot.
  */
 export async function loadKnowledge(dir: string, query: KnowledgeQuery = {}): Promise<string> {
+  const parts: string[] = [];
+  for (const { raw } of await matchingFiles(dir, query)) {
+    const body = stripFrontmatter(raw);
+    if (body.length > 0) parts.push(body);
+  }
+  return parts.join("\n\n");
+}
+
+/**
+ * Auth/headers for an API run, gathered from matching api/all-scope knowledge (#92) — the runner (#133)
+ * merges these under the user's config headers (config wins). `${ENV}` placeholders in a file resolve
+ * from `process.env`, so the credential itself lives in the environment, never in the committed file.
+ */
+export async function loadApiCreds(dir: string, query: KnowledgeQuery = {}): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {};
+  for (const { fm } of await matchingFiles(dir, { ...query, scope: "api" })) {
+    Object.assign(headers, fm.headers); // later files override earlier — deterministic dir order
+  }
+  return headers;
+}
+
+/** Scan base (web) + api subdir, return the files whose scope + key match this run, with parsed front-matter. */
+async function matchingFiles(
+  dir: string,
+  query: KnowledgeQuery,
+): Promise<{ raw: string; fm: Frontmatter }[]> {
   const runScope: RunScope = query.scope ?? "web";
   const target = (runScope === "api" ? query.endpoint : query.url) ?? "";
 
@@ -75,15 +115,14 @@ export async function loadKnowledge(dir: string, query: KnowledgeQuery = {}): Pr
     ...(await mdFiles(join(dir, "api"))).map((file) => ({ dir: join(dir, "api"), file, dirDefault: "api" as const })),
   ];
 
-  const parts: string[] = [];
+  const out: { raw: string; fm: Frontmatter }[] = [];
   for (const c of candidates) {
     const raw = await readFile(join(c.dir, c.file), "utf8");
-    const { scope, pattern } = parseFrontmatter(raw);
-    const fileScope = scope ?? c.dirDefault;
+    const fm = parseFrontmatter(raw);
+    const fileScope = fm.scope ?? c.dirDefault;
     if (fileScope !== "all" && fileScope !== runScope) continue; // wrong scope for this run
-    if (pattern && !target.includes(pattern)) continue; // keyed file: target must contain the pattern
-    const body = stripFrontmatter(raw);
-    if (body.length > 0) parts.push(body);
+    if (fm.pattern && !target.includes(fm.pattern)) continue; // keyed file: target must contain the pattern
+    out.push({ raw, fm });
   }
-  return parts.join("\n\n");
+  return out;
 }

--- a/tests/unit/__snapshots__/cli-modalities.test.ts.snap
+++ b/tests/unit/__snapshots__/cli-modalities.test.ts.snap
@@ -14,8 +14,8 @@ Commands:
                          screenshot
   explore [options]      Explore a page and generate methodology-based test
                          cases (Sprint 2: no code)
-  api [options]          Ingest an OpenAPI 3.x spec into the endpoint model
-                         (API-1: parse + summary, no code yet)
+  api [options]          Generate API tests from an OpenAPI 3.x spec; with
+                         --base-url, run them and assert responses
   dataset-add [options]  Add a run (study.json) to an experiment dataset
   experiment [options]   Compare prompt versions on a dataset (B2
                          self-improvement)

--- a/tests/unit/api-modality.test.ts
+++ b/tests/unit/api-modality.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
+import { mkdtemp, mkdir, writeFile, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 
 /**
  * C1-04 / API-1 (#22): the `cairn api` command — registration, the parsed-model summary, the
@@ -55,6 +57,80 @@ describe("cairn api command (real ingest)", () => {
     await buildProgram().parseAsync(["node", "cairn", "api", "--spec", join(fixtures, "malformed.yaml")]);
     expect(errChunks.join("")).toMatch(/✗ Could not read OpenAPI spec/);
     expect(process.exitCode).toBe(1);
+  });
+});
+
+describe("cairn api --base-url run path (API-3, mocked network)", () => {
+  let unstub: (() => void) | undefined;
+  afterEach(() => {
+    unstub?.();
+    unstub = undefined;
+    vi.unstubAllGlobals();
+  });
+
+  /** Stub global fetch with a per-method canned response; capture the headers each call received. */
+  function stubFetch(): { headers: Record<string, string>[] } {
+    const headers: Record<string, string>[] = [];
+    const fn = vi.fn(async (_url: string, init: RequestInit) => {
+      headers.push({ ...(init.headers as Record<string, string>) });
+      const status = init.method === "POST" ? 201 : init.method === "DELETE" ? 204 : 200;
+      const body = init.method === "GET" ? (_url.includes("{") || _url.endsWith("/pets") ? "[]" : "{}") : "";
+      return { status, headers: { get: () => null }, text: async () => body } as unknown as Response;
+    });
+    vi.stubGlobal("fetch", fn);
+    return { headers };
+  }
+
+  it("runs every case, merges config-over-knowledge auth, writes redacted evidence, exits 0", async () => {
+    const kdir = await mkdtemp(join(tmpdir(), "qa-api-know-"));
+    const out = await mkdtemp(join(tmpdir(), "qa-api-out-"));
+    try {
+      await mkdir(join(kdir, "api"), { recursive: true });
+      // api-scope creds: a shared header + one that config will override.
+      await writeFile(join(kdir, "api", "auth.md"), "---\nscope: all\nheader.X-Shared: from-knowledge\nheader.X-Key: KNOWLEDGE\n---\ncreds");
+
+      const { headers } = stubFetch();
+      const { buildProgram } = await import("../../src/cli/index.js");
+      await buildProgram().parseAsync([
+        "node", "cairn", "api", "--spec", join(fixtures, "petstore.yaml"),
+        "--base-url", "https://api.test", "--knowledge-dir", kdir, "--out", out,
+        "--header", "Authorization: Bearer SECRET", "--header", "X-Key: CONFIG",
+      ]);
+
+      expect(headers).toHaveLength(4); // one request per generated case
+      const sent = headers[0]!;
+      expect(sent["X-Shared"]).toBe("from-knowledge"); // knowledge header applied
+      expect(sent["X-Key"]).toBe("CONFIG"); // config overrides knowledge on the same header
+      expect(sent["Authorization"]).toBe("Bearer SECRET"); // config-only header applied
+
+      const out0 = outChunks.join("");
+      expect(out0).toContain("4/4 case(s) passed");
+      expect(process.exitCode ?? 0).toBe(0);
+
+      const evidence = JSON.parse(await readFile(join(out, "api-evidence.json"), "utf8")) as { request: { headers: Record<string, string> } }[];
+      expect(evidence).toHaveLength(4);
+      expect(evidence[0]!.request.headers["Authorization"]).toBe("***"); // secret redacted on disk
+    } finally {
+      await rm(kdir, { recursive: true, force: true });
+      await rm(out, { recursive: true, force: true });
+    }
+  });
+
+  it("exits non-zero when a case fails its assertion", async () => {
+    const out = await mkdtemp(join(tmpdir(), "qa-api-out2-"));
+    try {
+      // 404 is non-transient → fails fast (no retry/backoff), keeping the test quick.
+      vi.stubGlobal("fetch", vi.fn(async () => ({ status: 404, headers: { get: () => null }, text: async () => "" }) as unknown as Response));
+      const { buildProgram } = await import("../../src/cli/index.js");
+      await buildProgram().parseAsync([
+        "node", "cairn", "api", "--spec", join(fixtures, "petstore.yaml"),
+        "--base-url", "https://api.test", "--out", out,
+      ]);
+      expect(outChunks.join("")).toMatch(/0\/4 case\(s\) passed/);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      await rm(out, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/unit/api-runner.test.ts
+++ b/tests/unit/api-runner.test.ts
@@ -95,10 +95,14 @@ describe("response-schema conformance (b)", () => {
     expect(r!.schemaErrors[0]).toMatch(/not valid JSON/);
   });
 
-  it("validateAgainstSchema handles enums, arrays, nullable and composition", () => {
+  it("validateAgainstSchema handles enums, arrays, integers, nullable and composition", () => {
     expect(validateAgainstSchema(["a", "b"], { type: "array", items: { type: "string" } })).toEqual([]);
+    expect(validateAgainstSchema([1, "x"], { type: "array", items: { type: "integer" } })).toEqual([expect.stringContaining("[1]: expected number")]);
     expect(validateAgainstSchema("z", { enum: ["a", "b"] })).toEqual([expect.stringContaining("not in enum")]);
+    expect(validateAgainstSchema(7, { type: "integer" })).toEqual([]); // integer satisfied by a JSON number
     expect(validateAgainstSchema(null, { type: "string", nullable: true })).toEqual([]);
+    expect(validateAgainstSchema(null, { type: "string" })).toEqual([expect.stringContaining("null is not")]);
+    expect(validateAgainstSchema({ a: { b: 1 } }, { type: "object", properties: { a: { type: "object", properties: { b: { type: "string" } } } } })).toEqual([expect.stringContaining("$.a.b: expected string")]);
     expect(validateAgainstSchema(5, { oneOf: [{ type: "string" }, { type: "number" }] })).toEqual([]);
     expect(validateAgainstSchema(true, { oneOf: [{ type: "string" }, { type: "number" }] })).toEqual([expect.stringContaining("matches none")]);
   });

--- a/tests/unit/api-runner.test.ts
+++ b/tests/unit/api-runner.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import { runApiCases, validateAgainstSchema, type FetchLike, type ResponseLike } from "../../src/api/runner.js";
+import type { ApiCase } from "../../src/api/cases.js";
+
+/**
+ * C1-04 / API-3 (#133): the runner executes generated cases against a base URL and asserts each
+ * response (status + schema). Network is injected (`fetch`), never real. Covers: status assertion,
+ * schema conformance (valid/invalid), auth/header application, transient retry (#90) then fail, and
+ * captured request/response evidence.
+ */
+
+/** A canned response, and a fetch that records every call it receives. */
+function fakeFetch(responses: Array<ResponseLike | Error>): { fetch: FetchLike; calls: { url: string; init: RequestInit }[] } {
+  const calls: { url: string; init: RequestInit }[] = [];
+  let i = 0;
+  const fetch: FetchLike = async (url, init) => {
+    calls.push({ url, init });
+    const r = responses[Math.min(i++, responses.length - 1)];
+    if (r instanceof Error) throw r;
+    return r;
+  };
+  return { fetch, calls };
+}
+
+function res(status: number, body: unknown = ""): ResponseLike {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  return { status, headers: { get: () => null }, text: async () => text };
+}
+
+function caseOf(over: Partial<ApiCase> = {}): ApiCase {
+  return {
+    name: "getPet",
+    method: "GET",
+    path: "/pets/{id}",
+    params: { path: { id: "7" }, query: {}, header: {}, cookie: {} },
+    expectedStatus: "200",
+    ...over,
+  };
+}
+
+describe("runApiCases — execution + status assertion (a)", () => {
+  it("substitutes path/query params, sends the request, and asserts the declared status", async () => {
+    const { fetch, calls } = fakeFetch([res(200, { id: "7" })]);
+    const c = caseOf({ params: { path: { id: "7" }, query: { detail: "full" }, header: {}, cookie: {} } });
+    const [r] = await runApiCases([c], { baseUrl: "https://api.test/v1/", fetch });
+
+    expect(calls[0]!.url).toBe("https://api.test/v1/pets/7?detail=full");
+    expect(calls[0]!.init.method).toBe("GET");
+    expect(r!.statusOk).toBe(true);
+    expect(r!.passed).toBe(true);
+    expect(r!.attempts).toBe(1);
+  });
+
+  it("fails the status assertion when the code does not match", async () => {
+    const { fetch } = fakeFetch([res(404, { error: "nope" })]);
+    const [r] = await runApiCases([caseOf()], { baseUrl: "https://api.test", fetch });
+    expect(r!.statusOk).toBe(false);
+    expect(r!.passed).toBe(false);
+    expect(r!.attempts).toBe(1); // 4xx is NOT transient — no retry
+  });
+
+  it("sends a JSON body with a content-type for body cases", async () => {
+    const { fetch, calls } = fakeFetch([res(201, { id: "x" })]);
+    const c = caseOf({ method: "POST", path: "/pets", expectedStatus: "201", body: { name: "Rex" }, params: { path: {}, query: {}, header: {}, cookie: {} } });
+    await runApiCases([c], { baseUrl: "https://api.test", fetch });
+    expect(calls[0]!.init.body).toBe(JSON.stringify({ name: "Rex" }));
+    expect((calls[0]!.init.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+  });
+});
+
+describe("response-schema conformance (b)", () => {
+  const schema = { type: "object", required: ["id", "name"], properties: { id: { type: "string" }, name: { type: "string" } } };
+
+  it("passes when the body conforms to the declared success schema", async () => {
+    const { fetch } = fakeFetch([res(200, { id: "7", name: "Rex" })]);
+    const [r] = await runApiCases([caseOf({ expectedSchema: schema })], { baseUrl: "https://api.test", fetch });
+    expect(r!.schemaOk).toBe(true);
+    expect(r!.passed).toBe(true);
+  });
+
+  it("fails (with errors) when a required field is missing or mistyped", async () => {
+    const { fetch } = fakeFetch([res(200, { id: 7 })]);
+    const [r] = await runApiCases([caseOf({ expectedSchema: schema })], { baseUrl: "https://api.test", fetch });
+    expect(r!.schemaOk).toBe(false);
+    expect(r!.schemaErrors).toEqual(
+      expect.arrayContaining([expect.stringContaining("name: required property missing"), expect.stringContaining("expected string, got number")]),
+    );
+    expect(r!.passed).toBe(false);
+  });
+
+  it("flags a non-JSON body when a schema is expected", async () => {
+    const { fetch } = fakeFetch([res(200, "<html>not json</html>")]);
+    const [r] = await runApiCases([caseOf({ expectedSchema: schema })], { baseUrl: "https://api.test", fetch });
+    expect(r!.schemaOk).toBe(false);
+    expect(r!.schemaErrors[0]).toMatch(/not valid JSON/);
+  });
+
+  it("validateAgainstSchema handles enums, arrays, nullable and composition", () => {
+    expect(validateAgainstSchema(["a", "b"], { type: "array", items: { type: "string" } })).toEqual([]);
+    expect(validateAgainstSchema("z", { enum: ["a", "b"] })).toEqual([expect.stringContaining("not in enum")]);
+    expect(validateAgainstSchema(null, { type: "string", nullable: true })).toEqual([]);
+    expect(validateAgainstSchema(5, { oneOf: [{ type: "string" }, { type: "number" }] })).toEqual([]);
+    expect(validateAgainstSchema(true, { oneOf: [{ type: "string" }, { type: "number" }] })).toEqual([expect.stringContaining("matches none")]);
+  });
+});
+
+describe("auth / headers application (c)", () => {
+  it("applies configured auth headers to every request", async () => {
+    const { fetch, calls } = fakeFetch([res(200, {})]);
+    await runApiCases([caseOf()], { baseUrl: "https://api.test", fetch, auth: { headers: { Authorization: "Bearer t0ken", "X-Api-Key": "k" } } });
+    const sent = calls[0]!.init.headers as Record<string, string>;
+    expect(sent["Authorization"]).toBe("Bearer t0ken");
+    expect(sent["X-Api-Key"]).toBe("k");
+  });
+
+  it("redacts sensitive headers in captured evidence (no secrets on disk/logs)", async () => {
+    const { fetch } = fakeFetch([res(200, {})]);
+    const [r] = await runApiCases([caseOf()], { baseUrl: "https://api.test", fetch, auth: { headers: { Authorization: "Bearer secret" } } });
+    expect(r!.request.headers["Authorization"]).toBe("***");
+  });
+});
+
+describe("transient recovery then fail (d) — reuses the #90 ladder", () => {
+  it("retries on a 5xx and passes once the service recovers", async () => {
+    const { fetch, calls } = fakeFetch([res(503), res(503), res(200, {})]);
+    const [r] = await runApiCases([caseOf()], { baseUrl: "https://api.test", fetch, baseDelayMs: 0 });
+    expect(calls).toHaveLength(3);
+    expect(r!.attempts).toBe(3);
+    expect(r!.passed).toBe(true);
+  });
+
+  it("retries a transient throw (ECONNRESET) and gives up after retries → recorded error, not passed", async () => {
+    const { fetch, calls } = fakeFetch([new Error("read ECONNRESET"), new Error("read ECONNRESET"), new Error("read ECONNRESET")]);
+    const [r] = await runApiCases([caseOf()], { baseUrl: "https://api.test", fetch, retries: 2, baseDelayMs: 0 });
+    expect(calls).toHaveLength(3); // initial + 2 retries
+    expect(r!.error).toMatch(/ECONNRESET/);
+    expect(r!.passed).toBe(false);
+    expect(r!.response).toBeUndefined();
+  });
+
+  it("does NOT retry a fatal throw (DNS / connection refused)", async () => {
+    const { fetch, calls } = fakeFetch([new Error("getaddrinfo ENOTFOUND api.test")]);
+    const [r] = await runApiCases([caseOf()], { baseUrl: "https://api.test", fetch, baseDelayMs: 0 });
+    expect(calls).toHaveLength(1); // fatal → fail fast
+    expect(r!.error).toMatch(/ENOTFOUND/);
+  });
+});
+
+describe("evidence capture (e)", () => {
+  it("captures request + response per case", async () => {
+    const { fetch } = fakeFetch([res(200, { id: "7" })]);
+    const [r] = await runApiCases([caseOf()], { baseUrl: "https://api.test", fetch });
+    expect(r!.url).toBe("https://api.test/pets/7");
+    expect(r!.method).toBe("GET");
+    expect(r!.response).toEqual({ status: 200, bodyText: JSON.stringify({ id: "7" }), json: { id: "7" } });
+  });
+});

--- a/tests/unit/knowledge.test.ts
+++ b/tests/unit/knowledge.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadKnowledge } from "../../src/knowledge/index.js";
+import { loadKnowledge, loadApiCreds } from "../../src/knowledge/index.js";
 
 describe("loadKnowledge", () => {
   it("includes global (no url) + those whose url pattern is in the URL; skips the rest", async () => {
@@ -82,6 +82,39 @@ describe("loadKnowledge", () => {
         // unknown scope → directory default (base = web)
         expect(await loadKnowledge(dir, { scope: "web" })).toContain("WEIRD");
         expect(await loadKnowledge(dir, { scope: "api" })).not.toContain("WEIRD");
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  // API-3 (#133): auth/headers for an api run, from api/all-scope `header.*` front-matter.
+  describe("loadApiCreds (#133)", () => {
+    it("collects header.* from api+all scope, resolves ${ENV}, skips web-scoped files", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "qa-creds-"));
+      process.env.API_TOKEN = "tok-123";
+      try {
+        await mkdir(join(dir, "api"), { recursive: true });
+        await writeFile(join(dir, "creds.md"), "---\nscope: all\nheader.Authorization: Bearer ${API_TOKEN}\n---\nshared creds");
+        await writeFile(join(dir, "api", "users.md"), "---\nendpoint: /users\nheader.X-Api-Key: abc\n---\napi note");
+        await writeFile(join(dir, "web.md"), "---\nheader.X-Web: nope\n---\nweb file");
+
+        const creds = await loadApiCreds(dir, { endpoint: "https://api.test/users" });
+        expect(creds["Authorization"]).toBe("Bearer tok-123"); // all-scope + env-resolved
+        expect(creds["X-Api-Key"]).toBe("abc"); // api-scope, endpoint matched
+        expect(creds["X-Web"]).toBeUndefined(); // web-scoped file ignored on an api run
+      } finally {
+        delete process.env.API_TOKEN;
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("an endpoint-keyed creds file only applies when its key is in the target", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "qa-creds2-"));
+      try {
+        await mkdir(join(dir, "api"), { recursive: true });
+        await writeFile(join(dir, "api", "admin.md"), "---\nendpoint: /admin\nheader.X-Admin: 1\n---\nadmin");
+        expect(await loadApiCreds(dir, { endpoint: "https://api.test/users" })).toEqual({});
       } finally {
         await rm(dir, { recursive: true, force: true });
       }


### PR DESCRIPTION
Closes #133 · advances #22 (`cairn api` modality, slice **API-3**).

Builds on **API-2** (#132, generated happy-path cases), **#92** (api/all knowledge scope), **#90** (tiered transient recovery).

## What

`cairn api --base-url <url>` now **executes** the generated happy-path cases and asserts each response. Without `--base-url`, behaviour is unchanged (ingest + generate only — API-1/2).

Per case:
- **Status assertion** — actual status vs the declared success code (`default` → any `<400`; `2XX`-style ranges supported).
- **Schema conformance** — response body vs the declared success schema. Minimal structural check (`type`/`required`/`properties`/`items`/`enum`/`nullable` + `allOf`/`oneOf`/`anyOf`); the schema is already dereferenced by API-1, so no `$ref` walking. `ponytail:` comment names the ceiling (no format/pattern/min-max — upgrade to ajv only if a strict contract check is ever needed).

**Auth/headers** — `--header "Name: Value"` (repeatable) layered over **api-scope knowledge** (`header.*` front-matter in `all`/`api` files, `${ENV}` resolved so the secret stays in env, never in the committed file); config wins. New `loadApiCreds()` in `src/knowledge/index.ts` reuses #92's scope/key matching.

**Transient recovery (#90)** — connection reset / timeout / `429` / `5xx` retry with exponential backoff; DNS/refused and `4xx` fail fast (never mask a real assertion failure). Per-request 30s timeout (abort = transient).

**Evidence** — per-case request/response (sensitive headers redacted to `***`) → `runs/api-<id>/api-evidence.json` (override with `--out`). Any failed assertion → non-zero exit. `fetch` is injected, so tests never touch the network.

## Files
- `src/api/runner.ts` (new) — `runApiCases` + `validateAgainstSchema`.
- `src/knowledge/index.ts` — `loadApiCreds` + `header.*`/`${ENV}` parsing (shared scan refactor; `loadKnowledge` behaviour unchanged).
- `src/core/modalities/api.ts`, `src/cli/index.ts` — `--base-url` / `--header` / `--out` wiring + run summary.
- Tests: `api-runner.test.ts` (status, schema valid/invalid, auth, transient-retry-then-fail, evidence), `knowledge.test.ts` (`loadApiCreds`).
- Docs: `docs/runbooks/run-api-cases.md`; CHANGELOG `[Unreleased]`.

## Verification
- `build` + `lint` clean; targeted suite green (`api-runner`, `knowledge`, `cli-modalities`, `api-modality`, `api-cases` — 46 tests). `smoke:pack` ok.
- Full suite: only the 3 pre-existing browser-integration tests fail (Playwright Chromium not installed locally — environmental, untouched by this change).
- **Ran the real CLI** against a local mock server: 4/4 petstore cases pass; a first-call `503` on `POST /pets` is retried (`attempts: 2`) then passes; `Authorization` appears as `***` in the on-disk evidence.
- Top-level `cairn --help` snapshot updated for the api command's new one-line description (2/2 lines).

## Scope / follow-up
Strictly API-3 (runner + asserts + evidence). The **rich report / Plune-record write** are **API-4** — this PR only emits a console verdict + the raw evidence JSON.