### PR TITLE
feat: cairn api — reporting + run summary/TUI integration (API-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`cairn api` — reporting + run summary/TUI integration (#134, C1-04 / API-4).** A `--base-url` run
+  now writes `report.json` + `report.md` alongside the existing `api-evidence.json`, in the same
+  shape/location web runs already use — so the TUI's past-run browser (`Past runs`) lists api runs
+  too, showing per-operation pass/fail and endpoint coverage instead of green%/pilot. The CLI's final
+  line is now the **shared** `renderRunSummary` footer ("Operations: X/Y passed · N endpoint(s)
+  covered", evidence path, artifacts dir) — the same renderer web runs use, not a parallel one.
+
 - **`cairn api` — runner + response assertions (#133, C1-04 / API-3).** With `--base-url <url>`,
   `cairn api` now **executes** the generated happy-path cases (API-2) and, per case, asserts the HTTP
   **status** matches the declared success code and the response **body conforms** to the declared

--- a/docs/runbooks/run-api-cases.md
+++ b/docs/runbooks/run-api-cases.md
@@ -1,7 +1,8 @@
-# Runbook: run API cases against a base URL (API-3)
+# Runbook: run API cases against a base URL (API-3/API-4)
 
 > Execute the happy-path cases `cairn api` generates from an OpenAPI spec and assert each response
-> (status + schema). Builds on API-1 (ingest) / API-2 (case generation). The rich report is API-4.
+> (status + schema). Builds on API-1 (ingest) / API-2 (case generation). The rich report + run
+> summary/TUI integration is API-4.
 
 ## Steps
 1. **Generate only (no execution)** — sanity-check the cases first:
@@ -33,7 +34,13 @@
 ## Output
 - **Evidence:** `runs/api-<id>/api-evidence.json` (override the dir with `--out`) — per-case request +
   response, status/schema verdicts, attempt count. **Sensitive headers are redacted** (`***`).
-- **Console:** `N/M case(s) passed`, then a ✓/✗ line per case with the status and any schema errors.
+- **Console:** `N/M case(s) passed`, then a ✓/✗ line per case with the status and any schema errors,
+  then the **shared run-summary footer** (same renderer as web runs) — `Operations: N/M passed · K
+  endpoint(s) covered`, the evidence path, and the artifacts dir.
+- **Report + TUI (API-4):** `report.json` + `report.md` are written next to the evidence file, in the
+  same shape/location web runs use — so `cairn` (no args) → **Past runs** lists the api run too, with
+  pass/fail + endpoint coverage instead of green%/pilot, and its Report tab shows the per-operation
+  table + a link to `api-evidence.json`.
 
 ## Robustness
 - **Transient faults** (connection reset / timeout / `429` / `5xx`) retry with backoff before failing,

--- a/src/agent/summary.ts
+++ b/src/agent/summary.ts
@@ -18,6 +18,16 @@ export interface BudgetReport {
   max: number;
 }
 
+/** C1-04 / API-4 (#134): `cairn api` run counters, rendered alongside web-run validation. */
+export interface ApiRunSummary {
+  passed: number;
+  total: number;
+  /** Endpoints in the ingested spec covered by the run (API-1's endpoint count). */
+  endpointCount: number;
+  /** Where the per-case request/response evidence was written. */
+  evidencePath: string;
+}
+
 export interface RunSummaryInput {
   /** Where the artifacts landed (runs/<id>). */
   runDir: string;
@@ -31,6 +41,8 @@ export interface RunSummaryInput {
   partial?: boolean;
   /** A free-form note (e.g. the degrade reason) appended to the summary. */
   note?: string;
+  /** `cairn api` run counters (API-4) — mutually exclusive with `validation` (web runs). */
+  api?: ApiRunSummary;
 }
 
 /** 80% of the budget → warn the user the run is close to the cost guardrail. */
@@ -56,6 +68,10 @@ export function renderRunSummary(s: RunSummaryInput): string[] {
     if (casts && casts.length > 0) {
       lines.push(`  Screencasts: ${casts.length} .webm recorded → ${displayPath(join(s.runDir, "screencasts"))}/`);
     }
+  }
+  if (s.api) {
+    lines.push(`  Operations: ${s.api.passed}/${s.api.total} passed · ${s.api.endpointCount} endpoint(s) covered`);
+    lines.push(`  Evidence:  ${displayPath(s.api.evidencePath)}`);
   }
   if (typeof s.testCaseCount === "number") lines.push(`  Test cases: ${s.testCaseCount}`);
 

--- a/src/artifacts/report.ts
+++ b/src/artifacts/report.ts
@@ -6,6 +6,8 @@ import type { ValidationReport } from "../validate/index.js";
 import type { Score } from "../eval/scorers.js";
 import { METRIC_LEGEND, dirGlyph } from "../eval/legend.js";
 import type { CostReport } from "../llm/cost.js";
+import type { ApiCaseResult } from "../api/runner.js";
+import { displayPath } from "../agent/summary.js";
 
 /** Generate a Playwright locator for an element (ref → getByRole). */
 export function locatorFor(el: ElementRef): string {
@@ -166,5 +168,39 @@ export function renderReportMd(r: ReportInput): string {
       lines.push(`- ⇒ ${j.expected}`, "");
     }
   }
+  return lines.join("\n");
+}
+
+/** C1-04 / API-4 (#134): `cairn api` run report — sibling of {@link renderReportMd} for the api modality. */
+export interface ApiReportInput {
+  runId: string;
+  /** The base URL the cases were run against. */
+  baseUrl: string;
+  /** The OpenAPI spec source (path or URL). */
+  source: string;
+  results: ApiCaseResult[];
+  /** Endpoints in the ingested spec covered by the run. */
+  endpointCount: number;
+  evidencePath: string;
+}
+
+/** Human-readable Markdown run report for `cairn api`: per-operation pass/fail + evidence link. */
+export function renderApiReportMd(r: ApiReportInput): string {
+  const passed = r.results.filter((x) => x.passed).length;
+  const lines: string[] = ["# QA Explorer — API run report", ""];
+  lines.push(`- **Base URL:** ${r.baseUrl}`);
+  lines.push(`- **Spec:** ${r.source}`);
+  lines.push(`- **Run ID:** ${r.runId}`);
+  lines.push(`- **Operations:** ${passed}/${r.results.length} passed · ${r.endpointCount} endpoint(s) covered`);
+  lines.push(`- **Evidence:** ${displayPath(r.evidencePath)}`);
+  lines.push("");
+
+  lines.push(`## Operations (${r.results.length})`, "");
+  lines.push("| status | method | url | expected | got |", "|---|---|---|---|---|");
+  for (const x of r.results) {
+    const got = x.error ? `error: ${x.error}` : String(x.response?.status ?? "—");
+    lines.push(`| ${x.passed ? "✓" : "✗"} | ${x.method} | ${x.url} | ${x.expectedStatus} | ${got} |`);
+  }
+  lines.push("");
   return lines.join("\n");
 }

--- a/src/core/modalities/api.ts
+++ b/src/core/modalities/api.ts
@@ -8,12 +8,14 @@
  */
 import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { basename, join, resolve } from "node:path";
 import { ingestOpenApi, type ApiModel } from "../../api/openapi.js";
 import { generateApiCases, type ApiCase } from "../../api/cases.js";
 import { runApiCases, type ApiCaseResult } from "../../api/runner.js";
 import { loadApiCreds } from "../../knowledge/index.js";
 import { defaultRunsBaseDir } from "../../fs/run-dir.js";
+import { renderRunSummary } from "../../agent/summary.js";
+import { renderApiReportMd } from "../../artifacts/report.js";
 import type { Modality, ModalityContext } from "../modality.js";
 
 /** Parsed flags for `cairn api` (mirrors the command's option definitions). */
@@ -39,8 +41,11 @@ function parseHeaderFlags(flags: string[] | undefined): Record<string, string> {
   return out;
 }
 
-/** Render the runner's per-case verdicts — the verifiable artifact of API-3. */
-export function renderApiRun(results: ApiCaseResult[], evidencePath: string): string[] {
+/**
+ * Render the runner's per-case verdicts — the verifiable artifact of API-3. The aggregate
+ * pass/fail + coverage + evidence-path footer is API-4's `renderRunSummary` (shared with web runs).
+ */
+export function renderApiRun(results: ApiCaseResult[]): string[] {
   const passed = results.filter((r) => r.passed).length;
   const lines = ["", "=== Run results (status + schema asserts) ===", `${passed}/${results.length} case(s) passed`];
   for (const r of results) {
@@ -51,7 +56,6 @@ export function renderApiRun(results: ApiCaseResult[], evidencePath: string): st
     if (!r.statusOk && !r.error) lines.push(`      status mismatch`);
     for (const e of r.schemaErrors) lines.push(`      schema: ${e}`);
   }
-  lines.push("", `Evidence: ${evidencePath}`);
   return lines;
 }
 
@@ -142,7 +146,44 @@ export const apiModality: Modality = {
     const evidencePath = join(outDir, "api-evidence.json");
     await writeFile(evidencePath, JSON.stringify(results, null, 2), "utf8");
 
-    for (const line of renderApiRun(results, evidencePath)) ctx.out(`${line}\n`);
+    // API-4 (#134): report.json/report.md in the same shape/location the run summary and the TUI's
+    // past-run browser already read for web runs — no parallel reporting layer.
+    const passed = results.filter((r) => r.passed).length;
+    const runId = basename(outDir);
+    await writeFile(
+      join(outDir, "report.json"),
+      JSON.stringify(
+        {
+          runId,
+          url: opts.baseUrl,
+          mode: "api",
+          api: { passed, total: results.length, endpointCount: model.endpoints.length },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    await writeFile(
+      join(outDir, "report.md"),
+      renderApiReportMd({
+        runId,
+        baseUrl: opts.baseUrl,
+        source,
+        results,
+        endpointCount: model.endpoints.length,
+        evidencePath,
+      }),
+      "utf8",
+    );
+
+    for (const line of renderApiRun(results)) ctx.out(`${line}\n`);
+    for (const line of renderRunSummary({
+      runDir: outDir,
+      api: { passed, total: results.length, endpointCount: model.endpoints.length, evidencePath },
+    })) {
+      ctx.out(`${line}\n`);
+    }
     if (results.some((r) => !r.passed)) process.exitCode = 1; // any failed assertion → non-zero exit
   },
 };

--- a/src/tui/hooks/use-runs.ts
+++ b/src/tui/hooks/use-runs.ts
@@ -15,6 +15,8 @@ interface ReportShape {
   validation?: { greenRatio?: number };
   pilot?: { verdict?: "pass" | "needs-work" | "fail" };
   testCases?: unknown[];
+  /** C1-04 / API-4 (#134): present when `mode === "api"`. */
+  api?: { passed?: number; total?: number; endpointCount?: number };
 }
 
 /**
@@ -43,11 +45,14 @@ export function useRuns(baseDir = "runs"): RunsState & { reload: () => void } {
               runId: e.name,
               dir,
               url: rep.url ?? "(unknown url)",
-              mode: rep.mode === "design" ? "design" : "explore",
+              mode: rep.mode === "design" ? "design" : rep.mode === "api" ? "api" : "explore",
               greenRatio: rep.validation?.greenRatio,
               pilot: rep.pilot?.verdict,
               testCaseCount: rep.testCases?.length ?? 0,
               date: st.mtime,
+              ...(rep.mode === "api"
+                ? { api: { passed: rep.api?.passed ?? 0, total: rep.api?.total ?? 0, endpointCount: rep.api?.endpointCount ?? 0 } }
+                : {}),
             });
           } catch {
             // no readable report.json → not a finished run, skip

--- a/src/tui/screens/runs-list-screen.tsx
+++ b/src/tui/screens/runs-list-screen.tsx
@@ -26,7 +26,9 @@ export function RunsListScreen() {
     const date = r.date.toISOString().slice(0, 16).replace("T", " ");
     const green = r.greenRatio !== undefined ? `${String(Math.round(r.greenRatio * 100))}% ` : "";
     const pilot = r.pilot ? `${r.pilot} ` : "";
-    return { label: `${date}  ${r.mode}  ${green}${pilot} ${r.url}`, value: r.dir };
+    // C1-04 / API-4 (#134): api runs report pass/fail + endpoint coverage instead of green%/pilot.
+    const api = r.api ? `${r.api.passed}/${r.api.total} passed · ${r.api.endpointCount} endpoint(s) ` : "";
+    return { label: `${date}  ${r.mode}  ${api}${green}${pilot} ${r.url}`, value: r.dir };
   });
 
   return (

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -37,11 +37,13 @@ export interface RunSummary {
   runId: string;
   dir: string;
   url: string;
-  mode: "explore" | "design";
+  mode: "explore" | "design" | "api";
   greenRatio?: number;
   pilot?: "pass" | "needs-work" | "fail";
   testCaseCount: number;
   date: Date;
+  /** C1-04 / API-4 (#134): `cairn api` run counters — present only when `mode === "api"`. */
+  api?: { passed: number; total: number; endpointCount: number };
 }
 
 /** Live status of one graph node on the dashboard checklist. */

--- a/tests/unit/api-modality.test.ts
+++ b/tests/unit/api-modality.test.ts
@@ -105,11 +105,29 @@ describe("cairn api --base-url run path (API-3, mocked network)", () => {
 
       const out0 = outChunks.join("");
       expect(out0).toContain("4/4 case(s) passed");
+      // C1-04 / API-4 (#134): the shared run-summary footer (same renderer as web runs).
+      expect(out0).toMatch(/Operations: 4\/4 passed · 4 endpoint\(s\) covered/);
+      expect(out0).toContain("Artifacts:");
       expect(process.exitCode ?? 0).toBe(0);
 
       const evidence = JSON.parse(await readFile(join(out, "api-evidence.json"), "utf8")) as { request: { headers: Record<string, string> } }[];
       expect(evidence).toHaveLength(4);
       expect(evidence[0]!.request.headers["Authorization"]).toBe("***"); // secret redacted on disk
+
+      // API-4: report.json/report.md — the TUI's past-run browser reads these for any mode.
+      const report = JSON.parse(await readFile(join(out, "report.json"), "utf8")) as {
+        mode: string;
+        url: string;
+        api: { passed: number; total: number; endpointCount: number };
+      };
+      expect(report.mode).toBe("api");
+      expect(report.url).toBe("https://api.test");
+      expect(report.api).toEqual({ passed: 4, total: 4, endpointCount: 4 });
+
+      const reportMd = await readFile(join(out, "report.md"), "utf8");
+      expect(reportMd).toContain("4/4 passed");
+      expect(reportMd).toContain("4 endpoint(s) covered");
+      expect(reportMd).toContain("api-evidence.json");
     } finally {
       await rm(kdir, { recursive: true, force: true });
       await rm(out, { recursive: true, force: true });

--- a/tests/unit/report.test.ts
+++ b/tests/unit/report.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { renderReportMd, locatorFor } from "../../src/artifacts/report.js";
+import { renderReportMd, renderApiReportMd, locatorFor } from "../../src/artifacts/report.js";
 import type { ElementRef } from "../../src/browser/types.js";
+import type { ApiCaseResult } from "../../src/api/runner.js";
 
 const btn: ElementRef = { ref: "e6", role: "button", name: "Sign In", interactive: true, rank: 3 };
 
@@ -131,5 +132,54 @@ describe("renderReportMd", () => {
     });
     expect(md).toContain("Cost (per role)");
     expect(md).toMatch(/\bworker\b.*—/);
+  });
+});
+
+describe("renderApiReportMd (C1-04 / API-4, #134)", () => {
+  const results: ApiCaseResult[] = [
+    {
+      name: "listPets",
+      method: "GET",
+      url: "https://api.test/pets",
+      request: { headers: {} },
+      response: { status: 200, bodyText: "[]", json: [] },
+      attempts: 1,
+      expectedStatus: "200",
+      statusOk: true,
+      schemaOk: true,
+      schemaErrors: [],
+      passed: true,
+    },
+    {
+      name: "createPet",
+      method: "POST",
+      url: "https://api.test/pets",
+      request: { headers: {} },
+      response: { status: 500, bodyText: "", json: undefined },
+      attempts: 1,
+      expectedStatus: "201",
+      statusOk: false,
+      schemaOk: true,
+      schemaErrors: [],
+      passed: false,
+    },
+  ];
+
+  it("contains base URL, per-operation pass/fail marks, endpoint coverage, and the evidence path", () => {
+    const md = renderApiReportMd({
+      runId: "api-1",
+      baseUrl: "https://api.test",
+      source: "petstore.yaml",
+      results,
+      endpointCount: 2,
+      evidencePath: "/tmp/runs/api-1/api-evidence.json",
+    });
+    expect(md).toContain("https://api.test");
+    expect(md).toContain("petstore.yaml");
+    expect(md).toContain("1/2 passed");
+    expect(md).toContain("2 endpoint(s) covered");
+    expect(md).toContain("/tmp/runs/api-1/api-evidence.json");
+    expect(md).toMatch(/✓ \| GET/);
+    expect(md).toMatch(/✗ \| POST/);
   });
 });

--- a/tests/unit/run-summary.test.ts
+++ b/tests/unit/run-summary.test.ts
@@ -81,6 +81,16 @@ describe("renderRunSummary (L1-04, Box 4 — first-run UX)", () => {
     const text = renderRunSummary({ runDir: "/x", budget: { used: 85, max: 80 } }).join("\n");
     expect(text).not.toMatch(/-\d/);
   });
+
+  it("C1-04/API-4 (#134): renders api run pass/fail, endpoint coverage, and the evidence path", () => {
+    const text = renderRunSummary({
+      runDir: "/tmp/runs/api-1",
+      api: { passed: 3, total: 4, endpointCount: 4, evidencePath: "/tmp/runs/api-1/api-evidence.json" },
+    }).join("\n");
+    expect(text).toMatch(/3\/4 passed/);
+    expect(text).toMatch(/4 endpoint\(s\) covered/);
+    expect(text).toContain("Evidence:  /tmp/runs/api-1/api-evidence.json");
+  });
 });
 
 describe("classifyRunError (L1-04, Box 1/3 — friendly, actionable)", () => {

--- a/tests/unit/tui/runs-list.test.tsx
+++ b/tests/unit/tui/runs-list.test.tsx
@@ -22,6 +22,15 @@ vi.mock("../../../src/tui/hooks/use-runs.js", () => ({
         testCaseCount: 8,
         date: new Date("2026-06-02T10:00:00Z"),
       },
+      {
+        runId: "c",
+        dir: "runs/c",
+        url: "https://api.example.com",
+        mode: "api",
+        testCaseCount: 0,
+        api: { passed: 3, total: 4, endpointCount: 4 },
+        date: new Date("2026-06-03T10:00:00Z"),
+      },
     ],
     loading: false,
     reload: () => {},
@@ -50,10 +59,24 @@ describe("RunsListScreen", () => {
       </RouterProvider>,
     );
     const f = lastFrame() ?? "";
-    expect(f).toContain("Past runs (2)");
+    expect(f).toContain("Past runs (3)");
     expect(f).toContain("login");
     expect(f).toContain("90%");
     expect(f).toContain("design");
+    unmount();
+  });
+
+  it("C1-04/API-4 (#134): shows an api run's pass/fail + endpoint coverage instead of green%/pilot", () => {
+    const { lastFrame, unmount } = render(
+      <RouterProvider value={routerApi()}>
+        <RunsListScreen />
+      </RouterProvider>,
+    );
+    const f = lastFrame() ?? "";
+    expect(f).toContain("api");
+    expect(f).toContain("3/4 passed");
+    expect(f).toContain("4 endpoint(s)");
+    expect(f).toContain("api.example.com");
     unmount();
   });
 });


### PR DESCRIPTION
## Summary
- Closes #134 (advances #22). Depends on / builds on API-3 (#133, merged).
- Surfaces `cairn api` run results in the existing run summary / TUI **consistently with web runs**, reusing the shared reporting layer rather than a parallel one:
  - `cairn api --base-url` now writes `report.json` + `report.md` alongside the existing `api-evidence.json`, in the same shape/location web runs already use (`runs/<id>/report.json` + `report.md`).
  - The TUI's past-run browser (`useRuns` / `RunsListScreen`) picks up api runs automatically (no new interactive command needed) and shows per-operation pass/fail + endpoint coverage instead of green%/pilot.
  - The CLI's final line now reuses the shared `renderRunSummary` footer ("Operations: X/Y passed · N endpoint(s) covered", evidence path, artifacts dir) — the same renderer/wording web runs use.
  - `report.md` gets a new sibling renderer, `renderApiReportMd`, alongside `renderReportMd` in `src/artifacts/report.ts`.

## Scope notes
- Did **not** add `cairn api` as a live-launchable command in the TUI (form/launcher/use-runner wiring) — the DoD asks to *surface results*, not add interactive launch; the past-run browser already works generically off `report.json`/`report.md` with no command-union changes needed.
- Did **not** touch Plune-record write (API-5) or coverage (API-6) — noted as follow-ups per the issue.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 629 passed (3 pre-existing failures on this machine are unrelated: missing local Chromium install for Playwright integration tests, confirmed present on `main` before this change too)
- [x] `npm run smoke:pack` — 8 checks passed
- [x] New/updated tests: `run-summary.test.ts` (api summary footer), `report.test.ts` (`renderApiReportMd`), `api-modality.test.ts` (report.json/report.md written with correct shape), `tui/runs-list.test.tsx` (api row rendering)

## Follow-ups (out of scope here)
- API-5: Plune record write
- API-6: coverage
- #95 BORROW-07: adversarial styles (layers on top)