### PR TITLE
feat: cairn api — Plune-record write + methodology rigor (API-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`cairn api` — Plune-record write + methodology rigor (#135, C1-04 / API-5).** A `--base-url` run now
+  emits every generated case as an **ATC artifact** (`runs/api-<id>/testcases/<id>.md`) — the same
+  `testcases/<id>.md` boundary web runs already write, so Plune ingests API cases identically. Each
+  case is **methodology-tagged**: an ISO/IEC/IEEE 29119-4 `technique` (currently `equivalence-partitioning`
+  — the valid class API-2's happy-path synthesis embodies) plus a per-case coverage **rationale**
+  explaining what it exercises and why, both in the case's own frontmatter/fields and surfaced in
+  `report.json` (`cases[]`) and the case listing on stdout. Each ATC's `status` is **provenance-checked**
+  (aligned with BORROW-04, #91): it only reads "Passed" when a same-named, positively-asserted result
+  exists — never inferred from the mere absence of a failure. Cases-only invocations (no `--base-url`)
+  are unchanged (print-only, matching API-1..4 precedent) — no run directory exists yet to write into.
+
 - **`cairn api` — reporting + run summary/TUI integration (#134, C1-04 / API-4).** A `--base-url` run
   now writes `report.json` + `report.md` alongside the existing `api-evidence.json`, in the same
   shape/location web runs already use — so the TUI's past-run browser (`Past runs`) lists api runs

--- a/src/api/cases.ts
+++ b/src/api/cases.ts
@@ -9,8 +9,17 @@
  * cases). The provider abstraction (`StructuredInvoke`) stays available for later, fuzzier slices
  * (negative / boundary cases, API-3+); the DoD's "any LLM use is mockable" holds vacuously because
  * this slice uses none. No runner either — that is API-3.
+ *
+ * API-5 (#135): every case also carries a `technique` + `rationale` — the same ISO/IEC/IEEE 29119-4
+ * methodology tagging web cases carry (`design/schema.ts`) — so the emitted ATC artifact states WHY
+ * the case exists, not just what it sends.
  */
+import type { z } from "zod";
+import type { TestTechniqueSchema } from "../design/schema.js";
 import type { ApiEndpoint, ApiModel } from "./openapi.js";
+
+/** ISO/IEC/IEEE 29119-4 technique — shared enum with web cases (`design/schema.ts`). */
+export type ApiCaseTechnique = z.infer<typeof TestTechniqueSchema>;
 
 /** Values synthesised for an operation's parameters, grouped by location. */
 export interface ApiCaseParams {
@@ -35,6 +44,10 @@ export interface ApiCase {
   expectedStatus: string;
   /** Schema of the expected success body, if that response carries one. */
   expectedSchema?: unknown;
+  /** ISO/IEC/IEEE 29119-4 technique this case embodies (API-5 methodology tagging). */
+  technique: ApiCaseTechnique;
+  /** Why this case exists / what it covers — the coverage rationale (API-5). */
+  rationale: string;
 }
 
 /** Generate one baseline happy-path case per operation, in the model's (deterministic) order. */
@@ -51,6 +64,7 @@ function toCase(e: ApiEndpoint): ApiCase {
   }
 
   const success = pickSuccess(e);
+  const expectedStatus = success?.status ?? "200";
   return {
     name: e.operationId ?? `${e.method} ${e.path}`,
     method: e.method,
@@ -58,8 +72,14 @@ function toCase(e: ApiEndpoint): ApiCase {
     operationId: e.operationId,
     params,
     body: e.requestBody?.schema !== undefined ? synth(e.requestBody.schema) : undefined,
-    expectedStatus: success?.status ?? "200",
+    expectedStatus,
     expectedSchema: success?.schema,
+    // Nominal happy-path = the valid equivalence class for this operation's inputs (ISO 29119-4).
+    technique: "equivalence-partitioning",
+    rationale:
+      `Happy-path case in the valid equivalence class for ${e.method} ${e.path}: exercises the ` +
+      `required parameters/body with schema-valid values and asserts the declared success response ` +
+      `(${expectedStatus}).`,
   };
 }
 

--- a/src/api/testcase-docs.ts
+++ b/src/api/testcase-docs.ts
@@ -1,0 +1,33 @@
+/**
+ * C1-04 / API-5 (#135) — build ATC case docs (.md) for the generated/run API cases: the API sibling
+ * of `agent/testcase-docs.ts` (web), writing into the same `testcases/<id>.md` boundary Plune reads
+ * for web runs. Every API-2 case is happy-path/auto, so these are always ATC — an MTC branch would
+ * need a case that names a manual step, which no API slice produces yet.
+ *
+ * Provenance (aligns with BORROW-04, #91): a case's status can only read "Passed" when a same-named
+ * result is present AND asserts `passed` — never inferred from the mere absence of a failure.
+ */
+import { renderApiTestCaseMd } from "../artifacts/testcase-md.js";
+import type { ApiCase } from "./cases.js";
+import type { ApiCaseResult } from "./runner.js";
+
+export interface ApiTestCaseDocsResult {
+  /** id + rendered ATC markdown, in input order. */
+  docs: { id: string; md: string }[];
+}
+
+/** Pure — no I/O. `results` is absent for a cases-only (no `--base-url`) invocation. */
+export function buildApiTestCaseDocs(
+  cases: ApiCase[],
+  results: ApiCaseResult[] | undefined,
+  suite: string,
+): ApiTestCaseDocsResult {
+  const resultByName = new Map((results ?? []).map((r) => [r.name, r]));
+  const docs = cases.map((c, i) => {
+    const id = `ATC-${suite}-${String(i + 1).padStart(3, "0")}`;
+    const result = resultByName.get(c.name);
+    const status = !result ? "❌ Not run" : result.passed ? "✅ Passed" : "❌ Failed";
+    return { id, md: renderApiTestCaseMd(c, { id, suite, status }) };
+  });
+  return { docs };
+}

--- a/src/artifacts/testcase-md.ts
+++ b/src/artifacts/testcase-md.ts
@@ -1,4 +1,5 @@
 import type { TestCase } from "../design/index.js";
+import type { ApiCase } from "../api/cases.js";
 
 /** Context for rendering a single case into the user's ATC format. */
 export interface TestCaseDoc {
@@ -66,6 +67,54 @@ export function renderTestCaseMd(tc: TestCase, doc: TestCaseDoc): string {
     for (const t of doc.traceability) lines.push(`| ${t.source} | ${t.reference} |`);
     lines.push("");
   }
+
+  return lines.join("\n");
+}
+
+/** Context for rendering one API case into ATC markdown (API-5, #135). */
+export interface ApiTestCaseDoc {
+  id: string;
+  suite: string;
+  /** Provenance-checked verdict (aligns with BORROW-04, #91) — only "Passed" backed by a real result. */
+  status: string;
+}
+
+/**
+ * Render an API case into the same ATC frontmatter contract as {@link renderTestCaseMd} (id/title/
+ * suite/type/execution/status), with the operation's request/response contract and its methodology
+ * tag (technique + coverage rationale) standing in for UI preconditions/steps/selectors.
+ */
+export function renderApiTestCaseMd(c: ApiCase, doc: ApiTestCaseDoc): string {
+  const lines: string[] = [];
+  lines.push("---");
+  lines.push(`id: ${doc.id}`);
+  lines.push(`title: "${c.name.replace(/"/g, "'")}"`);
+  lines.push(`suite: ${doc.suite}`);
+  lines.push(`technique: ${c.technique}`);
+  lines.push(`type: Positive`);
+  lines.push(`execution: auto`);
+  lines.push(`status: ${doc.status}`);
+  lines.push("---", "");
+  lines.push(`# ${doc.id}: ${c.name}`, "");
+
+  lines.push("## Methodology", "");
+  lines.push(`- Technique: ${c.technique}`);
+  lines.push(`- Rationale: ${c.rationale}`);
+  lines.push("");
+
+  lines.push("## Request", "");
+  lines.push(`- ${c.method} ${c.path}`);
+  const sent: Record<string, unknown> = {};
+  for (const [where, vals] of Object.entries(c.params)) {
+    if (Object.keys(vals as object).length) sent[where] = vals;
+  }
+  if (c.body !== undefined) sent.body = c.body;
+  if (Object.keys(sent).length) lines.push(`- Params/body: \`${JSON.stringify(sent)}\``);
+  lines.push("");
+
+  lines.push("## Expected Result", "");
+  lines.push(`- HTTP ${c.expectedStatus}${c.expectedSchema !== undefined ? " conforming to the declared success schema" : ""}`);
+  lines.push("");
 
   return lines.join("\n");
 }

--- a/src/core/modalities/api.ts
+++ b/src/core/modalities/api.ts
@@ -12,9 +12,10 @@ import { basename, join, resolve } from "node:path";
 import { ingestOpenApi, type ApiModel } from "../../api/openapi.js";
 import { generateApiCases, type ApiCase } from "../../api/cases.js";
 import { runApiCases, type ApiCaseResult } from "../../api/runner.js";
+import { buildApiTestCaseDocs } from "../../api/testcase-docs.js";
 import { loadApiCreds } from "../../knowledge/index.js";
 import { defaultRunsBaseDir } from "../../fs/run-dir.js";
-import { renderRunSummary } from "../../agent/summary.js";
+import { renderRunSummary, displayPath } from "../../agent/summary.js";
 import { renderApiReportMd } from "../../artifacts/report.js";
 import type { Modality, ModalityContext } from "../modality.js";
 
@@ -64,6 +65,19 @@ function isUrl(spec: string): boolean {
   return /^https?:\/\//i.test(spec);
 }
 
+/** ATC id suite for this run's cases — mirrors web's `suiteFromUrl` (`agent/index.ts`). */
+function suiteFromApi(model: ApiModel, source: string): string {
+  const base = model.title ?? basename(source).replace(/\.[^.]+$/, "");
+  return `${base.replace(/[^a-z0-9]+/gi, "-").toUpperCase()}-API`;
+}
+
+/** Drop `expectedSchema` — a raw (possibly cyclic) pointer into the dereferenced spec, not JSON-safe. */
+function omitExpectedSchema(c: ApiCase): Omit<ApiCase, "expectedSchema"> {
+  const rest: Partial<ApiCase> = { ...c };
+  delete rest.expectedSchema;
+  return rest as Omit<ApiCase, "expectedSchema">;
+}
+
 /** Print the parsed-model summary — the verifiable artifact of this slice. */
 export function renderApiSummary(model: ApiModel, source: string): string[] {
   const lines = [
@@ -90,6 +104,7 @@ export function renderApiCases(cases: ApiCase[]): string[] {
   ];
   for (const c of cases) {
     lines.push(`  ▸ ${c.name} → ${c.expectedStatus}`);
+    lines.push(`      [${c.technique}] ${c.rationale}`);
     const sent: Record<string, unknown> = {};
     for (const [where, vals] of Object.entries(c.params)) {
       if (Object.keys(vals as object).length) sent[where] = vals;
@@ -158,6 +173,10 @@ export const apiModality: Modality = {
           url: opts.baseUrl,
           mode: "api",
           api: { passed, total: results.length, endpointCount: model.endpoints.length },
+          // API-5 (#135): methodology-tagged cases (technique + rationale) — the Plune-record payload.
+          // `expectedSchema` is dropped: it's a raw pointer into the (possibly cyclic, e.g. `Pet.friends:
+          // Pet[]`) dereferenced spec schema, not serialisable — the case's own contract is enough here.
+          cases: cases.map((c) => omitExpectedSchema(c)),
         },
         null,
         2,
@@ -177,6 +196,15 @@ export const apiModality: Modality = {
       "utf8",
     );
 
+    // API-5 (#135): emit the same ATC artifact boundary web runs write (`testcases/<id>.md`) so Plune
+    // ingests API cases identically — each doc carries the technique/rationale tag and a
+    // provenance-checked status (only "Passed" when a matching, positively-asserted result exists).
+    const suite = suiteFromApi(model, source);
+    const caseDocs = buildApiTestCaseDocs(cases, results, suite);
+    const testCasesDir = join(outDir, "testcases");
+    await mkdir(testCasesDir, { recursive: true });
+    for (const d of caseDocs.docs) await writeFile(join(testCasesDir, `${d.id}.md`), d.md, "utf8");
+
     for (const line of renderApiRun(results)) ctx.out(`${line}\n`);
     for (const line of renderRunSummary({
       runDir: outDir,
@@ -184,6 +212,7 @@ export const apiModality: Modality = {
     })) {
       ctx.out(`${line}\n`);
     }
+    ctx.out(`  Cases (ATC .md): ${displayPath(testCasesDir)}/\n`);
     if (results.some((r) => !r.passed)) process.exitCode = 1; // any failed assertion → non-zero exit
   },
 };

--- a/tests/unit/api-modality.test.ts
+++ b/tests/unit/api-modality.test.ts
@@ -128,6 +128,28 @@ describe("cairn api --base-url run path (API-3, mocked network)", () => {
       expect(reportMd).toContain("4/4 passed");
       expect(reportMd).toContain("4 endpoint(s) covered");
       expect(reportMd).toContain("api-evidence.json");
+
+      // API-5 (#135): methodology-tagged cases in report.json + ATC artifacts on the same boundary
+      // (`testcases/<id>.md`) web runs use.
+      const reportCases = JSON.parse(await readFile(join(out, "report.json"), "utf8")) as {
+        cases: { name: string; technique: string; rationale: string }[];
+      };
+      expect(reportCases.cases).toHaveLength(4);
+      for (const rc of reportCases.cases) {
+        expect(rc.technique).toBe("equivalence-partitioning");
+        expect(rc.rationale.length).toBeGreaterThan(0);
+      }
+
+      const { readdir } = await import("node:fs/promises");
+      const tcDir = join(out, "testcases");
+      const tcFileNames = await readdir(tcDir);
+      expect(tcFileNames).toHaveLength(4);
+      expect(tcFileNames.every((f) => /^ATC-PET-STORE-API-\d{3}\.md$/.test(f))).toBe(true);
+      const listPetsMd = await readFile(join(tcDir, "ATC-PET-STORE-API-001.md"), "utf8");
+      expect(listPetsMd).toContain('title: "listPets"');
+      expect(listPetsMd).toContain("technique: equivalence-partitioning");
+      expect(listPetsMd).toContain("status: ✅ Passed");
+      expect(out0).toContain("Cases (ATC .md):");
     } finally {
       await rm(kdir, { recursive: true, force: true });
       await rm(out, { recursive: true, force: true });

--- a/tests/unit/api-testcase-docs.test.ts
+++ b/tests/unit/api-testcase-docs.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { buildApiTestCaseDocs } from "../../src/api/testcase-docs.js";
+import type { ApiCase } from "../../src/api/cases.js";
+import type { ApiCaseResult } from "../../src/api/runner.js";
+
+/**
+ * C1-04 / API-5 (#135): ATC emission for API cases + the provenance-checked status rule that aligns
+ * with BORROW-04 (#91) — a case may only read "Passed" when backed by a real, matching result.
+ */
+const c = (over: Partial<ApiCase> = {}): ApiCase => ({
+  name: "getPet",
+  method: "GET",
+  path: "/pets/{id}",
+  params: { path: { id: "string" }, query: {}, header: {}, cookie: {} },
+  expectedStatus: "200",
+  technique: "equivalence-partitioning",
+  rationale: "Happy-path case in the valid equivalence class for GET /pets/{id}: asserts 200.",
+  ...over,
+});
+
+const result = (over: Partial<ApiCaseResult> = {}): ApiCaseResult => ({
+  name: "getPet",
+  method: "GET",
+  url: "https://api.test/pets/1",
+  request: { headers: {} },
+  attempts: 1,
+  expectedStatus: "200",
+  statusOk: true,
+  schemaOk: true,
+  schemaErrors: [],
+  passed: true,
+  ...over,
+});
+
+describe("buildApiTestCaseDocs — ATC emission + provenance (#91-aligned)", () => {
+  it("numbers cases ATC-<suite>-NNN in input order", () => {
+    const r = buildApiTestCaseDocs([c({ name: "a" }), c({ name: "b" })], undefined, "DEMO-API");
+    expect(r.docs.map((d) => d.id)).toEqual(["ATC-DEMO-API-001", "ATC-DEMO-API-002"]);
+  });
+
+  it("no results (cases-only run) → status is 'Not run', never a fabricated pass", () => {
+    const r = buildApiTestCaseDocs([c()], undefined, "DEMO-API");
+    expect(r.docs[0]?.md).toContain("status: ❌ Not run");
+  });
+
+  it("a matching passed result → status Passed", () => {
+    const r = buildApiTestCaseDocs([c()], [result({ passed: true })], "DEMO-API");
+    expect(r.docs[0]?.md).toContain("status: ✅ Passed");
+  });
+
+  it("a matching failed result → status Failed (never Passed without evidence)", () => {
+    const r = buildApiTestCaseDocs([c()], [result({ passed: false, statusOk: false })], "DEMO-API");
+    expect(r.docs[0]?.md).toContain("status: ❌ Failed");
+  });
+
+  it("a case absent from the results (name mismatch) is never marked Passed", () => {
+    const r = buildApiTestCaseDocs([c({ name: "other" })], [result({ name: "getPet", passed: true })], "DEMO-API");
+    expect(r.docs[0]?.md).toContain("status: ❌ Not run");
+  });
+
+  it("carries the technique/rationale methodology tag into the doc", () => {
+    const r = buildApiTestCaseDocs([c()], undefined, "DEMO-API");
+    expect(r.docs[0]?.md).toContain("technique: equivalence-partitioning");
+    expect(r.docs[0]?.md).toContain(c().rationale);
+  });
+});

--- a/tests/unit/testcase-md.test.ts
+++ b/tests/unit/testcase-md.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect } from "vitest";
 import {
   renderTestCaseMd,
+  renderApiTestCaseMd,
   mapPriority,
   parseTestCaseMd,
   type TestCaseDoc,
+  type ApiTestCaseDoc,
 } from "../../src/artifacts/testcase-md.js";
 import type { TestCase } from "../../src/design/index.js";
+import type { ApiCase } from "../../src/api/cases.js";
 
 const tc: TestCase = {
   id: "tc-1",
@@ -81,5 +84,46 @@ describe("renderTestCaseMd (ATC format)", () => {
     const parsed = parseTestCaseMd(md);
     expect(parsed.id).toBe("MTC-GENERATE-UI-001");
     expect(parsed.execution).toBe("manual");
+  });
+});
+
+const apiCase: ApiCase = {
+  name: "createPet",
+  method: "POST",
+  path: "/pets",
+  operationId: "createPet",
+  params: { path: {}, query: {}, header: {}, cookie: {} },
+  body: { name: "string" },
+  expectedStatus: "201",
+  expectedSchema: { type: "object" },
+  technique: "equivalence-partitioning",
+  rationale: "Happy-path case in the valid equivalence class for POST /pets: asserts 201.",
+};
+
+const apiDoc: ApiTestCaseDoc = { id: "ATC-PETSTORE-API-001", suite: "PETSTORE-API", status: "✅ Passed" };
+
+describe("renderApiTestCaseMd (ATC format, API-5 #135)", () => {
+  it("renders frontmatter + methodology tag + request/expected sections", () => {
+    const md = renderApiTestCaseMd(apiCase, apiDoc);
+    expect(md).toContain("id: ATC-PETSTORE-API-001");
+    expect(md).toContain('title: "createPet"');
+    expect(md).toContain("suite: PETSTORE-API");
+    expect(md).toContain("technique: equivalence-partitioning");
+    expect(md).toContain("execution: auto");
+    expect(md).toContain("status: ✅ Passed");
+    expect(md).toContain("## Methodology");
+    expect(md).toContain("- Technique: equivalence-partitioning");
+    expect(md).toContain("- Rationale: Happy-path case in the valid equivalence class for POST /pets: asserts 201.");
+    expect(md).toContain("## Request");
+    expect(md).toContain("- POST /pets");
+    expect(md).toContain('"body":{"name":"string"}');
+    expect(md).toContain("## Expected Result");
+    expect(md).toContain("- HTTP 201 conforming to the declared success schema");
+  });
+
+  it("omits the schema-conformance note when no success schema is declared", () => {
+    const md = renderApiTestCaseMd({ ...apiCase, expectedSchema: undefined }, apiDoc);
+    expect(md).toContain("- HTTP 201");
+    expect(md).not.toContain("conforming to");
   });
 });


### PR DESCRIPTION
## Summary
- Closes #135 (advances #22). Depends on / builds on API-4 (#134, merged).
- Every generated API case (API-2) is now **methodology-tagged** and emitted as a **Plune-record ATC artifact** on the same boundary web runs already use:
  - `ApiCase` carries a `technique` (ISO/IEC/IEEE 29119-4 — `equivalence-partitioning`, the valid class API-2's happy-path synthesis embodies) and a per-case `rationale` explaining what it covers and why.
  - A `--base-url` run writes each case to `runs/api-<id>/testcases/<id>.md` — the **same** `testcases/<id>.md` shape/location web runs (`explore`/`design`) already write, so Plune ingests API cases identically instead of through a parallel path. All API-2 cases are happy-path/auto, so these are always `ATC-<suite>-NNN`.
  - Each ATC's `status` is **provenance-checked** (aligns with BORROW-04, #91): it only reads "✅ Passed" when a same-named, positively-asserted result exists — never inferred from the mere absence of a failure. No matching result → "❌ Not run"; a matching but failed result → "❌ Failed".
  - `report.json` now also carries the tagged `cases[]` (methodology visible in the machine-readable record, not just the .md), and the stdout case listing shows `[technique] rationale` per case.

## Scope notes
- **Cases-only invocations (no `--base-url`) are unchanged** — still print-only, matching the API-1..4 precedent that no run directory exists until a base URL is given to run against. Emitting ATC artifacts for that path (which would need a new run-dir concept) is a follow-up if wanted.
- Did **not** touch coverage (API-6, separate issue) or add negative/boundary cases — this slice tags the existing happy-path cases; broader technique coverage is out of scope here.
- `expectedSchema` is dropped from the `cases[]` written to `report.json`: it's a raw (possibly cyclic, e.g. `Pet.friends: Pet[]`) pointer into the dereferenced spec schema, not JSON-serialisable — the case's own request/response contract is enough in the record.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 642 passed, 3 skipped (pre-existing, missing local Chromium — unrelated)
- [x] `npm run test:coverage` — clean, no regression
- [x] `npm run smoke:pack` — 8 checks passed
- [x] New/updated tests: `api-cases.test.ts` (technique/rationale on generated cases), `api-testcase-docs.test.ts` (new — ATC numbering + provenance-checked status), `testcase-md.test.ts` (new `renderApiTestCaseMd` cases), `api-modality.test.ts` (end-to-end: `testcases/*.md` written, `report.json.cases[]`, stdout footer line)

## Follow-ups (out of scope here)
- API-6: coverage