### PR TITLE
feat: cairn api — spec-vs-tested coverage report (API-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`cairn api` — spec-vs-tested coverage report (#136, C1-04 / API-6, `playswag`-style).** Given the
+  ingested spec (API-1) and the generated/executed cases (API-2/API-3), `cairn api` now reports which
+  operations are untested and which are only **partially** exercised: an operation is `covered` only
+  when every response status it declares (e.g. `200` **and** `404`) has a matching case, `partial`
+  when some (but not all) are, and `uncovered` when none are. Since every API-2 case is still a single
+  happy-path call, any operation declaring more than one response is `partial` by construction — a
+  concrete, honest signal (endpoint coverage ≠ test-pass rate) rather than a percentage that looks
+  better than it is. Shown as a summary + gaps-only listing on stdout, in `report.md` (new `## Coverage`
+  section), and as `coverage` in `report.json`; works without `--base-url` too (spec-vs-generated-cases).
+  Matching is by `operationId`/`METHOD path` (shared with case generation, `apiEndpointKey`), and the
+  spec's own `deprecated` flag is surfaced per row rather than filtered out. Feeds BORROW-07 (#95,
+  adversarial styles) and L2-05 coverage gap-analysis.
+
 - **`cairn api` — Plune-record write + methodology rigor (#135, C1-04 / API-5).** A `--base-url` run now
   emits every generated case as an **ATC artifact** (`runs/api-<id>/testcases/<id>.md`) — the same
   `testcases/<id>.md` boundary web runs already write, so Plune ingests API cases identically. Each

--- a/src/api/cases.ts
+++ b/src/api/cases.ts
@@ -21,6 +21,14 @@ import type { ApiEndpoint, ApiModel } from "./openapi.js";
 /** ISO/IEC/IEEE 29119-4 technique — shared enum with web cases (`design/schema.ts`). */
 export type ApiCaseTechnique = z.infer<typeof TestTechniqueSchema>;
 
+/**
+ * The stable key an operation is identified by across the model/cases/results/coverage — same rule
+ * everywhere (API-6, #136): `operationId` if declared, else `METHOD path`.
+ */
+export function apiEndpointKey(e: { method: string; path: string; operationId?: string }): string {
+  return e.operationId ?? `${e.method} ${e.path}`;
+}
+
 /** Values synthesised for an operation's parameters, grouped by location. */
 export interface ApiCaseParams {
   path: Record<string, unknown>;
@@ -66,7 +74,7 @@ function toCase(e: ApiEndpoint): ApiCase {
   const success = pickSuccess(e);
   const expectedStatus = success?.status ?? "200";
   return {
-    name: e.operationId ?? `${e.method} ${e.path}`,
+    name: apiEndpointKey(e),
     method: e.method,
     path: e.path,
     operationId: e.operationId,

--- a/src/api/coverage.ts
+++ b/src/api/coverage.ts
@@ -1,0 +1,121 @@
+/**
+ * C1-04 / API-6 (#136) — spec-vs-tested coverage report (`playswag`-style, borrowed from
+ * AZANIR/qa-skills): given the ingested {@link ApiModel} (API-1) and the generated/executed cases
+ * (API-2/API-3), report which spec operations are untested, and which are only partially exercised.
+ *
+ * "Partial" falls naturally out of the data already on hand: an operation can declare several
+ * responses (200, 404, 500…), but every case generated so far (API-2) targets exactly one status —
+ * the happy path. So an operation is `covered` only when every response IT declares has a matching
+ * case, `partial` when some (but not all) are exercised, and `uncovered` when none are. Grouping by
+ * declared-vs-tested statuses (not raw case count) means this keeps working once later slices (API-8
+ * contract/negative cases, API-9 scenarios) generate more than one case per operation — no rework
+ * needed here. An operation declaring zero responses (malformed but parseable) has nothing to miss —
+ * vacuously `covered`, the same "nothing observed → nothing left uncovered" convention
+ * `eval/coverage.ts` already uses for its ratio.
+ *
+ * Pure set arithmetic (no LLM, no I/O) — the API sibling of `eval/coverage.ts` (web gap-analysis).
+ */
+import { apiEndpointKey, type ApiCase } from "./cases.js";
+import type { ApiEndpoint, ApiModel } from "./openapi.js";
+import type { ApiCaseResult } from "./runner.js";
+
+export type ApiCoverageStatus = "covered" | "partial" | "uncovered";
+
+export interface ApiEndpointCoverage {
+  method: string;
+  path: string;
+  operationId?: string;
+  deprecated: boolean;
+  status: ApiCoverageStatus;
+  /** Every status the spec declares for this operation ("200","404",…). */
+  declaredStatuses: string[];
+  /** The subset of `declaredStatuses` some generated case actually targets. */
+  testedStatuses: string[];
+  /** Whether the run (if one happened) passed — undefined when no `--base-url` execution occurred. */
+  passed?: boolean;
+}
+
+export interface ApiCoverageReport {
+  endpointCount: number;
+  coveredCount: number;
+  partialCount: number;
+  uncoveredCount: number;
+  /** coveredCount / endpointCount (1 when the spec has no operations, never NaN). */
+  ratio: number;
+  /** Every operation, in the model's order — filter by `status` for a gaps-only view. */
+  endpoints: ApiEndpointCoverage[];
+}
+
+/**
+ * Coverage = for each spec operation, which of its declared response statuses a generated case
+ * exercises. `results` is optional — a cases-only invocation (no `--base-url`) still gets a
+ * meaningful report, just without the per-endpoint pass/fail overlay.
+ */
+export function computeApiCoverage(
+  model: ApiModel,
+  cases: ApiCase[],
+  results?: ApiCaseResult[],
+): ApiCoverageReport {
+  const casesByKey = new Map<string, ApiCase[]>();
+  for (const c of cases) {
+    const key = apiEndpointKey({ method: c.method, path: c.path, operationId: c.operationId });
+    const bucket = casesByKey.get(key);
+    if (bucket) bucket.push(c);
+    else casesByKey.set(key, [c]);
+  }
+  const resultByName = new Map((results ?? []).map((r) => [r.name, r]));
+
+  let coveredCount = 0;
+  let partialCount = 0;
+  let uncoveredCount = 0;
+  const endpoints = model.endpoints.map((e): ApiEndpointCoverage => {
+    const key = apiEndpointKey(e);
+    const targeting = casesByKey.get(key) ?? [];
+    const declaredStatuses = [...new Set(e.responses.map((r) => r.status))];
+    const testedStatuses = declaredStatuses.filter((s) => targeting.some((c) => c.expectedStatus === s));
+
+    // A malformed-but-parseable operation with no declared responses has nothing to miss — vacuously
+    // "covered" (same convention `eval/coverage.ts` uses: ratio is 1 when nothing was observed).
+    const status: ApiCoverageStatus =
+      declaredStatuses.length === 0 || testedStatuses.length === declaredStatuses.length
+        ? "covered"
+        : testedStatuses.length === 0
+          ? "uncovered"
+          : "partial";
+    if (status === "covered") coveredCount += 1;
+    else if (status === "partial") partialCount += 1;
+    else uncoveredCount += 1;
+
+    const passed = targeting.length > 0 ? targeting.every((c) => resultByName.get(c.name)?.passed) : undefined;
+
+    return endpointCoverage(e, status, declaredStatuses, testedStatuses, results ? passed : undefined);
+  });
+
+  return {
+    endpointCount: model.endpoints.length,
+    coveredCount,
+    partialCount,
+    uncoveredCount,
+    ratio: model.endpoints.length === 0 ? 1 : coveredCount / model.endpoints.length,
+    endpoints,
+  };
+}
+
+function endpointCoverage(
+  e: ApiEndpoint,
+  status: ApiCoverageStatus,
+  declaredStatuses: string[],
+  testedStatuses: string[],
+  passed: boolean | undefined,
+): ApiEndpointCoverage {
+  return {
+    method: e.method,
+    path: e.path,
+    operationId: e.operationId,
+    deprecated: e.deprecated,
+    status,
+    declaredStatuses,
+    testedStatuses,
+    ...(passed !== undefined ? { passed } : {}),
+  };
+}

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -49,6 +49,8 @@ export interface ApiEndpoint {
   responses: ApiResponse[];
   /** Names of the security schemes this op requires (operation-level, else the spec default). */
   security: string[];
+  /** The spec's own `deprecated:` flag (API-6, #136) — surfaced, not filtered: still worth a coverage row. */
+  deprecated: boolean;
 }
 
 /** The flattened spec: everything a later slice (API-2) needs to design + run cases. */
@@ -86,6 +88,7 @@ interface RawOperation {
   requestBody?: { required?: boolean; content?: Record<string, { schema?: unknown }> };
   responses?: Record<string, { description?: string; content?: Record<string, { schema?: unknown }> }>;
   security?: RawSecurityRequirement[];
+  deprecated?: boolean;
 }
 interface RawParam {
   name: string;
@@ -144,6 +147,7 @@ export async function ingestOpenApi(spec: string): Promise<ApiModel> {
         responses: toResponses(op.responses),
         // Operation security overrides the spec default; [] means "explicitly public".
         security: securityNames(op.security ?? doc.security ?? []),
+        deprecated: op.deprecated ?? false,
       });
     }
   }

--- a/src/artifacts/report.ts
+++ b/src/artifacts/report.ts
@@ -7,6 +7,7 @@ import type { Score } from "../eval/scorers.js";
 import { METRIC_LEGEND, dirGlyph } from "../eval/legend.js";
 import type { CostReport } from "../llm/cost.js";
 import type { ApiCaseResult } from "../api/runner.js";
+import type { ApiCoverageReport } from "../api/coverage.js";
 import { displayPath } from "../agent/summary.js";
 
 /** Generate a Playwright locator for an element (ref → getByRole). */
@@ -182,6 +183,8 @@ export interface ApiReportInput {
   /** Endpoints in the ingested spec covered by the run. */
   endpointCount: number;
   evidencePath: string;
+  /** API-6 (#136): spec-vs-tested coverage (playswag-style) — rendered as a gaps section when present. */
+  coverage?: ApiCoverageReport;
 }
 
 /** Human-readable Markdown run report for `cairn api`: per-operation pass/fail + evidence link. */
@@ -202,5 +205,23 @@ export function renderApiReportMd(r: ApiReportInput): string {
     lines.push(`| ${x.passed ? "✓" : "✗"} | ${x.method} | ${x.url} | ${x.expectedStatus} | ${got} |`);
   }
   lines.push("");
+
+  // API-6 (#136): spec-vs-tested coverage (playswag-style) — gaps only; covered ops need no row.
+  if (r.coverage) {
+    const c = r.coverage;
+    lines.push(`## Coverage (${c.coveredCount}/${c.endpointCount} endpoint(s) — ${Math.round(c.ratio * 100)}%)`, "");
+    const gaps = c.endpoints.filter((e) => e.status !== "covered");
+    if (gaps.length > 0) {
+      lines.push("| status | method | path | operationId | tested | missing |", "|---|---|---|---|---|---|");
+      for (const e of gaps) {
+        const missing = e.declaredStatuses.filter((s) => !e.testedStatuses.includes(s)).join(", ");
+        const dep = e.deprecated ? " (deprecated)" : "";
+        lines.push(
+          `| ${e.status === "partial" ? "⚠ partial" : "✗ uncovered"} | ${e.method} | ${e.path}${dep} | ${e.operationId ?? ""} | ${e.testedStatuses.join(", ") || "—"} | ${missing} |`,
+        );
+      }
+      lines.push("");
+    }
+  }
   return lines.join("\n");
 }

--- a/src/core/modalities/api.ts
+++ b/src/core/modalities/api.ts
@@ -13,6 +13,7 @@ import { ingestOpenApi, type ApiModel } from "../../api/openapi.js";
 import { generateApiCases, type ApiCase } from "../../api/cases.js";
 import { runApiCases, type ApiCaseResult } from "../../api/runner.js";
 import { buildApiTestCaseDocs } from "../../api/testcase-docs.js";
+import { computeApiCoverage, type ApiCoverageReport } from "../../api/coverage.js";
 import { loadApiCreds } from "../../knowledge/index.js";
 import { defaultRunsBaseDir } from "../../fs/run-dir.js";
 import { renderRunSummary, displayPath } from "../../agent/summary.js";
@@ -116,6 +117,31 @@ export function renderApiCases(cases: ApiCase[]): string[] {
   return lines;
 }
 
+/**
+ * Render the spec-vs-tested coverage report (API-6, #136, `playswag`-style) — a summary line plus
+ * gaps only (uncovered/partial); fully-covered operations need no per-row listing.
+ */
+export function renderApiCoverage(coverage: ApiCoverageReport): string[] {
+  const lines = [
+    "",
+    `=== Coverage (${coverage.coveredCount}/${coverage.endpointCount} endpoint(s) — ${Math.round(coverage.ratio * 100)}%) ===`,
+  ];
+  if (coverage.partialCount) lines.push(`  ${coverage.partialCount} partially covered`);
+  if (coverage.uncoveredCount) lines.push(`  ${coverage.uncoveredCount} uncovered`);
+  for (const e of coverage.endpoints) {
+    if (e.status === "covered") continue;
+    const mark = e.status === "partial" ? "⚠" : "✗";
+    const op = e.operationId ? ` (${e.operationId})` : "";
+    const dep = e.deprecated ? " [deprecated]" : "";
+    const tested = e.testedStatuses.length ? e.testedStatuses.join(", ") : "—";
+    const missing = e.declaredStatuses.filter((s) => !e.testedStatuses.includes(s)).join(", ");
+    lines.push(
+      `  ${mark} ${e.status.padEnd(9)} ${e.method.padEnd(6)} ${e.path}${op}${dep} — tested: ${tested}${missing ? ` · missing: ${missing}` : ""}`,
+    );
+  }
+  return lines;
+}
+
 export const apiModality: Modality = {
   name: "api",
   gated: false,
@@ -144,6 +170,8 @@ export const apiModality: Modality = {
 
     // API-3: without --base-url we stop at the generated cases (API-1/2 behaviour, unchanged).
     if (!opts.baseUrl) {
+      // API-6 (#136): coverage is meaningful even without a run — it's spec-vs-generated-cases.
+      for (const line of renderApiCoverage(computeApiCoverage(model, cases))) ctx.out(`${line}\n`);
       ctx.out("Note: cases only. Pass --base-url <url> to execute them and assert responses (API-3).\n");
       return;
     }
@@ -155,6 +183,8 @@ export const apiModality: Modality = {
 
     ctx.err(`▸ Running ${cases.length} case(s) against ${opts.baseUrl}…\n`);
     const results = await runApiCases(cases, { baseUrl: opts.baseUrl, auth: { headers } });
+    // API-6 (#136): spec-vs-tested coverage, overlaid with this run's pass/fail per operation.
+    const coverage = computeApiCoverage(model, cases, results);
 
     const outDir = opts.out ? resolve(opts.out) : join(defaultRunsBaseDir(), `api-${randomUUID()}`);
     await mkdir(outDir, { recursive: true });
@@ -177,6 +207,8 @@ export const apiModality: Modality = {
           // `expectedSchema` is dropped: it's a raw pointer into the (possibly cyclic, e.g. `Pet.friends:
           // Pet[]`) dereferenced spec schema, not serialisable — the case's own contract is enough here.
           cases: cases.map((c) => omitExpectedSchema(c)),
+          // API-6 (#136): spec-vs-tested coverage (playswag-style) — which operations/statuses are gaps.
+          coverage,
         },
         null,
         2,
@@ -192,6 +224,7 @@ export const apiModality: Modality = {
         results,
         endpointCount: model.endpoints.length,
         evidencePath,
+        coverage,
       }),
       "utf8",
     );
@@ -206,6 +239,7 @@ export const apiModality: Modality = {
     for (const d of caseDocs.docs) await writeFile(join(testCasesDir, `${d.id}.md`), d.md, "utf8");
 
     for (const line of renderApiRun(results)) ctx.out(`${line}\n`);
+    for (const line of renderApiCoverage(coverage)) ctx.out(`${line}\n`);
     for (const line of renderRunSummary({
       runDir: outDir,
       api: { passed, total: results.length, endpointCount: model.endpoints.length, evidencePath },

--- a/tests/unit/api-coverage.test.ts
+++ b/tests/unit/api-coverage.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { ingestOpenApi, type ApiModel, type ApiEndpoint } from "../../src/api/openapi.js";
+import { generateApiCases, type ApiCase } from "../../src/api/cases.js";
+import { computeApiCoverage } from "../../src/api/coverage.js";
+import type { ApiCaseResult } from "../../src/api/runner.js";
+
+/**
+ * C1-04 / API-6 (#136): spec-vs-tested coverage — a pure set-difference over the ingested model
+ * (API-1) and the generated/executed cases (API-2/API-3/API-4). Driven by the real petstore fixture
+ * (already used by API-2's own tests) so the partial-coverage case (`getPet`: 200 + 404 declared,
+ * only 200 tested) comes from a real spec, not a hand-built one.
+ */
+const fixtures = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "api");
+
+const endpoint = (over: Partial<ApiEndpoint> = {}): ApiEndpoint => ({
+  method: "GET",
+  path: "/x",
+  tags: [],
+  parameters: [],
+  responses: [{ status: "200" }],
+  security: [],
+  deprecated: false,
+  ...over,
+});
+
+const model = (...endpoints: ApiEndpoint[]): ApiModel => ({
+  openapiVersion: "3.0.0",
+  endpoints,
+  tags: [],
+  securitySchemes: [],
+});
+
+describe("computeApiCoverage — petstore fixture (a, c: covered + partial)", () => {
+  it("an operation with one declared response, tested → covered", async () => {
+    const m = await ingestOpenApi(join(fixtures, "petstore.yaml"));
+    const cases = generateApiCases(m);
+    const r = computeApiCoverage(m, cases);
+    const createPet = r.endpoints.find((e) => e.operationId === "createPet")!;
+    expect(createPet.status).toBe("covered");
+    expect(createPet.declaredStatuses).toEqual(["201"]);
+    expect(createPet.testedStatuses).toEqual(["201"]);
+  });
+
+  it("getPet declares 200+404 but the happy-path case only tests 200 → partial", async () => {
+    const m = await ingestOpenApi(join(fixtures, "petstore.yaml"));
+    const cases = generateApiCases(m);
+    const r = computeApiCoverage(m, cases);
+    const getPet = r.endpoints.find((e) => e.operationId === "getPet")!;
+    expect(getPet.status).toBe("partial");
+    expect(getPet.declaredStatuses).toEqual(["200", "404"]);
+    expect(getPet.testedStatuses).toEqual(["200"]);
+    expect(r.partialCount).toBe(1);
+  });
+
+  it("summary counts + ratio reconcile with the fixture's 4 operations", async () => {
+    const m = await ingestOpenApi(join(fixtures, "petstore.yaml"));
+    const cases = generateApiCases(m);
+    const r = computeApiCoverage(m, cases);
+    expect(r.endpointCount).toBe(4);
+    expect(r.coveredCount + r.partialCount + r.uncoveredCount).toBe(4);
+    expect(r.ratio).toBeCloseTo(r.coveredCount / 4);
+  });
+});
+
+describe("computeApiCoverage — uncovered + edge cases (b, d, e, f)", () => {
+  it("an operation with no matching case at all → uncovered", () => {
+    const m = model(endpoint({ operationId: "getX" }));
+    const r = computeApiCoverage(m, []); // no cases generated for it
+    expect(r.endpoints[0]?.status).toBe("uncovered");
+    expect(r.endpoints[0]?.testedStatuses).toEqual([]);
+    expect(r.uncoveredCount).toBe(1);
+  });
+
+  it("an endpoint in the spec whose case was filtered out (drift) → uncovered, others unaffected", () => {
+    const m = model(endpoint({ operationId: "a" }), endpoint({ operationId: "b", path: "/y" }));
+    const allCases = generateApiCases(m);
+    const onlyA = allCases.filter((c) => c.name === "a"); // simulate "b"'s case having been dropped
+    const r = computeApiCoverage(m, onlyA);
+    expect(r.endpoints.find((e) => e.operationId === "a")?.status).toBe("covered");
+    expect(r.endpoints.find((e) => e.operationId === "b")?.status).toBe("uncovered");
+  });
+
+  it("empty spec → ratio 1, no NaN, zero counts", () => {
+    const r = computeApiCoverage(model(), []);
+    expect(r.endpointCount).toBe(0);
+    expect(r.ratio).toBe(1);
+    expect(r.coveredCount).toBe(0);
+    expect(r.endpoints).toEqual([]);
+  });
+
+  it("carries the spec's `deprecated` flag through to the coverage row", () => {
+    const m = model(endpoint({ operationId: "old", deprecated: true }));
+    const r = computeApiCoverage(m, []);
+    expect(r.endpoints[0]?.deprecated).toBe(true);
+  });
+
+  it("an operation with zero declared responses is vacuously covered (nothing to miss)", () => {
+    const m = model(endpoint({ operationId: "noResponses", responses: [] }));
+    const r = computeApiCoverage(m, []); // no case either — still nothing to be "uncovered" against
+    expect(r.endpoints[0]?.status).toBe("covered");
+    expect(r.coveredCount).toBe(1);
+  });
+});
+
+describe("computeApiCoverage — result overlay (g)", () => {
+  const result = (over: Partial<ApiCaseResult> = {}): ApiCaseResult => ({
+    name: "a",
+    method: "GET",
+    url: "https://api.test/x",
+    request: { headers: {} },
+    attempts: 1,
+    expectedStatus: "200",
+    statusOk: true,
+    schemaOk: true,
+    schemaErrors: [],
+    passed: true,
+    ...over,
+  });
+
+  it("no results supplied (cases-only run) → passed is undefined, not false", () => {
+    const m = model(endpoint({ operationId: "a" }));
+    const cases: ApiCase[] = generateApiCases(m);
+    const r = computeApiCoverage(m, cases);
+    expect(r.endpoints[0]?.passed).toBeUndefined();
+  });
+
+  it("a passing result → passed: true on the covering operation", () => {
+    const m = model(endpoint({ operationId: "a" }));
+    const cases = generateApiCases(m);
+    const r = computeApiCoverage(m, cases, [result({ passed: true })]);
+    expect(r.endpoints[0]?.passed).toBe(true);
+  });
+
+  it("a failing result → passed: false (coverage ≠ correctness)", () => {
+    const m = model(endpoint({ operationId: "a" }));
+    const cases = generateApiCases(m);
+    const r = computeApiCoverage(m, cases, [result({ passed: false })]);
+    expect(r.endpoints[0]?.status).toBe("covered"); // a case targets it — still "tested"
+    expect(r.endpoints[0]?.passed).toBe(false); // but it didn't pass
+  });
+
+  it("uncovered operation with results present → passed stays undefined (nothing ran against it)", () => {
+    const m = model(endpoint({ operationId: "a" }));
+    const r = computeApiCoverage(m, [], [result({ name: "other" })]);
+    expect(r.endpoints[0]?.status).toBe("uncovered");
+    expect(r.endpoints[0]?.passed).toBeUndefined();
+  });
+});

--- a/tests/unit/api-modality.test.ts
+++ b/tests/unit/api-modality.test.ts
@@ -49,6 +49,9 @@ describe("cairn api command (real ingest)", () => {
     expect(out).toContain("1 security scheme(s)");
     expect(out).toContain("GET    /pets");
     expect(out).toContain("DELETE /pets/{id}");
+    // API-6 (#136): coverage is meaningful even without a run — spec-vs-generated-cases.
+    expect(out).toContain("Coverage (3/4 endpoint(s)");
+    expect(out).toMatch(/⚠ partial\s+GET\s+\/pets\/\{id\} \(getPet\) — tested: 200 · missing: 404/);
     expect(process.exitCode ?? 0).toBe(0);
   });
 
@@ -150,6 +153,17 @@ describe("cairn api --base-url run path (API-3, mocked network)", () => {
       expect(listPetsMd).toContain("technique: equivalence-partitioning");
       expect(listPetsMd).toContain("status: ✅ Passed");
       expect(out0).toContain("Cases (ATC .md):");
+
+      // API-6 (#136): spec-vs-tested coverage — getPet declares 200+404 but the happy-path case only
+      // targets 200, so it's "partial" even though this run is 4/4 GREEN — coverage ≠ pass rate.
+      const reportCoverage = JSON.parse(await readFile(join(out, "report.json"), "utf8")) as {
+        coverage: { endpointCount: number; coveredCount: number; partialCount: number; uncoveredCount: number };
+      };
+      expect(reportCoverage.coverage).toMatchObject({ endpointCount: 4, coveredCount: 3, partialCount: 1, uncoveredCount: 0 });
+      expect(reportMd).toContain("Coverage (3/4 endpoint(s)");
+      expect(reportMd).toContain("⚠ partial | GET | /pets/{id}");
+      expect(out0).toContain("Coverage (3/4 endpoint(s)");
+      expect(out0).toContain("partially covered");
     } finally {
       await rm(kdir, { recursive: true, force: true });
       await rm(out, { recursive: true, force: true });

--- a/tests/unit/report.test.ts
+++ b/tests/unit/report.test.ts
@@ -182,4 +182,57 @@ describe("renderApiReportMd (C1-04 / API-4, #134)", () => {
     expect(md).toMatch(/✓ \| GET/);
     expect(md).toMatch(/✗ \| POST/);
   });
+
+  it("renders a Coverage section (gaps only) when `coverage` is supplied (API-6, #136)", () => {
+    const md = renderApiReportMd({
+      runId: "api-1",
+      baseUrl: "https://api.test",
+      source: "petstore.yaml",
+      results,
+      endpointCount: 2,
+      evidencePath: "/tmp/runs/api-1/api-evidence.json",
+      coverage: {
+        endpointCount: 2,
+        coveredCount: 1,
+        partialCount: 1,
+        uncoveredCount: 0,
+        ratio: 0.5,
+        endpoints: [
+          {
+            method: "GET",
+            path: "/pets",
+            operationId: "listPets",
+            deprecated: false,
+            status: "covered",
+            declaredStatuses: ["200"],
+            testedStatuses: ["200"],
+          },
+          {
+            method: "GET",
+            path: "/pets/{id}",
+            operationId: "getPet",
+            deprecated: false,
+            status: "partial",
+            declaredStatuses: ["200", "404"],
+            testedStatuses: ["200"],
+          },
+        ],
+      },
+    });
+    expect(md).toContain("Coverage (1/2 endpoint(s) — 50%)");
+    expect(md).toContain("⚠ partial | GET | /pets/{id} | getPet | 200 | 404");
+    expect(md).not.toContain("listPets |"); // fully-covered rows are omitted — gaps only
+  });
+
+  it("omits the Coverage section entirely when `coverage` is absent (back-compat)", () => {
+    const md = renderApiReportMd({
+      runId: "api-1",
+      baseUrl: "https://api.test",
+      source: "petstore.yaml",
+      results,
+      endpointCount: 2,
+      evidencePath: "/tmp/runs/api-1/api-evidence.json",
+    });
+    expect(md).not.toContain("## Coverage");
+  });
 });


### PR DESCRIPTION
## Summary
- Closes #136 (advances #22). Builds on API-1 (#22, endpoint model) + API-4 (#134, run results).
- Given the ingested `ApiModel` and the generated/executed cases, `cairn api` now reports **which spec operations are untested, and which are only partially exercised** — `playswag`-style, borrowed from AZANIR/qa-skills:
  - An operation is `covered` only when **every** response status it declares (e.g. `200` **and** `404`) has a matching case, `partial` when some (but not all) are, `uncovered` when none are.
  - Since every API-2 case is still a single happy-path call, **any operation declaring more than one response is `partial` by construction** — a concrete, honest signal that endpoint coverage ≠ test-pass rate (the petstore fixture's `getPet` declares `200`+`404`; the happy-path case only ever exercises `200`, so it's `partial` even on a 4/4-green run).
  - Matching is by the same key case generation already uses (`operationId` else `METHOD path`), now shared as `apiEndpointKey` (`src/api/cases.ts`) so coverage never silently diverges from how cases are named.
  - Works **with or without `--base-url`** (spec-vs-generated-cases is meaningful before any run happens); when results are available, each row also carries a `passed` overlay.
  - Surfaced in three places: a stdout summary + gaps-only listing, a new `## Coverage` section in `report.md` (gaps-only table), and the full per-endpoint `coverage` object in `report.json` (unfiltered — gap-filtering is presentation-only).
  - The spec's own `deprecated` flag (newly ingested in API-1's model) rides along per row rather than being filtered out — a human can judge whether an untested deprecated endpoint is actually a gap.

## Scope notes
- **Playswag-style report only** — this does not generate negative/boundary/contract cases to close the gaps it finds; that's BORROW-07 (#95, adversarial styles) and API-8/API-9 (contract/scenario cases), which this feeds.
- Duplicate `operationId` across different paths (a spec that's technically invalid per the OpenAPI spec, since `operationId` must be unique) would alias two operations onto the same coverage bucket — this is an existing limitation of case generation's own name-based keying (`cases.ts`), not something introduced here; not defended against since it requires an already-invalid input spec.
- An operation declaring zero responses (malformed but parseable) is reported as vacuously `covered` (nothing declared → nothing missing) — the same "nothing observed → nothing left uncovered" convention `eval/coverage.ts` already uses for its ratio.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 656 passed, 3 skipped (pre-existing, missing local Chromium — unrelated)
- [x] `npm run test:coverage` — clean, no regression
- [x] `npm run smoke:pack` — 8 checks passed
- [x] New/updated tests: `api-coverage.test.ts` (new — covered/partial/uncovered against the real petstore fixture + hand-built edge cases: no case at all, spec drift/filtered case, empty spec, deprecated flag, zero-response operation, result overlay with/without `--base-url`), `report.test.ts` (new `## Coverage` section + back-compat when absent), `api-modality.test.ts` (end-to-end: `report.json.coverage`, `report.md` coverage table, stdout in both the cases-only and `--base-url` paths)

## Follow-ups (out of scope here)
- BORROW-07 (#95): adversarial styles, closing the gaps this report surfaces
- API-8 (#145): contract validation / negative-schema cases
- API-9 (#146): multi-endpoint scenario chains