### PR TITLE
feat: cairn api — Playwright codegen from ATC cases (API-7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`cairn api` — Playwright codegen from ATC cases (#144, C1-04 / API-7).** `cairn automate --run
+  <runDir>` — the same decoupled design→automate contract web runs use — now also works on an API
+  run (`report.json`'s `mode: "api"`, API-4): it reads the ATC `.md` cases (API-5) and generates a
+  runnable `tests/api.spec.ts` using `@playwright/test`'s `request` fixture, one `test()` per case,
+  asserting the declared success status (exact/`default`/`NXX`, same vocabulary as the runner). No
+  LLM call — every field a request needs (method/path/params/body/expected status) is already fully
+  structured in the case, so codegen is deterministic templating (the same reasoning as API-2's case
+  generation). The generated suite imports nothing from `cairn`, so it runs standalone in CI; `baseURL`
+  defaults to the recorded value but is overridable per-environment via `API_BASE_URL`. `--validate`
+  is a web-only concept (needs a browser/session) and is a no-op (with a progress note) on an API run.
+
 - **`cairn api` — spec-vs-tested coverage report (#136, C1-04 / API-6, `playswag`-style).** Given the
   ingested spec (API-1) and the generated/executed cases (API-2/API-3), `cairn api` now reports which
   operations are untested and which are only **partially** exercised: an operation is `covered` only

--- a/docs/runbooks/design-and-automate.md
+++ b/docs/runbooks/design-and-automate.md
@@ -33,7 +33,18 @@ cairn explore --url ... --session ... [--checklist ...]
 ```
 observe→design→code→validation→repair (keep-best)→Pilot verdict — a validated suite + metrics right away.
 
-## 5. Plug into an existing Playwright project (`--into-project`, #51)
+## 5. `automate` on an API run (API-7, #144)
+```
+cairn api --spec ./openapi.yaml --base-url https://api.example.com --out runs/api-1
+cairn automate --run runs/api-1
+```
+`automate` detects an API run from `report.json`'s `mode: "api"` (written by `cairn api --base-url`,
+API-4) and generates `runs/api-1/tests/api.spec.ts` from the ATC cases (API-5) instead — one
+`@playwright/test` `test()` per case using the `request` fixture, asserting the declared success
+status. No LLM, no session/`--validate` (that's a web-only, browser concept — a no-op here); `baseURL`
+is overridable per environment via `API_BASE_URL` so the same generated suite runs standalone in CI.
+
+## 6. Plug into an existing Playwright project (`--into-project`, #51)
 ```
 cairn explore  --url ... --into-project           # detect playwright.config.* from cwd
 cairn automate --run runs/<id> --into-project ./e2e   # or point at a project dir

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -10,8 +10,8 @@ import { initTelemetry } from "../telemetry/index.js";
 import { ArtifactStore, rmrf, type RunWriter } from "../artifacts/index.js";
 import { resolveProjectTarget, ejectSuiteToProject } from "../project/index.js";
 import { renderReportMd } from "../artifacts/report.js";
-import { parseTestCaseMd } from "../artifacts/testcase-md.js";
-import { automateCases } from "../codegen/index.js";
+import { parseTestCaseMd, parseApiTestCaseMd } from "../artifacts/testcase-md.js";
+import { automateCases, automateApiCases } from "../codegen/index.js";
 import { lintSuite, lintHint } from "../codegen/lint.js";
 import { deterministicScores, type Score } from "../eval/scorers.js";
 import { computeCoverage } from "../eval/coverage.js";
@@ -911,62 +911,77 @@ export async function runAutomate(input: {
   const rep = JSON.parse(await readFile(join(runDir, "report.json"), "utf8")) as {
     url?: string;
     pageSemantics?: string;
+    mode?: string;
   };
   const baseUrl = rep.url ?? "";
   const pageSemantics = rep.pageSemantics ?? "";
+  const isApi = rep.mode === "api"; // API-7 (#144): report.json's mode (API-4) picks the codegen path.
 
   const tcDir = join(runDir, "testcases");
   const mdFiles = (await readdir(tcDir)).filter((f) => f.endsWith(".md"));
-  const allCases: ReturnType<typeof parseTestCaseMd>[] = [];
-  for (const f of mdFiles) allCases.push(parseTestCaseMd(await readFile(join(tcDir, f), "utf8")));
-  // Only auto/ATC — manual/MTC cases are NOT automated (they are manual).
-  const cases = allCases.filter((c) => c.execution !== "manual" && !c.id.startsWith("MTC"));
-  const skipped = allCases.length - cases.length;
-  onProgress(`automate — ${cases.length} auto cases (skipped manual/MTC: ${skipped}) from ${displayPath(tcDir)}`);
-
-  const invoke = router.invoke("worker", router.tierFor("worker", cfg.models.bulk));
-  const prompts = new PromptRegistry();
-  const buildSuite = (repairHint?: string): Promise<GeneratedSuite> =>
-    automateCases(cases, { baseUrl, pageSemantics }, { invoke, prompts }, repairHint);
 
   const artifacts = new ArtifactStore(dirname(runDir));
   const runWriter = await artifacts.openRun(basename(runDir));
 
-  let sessionPath: string | undefined;
-  if (input.sessionFile) sessionPath = resolve(input.sessionFile);
-  else if (input.sessionName) {
-    sessionPath = new SessionStore(resolve(input.sessionsDir ?? ".auth")).pathFor(input.sessionName);
-  }
-
   let suite: GeneratedSuite;
   let validation: ValidationReport | undefined;
   let stoppedEarly = false;
-  if (input.validate) {
-    // Onboarding guardrail: validation runs the generated suite → fail fast with a copy-paste fix
-    // before spending LLM calls on codegen. FIX B (0.3.3): pass the channel — skipped when a system
-    // browser is configured (the bug: `automate --validate` fired this even with BROWSER_CHANNEL=chrome).
-    ensureBrowsersInstalled({ channel: cfg.browser.channel });
-    // #40: validate ⇄ repair ⇄ keep-best (+ no-progress early-stop) — the SAME convergence the explore
-    // graph uses, instead of a single one-shot generation. Lifts the decoupled flow to explore-grade green.
-    const result = await runRepairLoop({
-      generate: async (hint) => {
-        const s = await buildSuite(hint);
-        await runWriter.writeSuite(s);
-        return s;
-      },
-      validate: () => validateSuite(runWriter.dir, { storageStatePath: sessionPath, channel: cfg.browser.channel, workers: cfg.playwrightWorkers, screencast: input.screencast }),
-      maxRepair: cfg.maxRepair,
-      onProgress,
-      lint: (s) => lintHint(lintSuite(s)), // #57: feed fragile-pattern findings into repair
-    });
-    suite = result.bestSuite;
-    validation = result.bestValidation;
-    stoppedEarly = result.stoppedEarly;
-    onProgress(
-      `automate — validation: ${Math.round(validation.greenRatio * 100)}% green${stoppedEarly ? " · stopped early (no progress)" : ""}`,
-    );
+
+  if (isApi) {
+    // Every field a request needs (method/path/params/body/expected status) is already fully
+    // structured in the ATC case — deterministic templating, no LLM (same reasoning as API-2's case
+    // generation). No browser either, so --validate (web's repair/session loop) doesn't apply here.
+    const apiCases: ReturnType<typeof parseApiTestCaseMd>[] = [];
+    for (const f of mdFiles) apiCases.push(parseApiTestCaseMd(await readFile(join(tcDir, f), "utf8")));
+    onProgress(`automate — ${apiCases.length} API case(s) from ${displayPath(tcDir)}`);
+    if (input.validate) onProgress("automate — --validate needs a browser/session (web-only); skipping for an API run.");
+    suite = automateApiCases(apiCases, { baseUrl });
   } else {
-    suite = await buildSuite(); // single pass — repair needs validation to measure progress
+    const allCases: ReturnType<typeof parseTestCaseMd>[] = [];
+    for (const f of mdFiles) allCases.push(parseTestCaseMd(await readFile(join(tcDir, f), "utf8")));
+    // Only auto/ATC — manual/MTC cases are NOT automated (they are manual).
+    const cases = allCases.filter((c) => c.execution !== "manual" && !c.id.startsWith("MTC"));
+    const skipped = allCases.length - cases.length;
+    onProgress(`automate — ${cases.length} auto cases (skipped manual/MTC: ${skipped}) from ${displayPath(tcDir)}`);
+
+    const invoke = router.invoke("worker", router.tierFor("worker", cfg.models.bulk));
+    const prompts = new PromptRegistry();
+    const buildSuite = (repairHint?: string): Promise<GeneratedSuite> =>
+      automateCases(cases, { baseUrl, pageSemantics }, { invoke, prompts }, repairHint);
+
+    let sessionPath: string | undefined;
+    if (input.sessionFile) sessionPath = resolve(input.sessionFile);
+    else if (input.sessionName) {
+      sessionPath = new SessionStore(resolve(input.sessionsDir ?? ".auth")).pathFor(input.sessionName);
+    }
+
+    if (input.validate) {
+      // Onboarding guardrail: validation runs the generated suite → fail fast with a copy-paste fix
+      // before spending LLM calls on codegen. FIX B (0.3.3): pass the channel — skipped when a system
+      // browser is configured (the bug: `automate --validate` fired this even with BROWSER_CHANNEL=chrome).
+      ensureBrowsersInstalled({ channel: cfg.browser.channel });
+      // #40: validate ⇄ repair ⇄ keep-best (+ no-progress early-stop) — the SAME convergence the explore
+      // graph uses, instead of a single one-shot generation. Lifts the decoupled flow to explore-grade green.
+      const result = await runRepairLoop({
+        generate: async (hint) => {
+          const s = await buildSuite(hint);
+          await runWriter.writeSuite(s);
+          return s;
+        },
+        validate: () => validateSuite(runWriter.dir, { storageStatePath: sessionPath, channel: cfg.browser.channel, workers: cfg.playwrightWorkers, screencast: input.screencast }),
+        maxRepair: cfg.maxRepair,
+        onProgress,
+        lint: (s) => lintHint(lintSuite(s)), // #57: feed fragile-pattern findings into repair
+      });
+      suite = result.bestSuite;
+      validation = result.bestValidation;
+      stoppedEarly = result.stoppedEarly;
+      onProgress(
+        `automate — validation: ${Math.round(validation.greenRatio * 100)}% green${stoppedEarly ? " · stopped early (no progress)" : ""}`,
+      );
+    } else {
+      suite = await buildSuite(); // single pass — repair needs validation to measure progress
+    }
   }
 
   // #51: eject into an existing Playwright project when requested; else write to runDir/tests as before.

--- a/src/artifacts/testcase-md.ts
+++ b/src/artifacts/testcase-md.ts
@@ -1,5 +1,5 @@
 import type { TestCase } from "../design/index.js";
-import type { ApiCase } from "../api/cases.js";
+import type { ApiCase, ApiCaseParams } from "../api/cases.js";
 
 /** Context for rendering a single case into the user's ATC format. */
 export interface TestCaseDoc {
@@ -163,4 +163,43 @@ export function parseTestCaseMd(md: string): ParsedTestCase {
     })
     .filter((s) => s.locator.length > 0);
   return { id, execution, title, steps, expected, selectors };
+}
+
+/** A parsed API test case (for `automate` — API-7, #144: ATC `.md` → codegen input). */
+export interface ParsedApiCase {
+  id: string;
+  title: string;
+  method: string;
+  path: string;
+  params: ApiCaseParams;
+  body?: unknown;
+  /** Declared success status ("200"/"201"/"default"/"2XX"…) — same vocabulary as {@link ApiCase}. */
+  expectedStatus: string;
+}
+
+/** Parse an API ATC markdown doc (rendered by {@link renderApiTestCaseMd}) back into a structure. */
+export function parseApiTestCaseMd(md: string): ParsedApiCase {
+  const id = md.match(/^id:\s*(.+?)\s*$/m)?.[1]?.trim() ?? "";
+  const titleM = md.match(/^title:\s*"?(.+?)"?\s*$/m);
+  const title = (titleM?.[1] ?? "Untitled").trim();
+
+  const requestLine = section(md, "Request")
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .find((l) => /^-\s+\S+\s+\S+/.test(l) && !l.startsWith("- Params/body:"));
+  const [, method = "GET", path = "/"] = requestLine?.match(/^-\s+(\S+)\s+(\S+)/) ?? [];
+
+  const sentBlob = section(md, "Request").match(/^-\s+Params\/body:\s+`(.+)`\s*$/m)?.[1];
+  const sent = sentBlob ? (JSON.parse(sentBlob) as Record<string, unknown>) : {};
+  const { body, ...rest } = sent;
+  const params: ApiCaseParams = {
+    path: (rest.path as Record<string, unknown>) ?? {},
+    query: (rest.query as Record<string, unknown>) ?? {},
+    header: (rest.header as Record<string, unknown>) ?? {},
+    cookie: (rest.cookie as Record<string, unknown>) ?? {},
+  };
+
+  const expectedStatus = section(md, "Expected Result").match(/^-\s+HTTP\s+(\S+)/m)?.[1] ?? "default";
+
+  return { id, title, method, path, params, body, expectedStatus };
 }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -6,7 +6,7 @@ import type { TestCase } from "../design/index.js";
 import type { VerifiedElement } from "../browser/types.js";
 import { formatTransitions, type Transition } from "../probe/index.js";
 import { detectLanguage } from "../checklist/index.js";
-import type { ParsedTestCase } from "../artifacts/testcase-md.js";
+import type { ParsedTestCase, ParsedApiCase } from "../artifacts/testcase-md.js";
 import { GeneratedSuiteSchema, type GeneratedSuite } from "./schema.js";
 
 export type { GeneratedSuite, FileBlob } from "./schema.js";
@@ -106,4 +106,79 @@ export async function automateCases(
     : prompt.text;
   const suite = await deps.invoke(GeneratedSuiteSchema, [new HumanMessage(text)]);
   return { files: suite.files.map((f) => ({ path: sanitizePath(f.path), content: f.content })) };
+}
+
+/** Substitute `{name}` path params with their synthesised value (mirrors `api/runner.ts`'s buildUrl). */
+function substitutePathParams(path: string, params: Record<string, unknown>): string {
+  let out = path;
+  for (const [k, v] of Object.entries(params)) out = out.replace(`{${k}}`, encodeURIComponent(String(v)));
+  return out;
+}
+
+/** Literal query string from synthesised query params (values are known at generation time). */
+function buildQueryString(params: Record<string, unknown>): string {
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) qs.append(k, String(v));
+  const s = qs.toString();
+  return s ? `?${s}` : "";
+}
+
+/** Header params + a Cookie header from cookie params (mirrors `api/runner.ts`'s buildHeaders). */
+function buildApiHeaders(c: ParsedApiCase): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const [k, v] of Object.entries(c.params.header)) headers[k] = String(v);
+  const cookies = Object.entries(c.params.cookie);
+  if (cookies.length) headers["Cookie"] = cookies.map(([k, v]) => `${k}=${v}`).join("; ");
+  if (c.body !== undefined) headers["Content-Type"] = "application/json";
+  return headers;
+}
+
+/**
+ * A `response.status()` assertion for the case's declared success status — same vocabulary as
+ * `api/runner.ts`'s `statusMatches`: an exact code, `default` (any non-error status), or an `NXX` range.
+ */
+function statusAssertion(expected: string): string {
+  if (expected === "default") return "expect(response.status(), 'expected a non-error (< 400) status').toBeLessThan(400);";
+  const range = /^(\d)XX$/i.exec(expected);
+  if (range) {
+    const base = Number(range[1]) * 100;
+    return `expect(response.status()).toBeGreaterThanOrEqual(${base});\n  expect(response.status()).toBeLessThan(${base + 100});`;
+  }
+  return `expect(response.status()).toBe(${Number(expected)});`;
+}
+
+function renderApiTest(c: ParsedApiCase): string {
+  const path = substitutePathParams(c.path, c.params.path);
+  const query = buildQueryString(c.params.query);
+  const headers = buildApiHeaders(c);
+  const dataLine = c.body !== undefined ? `\n    data: ${JSON.stringify(c.body)},` : "";
+  return `test(${JSON.stringify(c.title)}, async ({ request }) => {
+  const response = await request.fetch(\`\${baseURL}${path}${query}\`, {
+    method: ${JSON.stringify(c.method)},
+    headers: ${JSON.stringify(headers)},${dataLine}
+  });
+  ${statusAssertion(c.expectedStatus)}
+});`;
+}
+
+/**
+ * `automate` command for API runs (API-7, #144): generate a runnable `@playwright/test` suite
+ * straight from PARSED ATC cases — no LLM. Unlike the web flow, every field a request needs
+ * (method/path/params/body/expected status) is already fully structured in the case, so codegen here
+ * is deterministic templating (the same "no LLM" reasoning as API-2's case generation), using the
+ * `request` fixture so the suite runs standalone in CI with no browser. `baseURL` is overridable via
+ * `API_BASE_URL` so the same generated suite targets a different environment than the one it was
+ * recorded against.
+ */
+export function automateApiCases(cases: ParsedApiCase[], ctx: { baseUrl: string }): GeneratedSuite {
+  const tests = cases.map(renderApiTest).join("\n\n");
+  const content = `import { test, expect } from '@playwright/test';
+
+// Trailing slash stripped (mirrors api/runner.ts's buildUrl) — a trailing-slash override never
+// doubles up with the case path, which always starts with "/".
+const baseURL = (process.env.API_BASE_URL ?? ${JSON.stringify(ctx.baseUrl)}).replace(/\\/+$/, "");
+
+${tests}
+`;
+  return { files: [{ path: "api.spec.ts", content }] };
 }

--- a/tests/unit/automate-api.test.ts
+++ b/tests/unit/automate-api.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runAutomate } from "../../src/agent/index.js";
+import { loadConfig } from "../../src/config/index.js";
+import { renderApiTestCaseMd, type ApiTestCaseDoc } from "../../src/artifacts/testcase-md.js";
+import type { ApiCase } from "../../src/api/cases.js";
+
+/**
+ * C1-04 / API-7 (#144): `cairn automate --run <runDir>` on an API run (report.json's `mode: "api"`,
+ * API-4) — the decoupled contract web runs already have, now covering API ATC cases too.
+ */
+const apiCase: ApiCase = {
+  name: "getPet",
+  method: "GET",
+  path: "/pets/{id}",
+  params: { path: { id: "1" }, query: {}, header: {}, cookie: {} },
+  expectedStatus: "200",
+  technique: "equivalence-partitioning",
+  rationale: "Happy-path case in the valid equivalence class for GET /pets/{id}: asserts 200.",
+};
+const apiDoc: ApiTestCaseDoc = { id: "ATC-PETSTORE-API-001", suite: "PETSTORE-API", status: "❌ Not run" };
+
+describe("runAutomate — API runs (API-7, #144)", () => {
+  it("generates tests/api.spec.ts from ATC cases with no LLM call and no validation", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "qa-automate-api-"));
+    try {
+      await writeFile(
+        join(runDir, "report.json"),
+        JSON.stringify({ runId: "api-1", url: "https://api.test", mode: "api" }),
+        "utf8",
+      );
+      const tcDir = join(runDir, "testcases");
+      await mkdir(tcDir, { recursive: true });
+      await writeFile(join(tcDir, `${apiDoc.id}.md`), renderApiTestCaseMd(apiCase, apiDoc), "utf8");
+
+      const config = loadConfig({ ANTHROPIC_API_KEY: "test-key" });
+      const result = await runAutomate({ runDir, config });
+
+      expect(result.specFiles).toHaveLength(1);
+      expect(result.validation).toBeUndefined();
+      const content = await readFile(join(runDir, "tests", "api.spec.ts"), "utf8");
+      expect(content).toContain("@playwright/test");
+      expect(content).toContain("request.fetch");
+      expect(content).toContain("${baseURL}/pets/1");
+      expect(content).toContain("expect(response.status()).toBe(200);");
+    } finally {
+      await rm(runDir, { recursive: true, force: true });
+    }
+  });
+
+  it("--validate on an API run is a no-op (web-only), still writes the suite", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "qa-automate-api-"));
+    try {
+      await writeFile(
+        join(runDir, "report.json"),
+        JSON.stringify({ runId: "api-1", url: "https://api.test", mode: "api" }),
+        "utf8",
+      );
+      const tcDir = join(runDir, "testcases");
+      await mkdir(tcDir, { recursive: true });
+      await writeFile(join(tcDir, `${apiDoc.id}.md`), renderApiTestCaseMd(apiCase, apiDoc), "utf8");
+
+      const config = loadConfig({ ANTHROPIC_API_KEY: "test-key" });
+      const events: string[] = [];
+      const result = await runAutomate({ runDir, config, validate: true, onProgress: (e) => events.push(e) });
+
+      expect(result.validation).toBeUndefined();
+      expect(result.specFiles).toHaveLength(1);
+      expect(events.some((e) => e.includes("--validate needs a browser/session"))).toBe(true);
+    } finally {
+      await rm(runDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/codegen.test.ts
+++ b/tests/unit/codegen.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { generateSuite, automateCases } from "../../src/codegen/index.js";
+import { generateSuite, automateCases, automateApiCases } from "../../src/codegen/index.js";
 import { PromptRegistry } from "../../src/prompts/index.js";
 import type { StructuredInvoke } from "../../src/llm/structured.js";
 import type { PageStudy } from "../../src/observe/index.js";
 import type { TestCase } from "../../src/design/index.js";
-import type { ParsedTestCase } from "../../src/artifacts/testcase-md.js";
+import type { ParsedTestCase, ParsedApiCase } from "../../src/artifacts/testcase-md.js";
 
 const study: PageStudy = {
   url: "http://x/login",
@@ -109,5 +109,75 @@ describe("automateCases (decoupled automate — repair support, #40)", () => {
       { invoke: fakeInvoke, prompts: new PromptRegistry() },
     );
     expect(captured).not.toContain("REPAIR");
+  });
+});
+
+describe("automateApiCases (API-7, #144 — no LLM, request fixture)", () => {
+  const getCase: ParsedApiCase = {
+    id: "ATC-PETSTORE-API-001",
+    title: "getPet",
+    method: "GET",
+    path: "/pets/{id}",
+    params: { path: { id: "1" }, query: { verbose: "true" }, header: {}, cookie: {} },
+    expectedStatus: "200",
+  };
+  const postCase: ParsedApiCase = {
+    id: "ATC-PETSTORE-API-002",
+    title: "createPet",
+    method: "POST",
+    path: "/pets",
+    params: { path: {}, query: {}, header: {}, cookie: {} },
+    body: { name: "Fido" },
+    expectedStatus: "201",
+  };
+
+  it("generates one api.spec.ts file, no LLM invoke involved", () => {
+    const suite = automateApiCases([getCase], { baseUrl: "https://api.test" });
+    expect(suite.files).toHaveLength(1);
+    expect(suite.files[0]?.path).toBe("api.spec.ts");
+    expect(suite.files[0]?.content).toContain("@playwright/test");
+  });
+
+  it("substitutes path params and appends the query string", () => {
+    const suite = automateApiCases([getCase], { baseUrl: "https://api.test" });
+    const content = suite.files[0]?.content ?? "";
+    expect(content).toContain("${baseURL}/pets/1?verbose=true");
+    expect(content).toContain('method: "GET"');
+  });
+
+  it("embeds the request body and a JSON content-type header", () => {
+    const suite = automateApiCases([postCase], { baseUrl: "https://api.test" });
+    const content = suite.files[0]?.content ?? "";
+    expect(content).toContain('data: {"name":"Fido"}');
+    expect(content).toContain('"Content-Type":"application/json"');
+    expect(content).toContain('method: "POST"');
+  });
+
+  it("asserts an exact status code", () => {
+    const content = automateApiCases([postCase], { baseUrl: "https://api.test" }).files[0]?.content ?? "";
+    expect(content).toContain("expect(response.status()).toBe(201);");
+  });
+
+  it("asserts a non-error status for 'default'", () => {
+    const c: ParsedApiCase = { ...getCase, expectedStatus: "default" };
+    const content = automateApiCases([c], { baseUrl: "https://api.test" }).files[0]?.content ?? "";
+    expect(content).toContain("toBeLessThan(400)");
+  });
+
+  it("asserts a status class range for e.g. '2XX'", () => {
+    const c: ParsedApiCase = { ...getCase, expectedStatus: "2XX" };
+    const content = automateApiCases([c], { baseUrl: "https://api.test" }).files[0]?.content ?? "";
+    expect(content).toContain("toBeGreaterThanOrEqual(200)");
+    expect(content).toContain("toBeLessThan(300)");
+  });
+
+  it("baseURL falls back to the recorded value but is overridable via API_BASE_URL", () => {
+    const content = automateApiCases([getCase], { baseUrl: "https://api.test" }).files[0]?.content ?? "";
+    expect(content).toContain('process.env.API_BASE_URL ?? "https://api.test"');
+  });
+
+  it("strips a trailing slash from baseURL so it never doubles with the path's leading slash", () => {
+    const content = automateApiCases([getCase], { baseUrl: "https://api.test/" }).files[0]?.content ?? "";
+    expect(content).toContain('.replace(/\\/+$/, "")');
   });
 });

--- a/tests/unit/testcase-md.test.ts
+++ b/tests/unit/testcase-md.test.ts
@@ -4,6 +4,7 @@ import {
   renderApiTestCaseMd,
   mapPriority,
   parseTestCaseMd,
+  parseApiTestCaseMd,
   type TestCaseDoc,
   type ApiTestCaseDoc,
 } from "../../src/artifacts/testcase-md.js";
@@ -125,5 +126,43 @@ describe("renderApiTestCaseMd (ATC format, API-5 #135)", () => {
     const md = renderApiTestCaseMd({ ...apiCase, expectedSchema: undefined }, apiDoc);
     expect(md).toContain("- HTTP 201");
     expect(md).not.toContain("conforming to");
+  });
+});
+
+describe("parseApiTestCaseMd (API-7, #144: ATC .md → codegen input)", () => {
+  it("round-trips from the renderer (id/title/method/path/body/expectedStatus)", () => {
+    const parsed = parseApiTestCaseMd(renderApiTestCaseMd(apiCase, apiDoc));
+    expect(parsed.id).toBe("ATC-PETSTORE-API-001");
+    expect(parsed.title).toBe("createPet");
+    expect(parsed.method).toBe("POST");
+    expect(parsed.path).toBe("/pets");
+    expect(parsed.body).toEqual({ name: "string" });
+    expect(parsed.expectedStatus).toBe("201");
+    expect(parsed.params).toEqual({ path: {}, query: {}, header: {}, cookie: {} });
+  });
+
+  it("recovers non-body params (path/query/header/cookie) grouped by location", () => {
+    const withParams: ApiCase = {
+      ...apiCase,
+      body: undefined,
+      params: { path: { id: "1" }, query: { limit: "10" }, header: {}, cookie: {} },
+    };
+    const parsed = parseApiTestCaseMd(renderApiTestCaseMd(withParams, apiDoc));
+    expect(parsed.params).toEqual({ path: { id: "1" }, query: { limit: "10" }, header: {}, cookie: {} });
+    expect(parsed.body).toBeUndefined();
+  });
+
+  it("no params/body sent (bare GET) → empty params, no body", () => {
+    const bare: ApiCase = { ...apiCase, method: "GET", path: "/pets", body: undefined };
+    const parsed = parseApiTestCaseMd(renderApiTestCaseMd(bare, apiDoc));
+    expect(parsed.params).toEqual({ path: {}, query: {}, header: {}, cookie: {} });
+    expect(parsed.body).toBeUndefined();
+  });
+
+  it("'default' expected status (no HTTP-status line matched) falls back to 'default'", () => {
+    // Defensive default — every rendered doc actually has a "HTTP <status>" line (this covers a
+    // malformed/hand-edited doc without one).
+    const parsed = parseApiTestCaseMd("---\nid: X\ntitle: \"x\"\n---\n\n## Request\n- GET /x\n");
+    expect(parsed.expectedStatus).toBe("default");
   });
 });


### PR DESCRIPTION
Closes #144.

## What
`cairn automate --run <runDir>` now also handles an API run (`report.json`'s `mode: "api"`, written by API-4) — the same decoupled design→automate contract web runs already use:

- New `parseApiTestCaseMd` (`src/artifacts/testcase-md.ts`) parses the ATC `.md` cases (API-5) back into a structure (method/path/params/body/expected status).
- New `automateApiCases` (`src/codegen/index.ts`) generates a runnable `tests/api.spec.ts` from those cases — **no LLM call**: every field a request needs is already fully structured in the case, so codegen is deterministic templating (same "no LLM" reasoning as API-2's case generation). Uses `@playwright/test`'s `request.fetch()` (method-agnostic), asserts the declared success status (exact/`default`/`NXX`, mirroring `api/runner.ts`'s `statusMatches`). `baseURL` is trailing-slash-stripped and overridable per environment via `API_BASE_URL`, so the generated suite runs standalone in CI with no dependency on `cairn`.
- `runAutomate` (`src/agent/index.ts`) branches on report mode; the web path is unchanged. `--validate` is a no-op (+ progress note) on an API run — it's a web-only, browser/session concept.
- The CLI needed **zero changes** — `automate`'s existing flags were already generic.

## Scope note
Full response-schema-conformance assertions are **not** in the generated code: `ApiCase.expectedSchema` is deliberately never persisted to disk (cyclic, not JSON-safe — noted in API-4/API-5), so `automate`'s on-disk inputs (`report.json` + ATC `.md`) never carry it. Status-only assertion is the natural ceiling from what's actually recorded, not a scope cut — matches the issue's stated out-of-scope items (API-8 contract-validation strictness, API-9 multi-endpoint journeys).

## How I verified (against the DoD)
- `npm run build`, `npm run lint`, `npm test` (673 tests, all green) — new unit tests cover the parser round-trip, the codegen templating (path/query/header/body embedding, all three status-assertion forms, trailing-slash handling), and an fs-based integration test exercising `runAutomate` end-to-end on a temp API run dir.
- `npm run smoke:pack` — green.
- Confirmed the generated `api.spec.ts` imports nothing from `cairn` (only `@playwright/test`).

## Follow-ups (out of scope here)
- Full response-body schema assertions in generated code would need a serializable schema representation persisted at API-3/4 time (currently dropped as cyclic) — a separate slice if ever needed.