### PR TITLE
cairn api — stricter contract validation + negative-schema cases (API-8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`cairn api` — stricter contract validation + negative-schema cases (#145, C1-04 / API-8).**
+  Response-schema conformance now goes through `ajv` (+ `ajv-formats`) instead of the hand-rolled
+  structural checker: `format`/`pattern`/`minimum`/`maximum`/`additionalProperties` are now enforced,
+  not just type/required/properties/items/enum/allOf/oneOf/anyOf. Circular schemas from swagger-parser's
+  dereference (e.g. `Pet.friends -> Pet`) are de-cycled before compiling so ajv doesn't recurse forever.
+  New `--negative` flag: generates one additional contract-violation case per operation that has
+  something to violate (a request-body property flipped to the wrong JSON type, or a required
+  query/header/cookie param omitted — path params are left alone since removing one just breaks
+  routing), expecting the declared 4xx (or a generic `4XX` range) rather than acceptance. Tagged
+  `type: "Negative"` / technique `error-guessing`, flowing through the same run/report/coverage/ATC
+  pipeline as the happy-path cases — a distinct case category, not a parallel one.
+
 - **`cairn api` — Playwright codegen from ATC cases (#144, C1-04 / API-7).** `cairn automate --run
   <runDir>` — the same decoupled design→automate contract web runs use — now also works on an API
   run (`report.json`'s `mode: "api"`, API-4): it reads the ATC `.md` cases (API-5) and generates a

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@langchain/core": "^1.1.48",
         "@langchain/openai": "^1.4.7",
         "@playwright/test": "^1.60.0",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "commander": "^15.0.0",
         "dotenv": "^17.4.2",
         "playwright": "^1.60.0",
@@ -169,22 +171,6 @@
         "openapi-types": ">=7"
       }
     },
-    "node_modules/@apidevtools/swagger-parser/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@apidevtools/swagger-parser/node_modules/ajv-draft-04": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
@@ -198,12 +184,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@apidevtools/swagger-parser/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
@@ -1186,30 +1166,6 @@
           "optional": false
         }
       }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
@@ -4260,46 +4216,10 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4311,12 +4231,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
-      "optional": true
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
@@ -5205,6 +5135,30 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "11.2.0",
@@ -6147,10 +6101,9 @@
       }
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "@langchain/core": "^1.1.48",
     "@langchain/openai": "^1.4.7",
     "@playwright/test": "^1.60.0",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "commander": "^15.0.0",
     "dotenv": "^17.4.2",
     "playwright": "^1.60.0",

--- a/src/api/cases.ts
+++ b/src/api/cases.ts
@@ -15,11 +15,14 @@
  * the case exists, not just what it sends.
  */
 import type { z } from "zod";
-import type { TestTechniqueSchema } from "../design/schema.js";
-import type { ApiEndpoint, ApiModel } from "./openapi.js";
+import type { TestTechniqueSchema, TestTypeSchema } from "../design/schema.js";
+import type { ApiEndpoint, ApiModel, ApiParam } from "./openapi.js";
 
 /** ISO/IEC/IEEE 29119-4 technique — shared enum with web cases (`design/schema.ts`). */
 export type ApiCaseTechnique = z.infer<typeof TestTechniqueSchema>;
+
+/** Positive (valid path) | Negative (invalid/erroneous) — shared enum with web cases (API-8, #145). */
+export type ApiCaseType = z.infer<typeof TestTypeSchema>;
 
 /**
  * The stable key an operation is identified by across the model/cases/results/coverage — same rule
@@ -52,6 +55,8 @@ export interface ApiCase {
   expectedStatus: string;
   /** Schema of the expected success body, if that response carries one. */
   expectedSchema?: unknown;
+  /** Positive (happy-path) | Negative (contract-violating) — API-8 (#145) distinct case category. */
+  type: ApiCaseType;
   /** ISO/IEC/IEEE 29119-4 technique this case embodies (API-5 methodology tagging). */
   technique: ApiCaseTechnique;
   /** Why this case exists / what it covers — the coverage rationale (API-5). */
@@ -63,14 +68,28 @@ export function generateApiCases(model: ApiModel): ApiCase[] {
   return model.endpoints.map(toCase);
 }
 
-function toCase(e: ApiEndpoint): ApiCase {
+/**
+ * C1-04 / API-8 (#145) — one negative-schema case per operation that has a request contract worth
+ * violating: corrupt a request-body property to the wrong JSON type, or (bodyless operations) omit a
+ * required non-path parameter. An operation with neither (e.g. `GET /health`) has nothing to violate
+ * and is skipped — a forced violation would just be noise, not a contract check.
+ */
+export function generateNegativeCases(model: ApiModel): ApiCase[] {
+  return model.endpoints.map(toNegativeCase).filter((c): c is ApiCase => c !== undefined);
+}
+
+/** Required params (as sent for the nominal happy path), optionally dropping one to violate it. */
+function synthRequiredParams(e: ApiEndpoint, omit?: ApiParam): ApiCaseParams {
   const params: ApiCaseParams = { path: {}, query: {}, header: {}, cookie: {} };
   for (const p of e.parameters) {
-    // Nominal happy-path: send the required params; leave optional ones unset.
     if (!p.required) continue;
+    if (omit && p.in === omit.in && p.name === omit.name) continue;
     params[p.in][p.name] = synth(p.schema);
   }
+  return params;
+}
 
+function toCase(e: ApiEndpoint): ApiCase {
   const success = pickSuccess(e);
   const expectedStatus = success?.status ?? "200";
   return {
@@ -78,10 +97,11 @@ function toCase(e: ApiEndpoint): ApiCase {
     method: e.method,
     path: e.path,
     operationId: e.operationId,
-    params,
+    params: synthRequiredParams(e),
     body: e.requestBody?.schema !== undefined ? synth(e.requestBody.schema) : undefined,
     expectedStatus,
     expectedSchema: success?.schema,
+    type: "Positive",
     // Nominal happy-path = the valid equivalence class for this operation's inputs (ISO 29119-4).
     technique: "equivalence-partitioning",
     rationale:
@@ -89,6 +109,90 @@ function toCase(e: ApiEndpoint): ApiCase {
       `required parameters/body with schema-valid values and asserts the declared success response ` +
       `(${expectedStatus}).`,
   };
+}
+
+/** Body-schema properties whose declared (primitive) type we can flip to something invalid. */
+function corruptibleProps(schema: Schema): [string, string][] {
+  const out: [string, string][] = [];
+  for (const [name, sub] of Object.entries(schema.properties ?? {})) {
+    const type = Array.isArray(sub.type) ? sub.type.find((t) => t !== "null") : sub.type;
+    if (typeof type === "string") out.push([name, type]);
+  }
+  return out;
+}
+
+/** A JSON value of a different type than `type` — always a contract violation for that property. */
+function wrongTypeValue(type: string): unknown {
+  switch (type) {
+    case "string":
+      return 42;
+    case "integer":
+    case "number":
+      return "not-a-number";
+    case "boolean":
+      return "not-a-boolean";
+    default:
+      return "not-a-valid-value"; // array/object/other
+  }
+}
+
+/** The lowest declared 4xx status, else the generic "4XX" range (matched by the runner's `statusMatches`). */
+function pickErrorStatus(e: ApiEndpoint): string {
+  const fourXX = e.responses.filter((r) => /^4\d\d$/.test(r.status)).sort((a, b) => a.status.localeCompare(b.status));
+  return fourXX[0]?.status ?? "4XX";
+}
+
+/** The declared response schema for an EXACT status match, if the case picked one (not the "4XX" fallback). */
+function pickErrorSchema(e: ApiEndpoint, expectedStatus: string): unknown {
+  return e.responses.find((r) => r.status === expectedStatus)?.schema;
+}
+
+function buildNegativeCase(e: ApiEndpoint, input: { body?: unknown; params: ApiCaseParams }, violation: string): ApiCase {
+  const expectedStatus = pickErrorStatus(e);
+  return {
+    name: `${apiEndpointKey(e)} (negative)`,
+    method: e.method,
+    path: e.path,
+    operationId: e.operationId,
+    params: input.params,
+    body: input.body,
+    expectedStatus,
+    expectedSchema: pickErrorSchema(e, expectedStatus),
+    type: "Negative",
+    // Deliberately-invalid input, chosen from experience of common contract violations (ISO 29119-4).
+    technique: "error-guessing",
+    rationale:
+      `Negative-schema case for ${e.method} ${e.path}: ${violation}, expecting the API to reject the ` +
+      `request (${expectedStatus}) rather than accept it.`,
+  };
+}
+
+function toNegativeCase(e: ApiEndpoint): ApiCase | undefined {
+  const bodySchema = e.requestBody?.schema as Schema | undefined;
+  if (bodySchema) {
+    const [prop] = corruptibleProps(bodySchema);
+    if (prop) {
+      const [name, type] = prop;
+      const body = synth(bodySchema) as Record<string, unknown>;
+      body[name] = wrongTypeValue(type);
+      return buildNegativeCase(
+        e,
+        { body, params: synthRequiredParams(e) },
+        `sends "${name}" as the wrong type in the request body (expected ${type})`,
+      );
+    }
+  }
+
+  const nonPathRequired = e.parameters.find((p) => p.required && p.in !== "path");
+  if (nonPathRequired) {
+    return buildNegativeCase(
+      e,
+      { params: synthRequiredParams(e, nonPathRequired) },
+      `omits the required ${nonPathRequired.in} param "${nonPathRequired.name}"`,
+    );
+  }
+
+  return undefined; // nothing in this operation's contract is worth violating
 }
 
 /** The declared success response: the lowest 2xx, else `default`, else the first declared. */

--- a/src/api/runner.ts
+++ b/src/api/runner.ts
@@ -12,6 +12,8 @@
  * fault earns a cheap backoff + retry of the SAME request; everything else fails fast (we never mask a
  * real 4xx / assertion failure behind a retry). `fetch` is injected so tests never touch the network.
  */
+import { Ajv, type ErrorObject, type ValidateFunction } from "ajv";
+import addFormats from "ajv-formats";
 import type { ApiCase } from "./cases.js";
 
 /** Minimal response shape we read — satisfied by the global `fetch` Response. */
@@ -222,70 +224,84 @@ function buildHeaders(c: ApiCase, auth?: ApiAuth): Record<string, string> {
 }
 
 /**
- * Minimal JSON-Schema instance check for happy-path response conformance. The schema is already
- * dereferenced (API-1), so there are no `$ref`s to follow. Returns path-qualified error strings.
- *
- * ponytail: covers the keywords real success-response schemas use — type (incl. 3.1 type-arrays +
- * 3.0 `nullable`), required, properties, items, enum, and allOf/oneOf/anyOf composition. It does NOT
- * enforce format/pattern/min/max/additionalProperties — upgrade to ajv if strict contract checks are
- * ever needed (none of the happy-path slices require it).
+ * C1-04 / API-8 (#145) — strict JSON-Schema response conformance via `ajv` (draft 2020-12 + formats):
+ * type/required/properties/items/enum/allOf/oneOf/anyOf, plus format/pattern/min/max/additionalProperties
+ * that a hand-rolled checker would have to reimplement one keyword at a time. Returns path-qualified
+ * error strings (same shape callers already expect).
  */
-export function validateAgainstSchema(value: unknown, schema: unknown, path = "$"): string[] {
-  if (!schema || typeof schema !== "object") return [];
-  const s = schema as Record<string, unknown>;
+const ajv = new Ajv({ allErrors: true, strict: false, verbose: true });
+// ponytail: ajv-formats' .d.ts models CJS/ESM interop differently than its actual dist/index.js emit
+// (`module.exports = formatsPlugin` directly) — the mismatch is type-only, so this cast matches runtime.
+(addFormats as unknown as (a: Ajv) => void)(ajv);
 
-  if (Array.isArray(s.allOf)) return s.allOf.flatMap((sub) => validateAgainstSchema(value, sub, path));
-  for (const key of ["oneOf", "anyOf"] as const) {
-    const branches = s[key];
-    if (Array.isArray(branches) && branches.length) {
-      const anyOk = branches.some((b) => validateAgainstSchema(value, b, path).length === 0);
-      return anyOk ? [] : [`${path}: matches none of ${key}`];
-    }
-  }
+/** One compiled validator per (already-dereferenced) schema object — a run checks the same declared
+ * schema across many responses; recompiling per call would be wasted work. */
+const compiledCache = new WeakMap<object, ValidateFunction>();
 
-  if (s.enum && Array.isArray(s.enum)) {
-    return s.enum.some((e) => deepEqual(e, value)) ? [] : [`${path}: ${JSON.stringify(value)} not in enum`];
-  }
-
-  const types = normaliseTypes(s);
-  if (types.length === 0) return []; // untyped schema — nothing to check
-  if (value === null) return types.includes("null") ? [] : [`${path}: null is not ${types.join("|")}`];
-
-  const actual = jsonType(value);
-  if (!types.includes(actual)) return [`${path}: expected ${types.join("|")}, got ${actual}`];
-
-  const errors: string[] = [];
-  if (actual === "object") {
-    const obj = value as Record<string, unknown>;
-    for (const req of (s.required as string[]) ?? []) {
-      if (!(req in obj)) errors.push(`${path}.${req}: required property missing`);
-    }
-    const props = (s.properties as Record<string, unknown>) ?? {};
-    for (const [k, sub] of Object.entries(props)) {
-      if (k in obj) errors.push(...validateAgainstSchema(obj[k], sub, `${path}.${k}`));
-    }
-  } else if (actual === "array" && s.items) {
-    (value as unknown[]).forEach((item, i) => errors.push(...validateAgainstSchema(item, s.items, `${path}[${i}]`)));
-  }
-  return errors;
+function compile(schema: object): ValidateFunction {
+  const cached = compiledCache.get(schema);
+  if (cached) return cached;
+  const validate = ajv.compile(deCycle(schema, new Set()) as object);
+  compiledCache.set(schema, validate);
+  return validate;
 }
 
-/** Declared types as a list, folding OpenAPI 3.0 `nullable: true` into an implicit `null` member. */
-function normaliseTypes(s: Record<string, unknown>): string[] {
-  const raw = s.type;
-  const list = Array.isArray(raw) ? raw : typeof raw === "string" ? [raw] : [];
-  if (s.nullable === true && !list.includes("null")) list.push("null");
-  // `integer` is satisfied by a JSON number — collapse it so jsonType() comparison lines up.
-  return list.map((t) => (t === "integer" ? "number" : t)) as string[];
+/**
+ * Swagger-parser's `dereference()` (API-1) resolves circular `$ref`s into literal object-identity
+ * cycles (e.g. `Pet.friends -> Pet`) rather than JSON-Schema `$ref` pointers — ajv can't compile a
+ * schema containing a real object cycle (infinite recursion). Breaking the cycle at the point of
+ * re-entry — tracked as the current DFS ancestor path, not a global "seen" set, since a schema
+ * legitimately reused as two *sibling* branches is not a cycle — relaxes only the recursive tail to
+ * "anything" and keeps the rest of the schema strict. Also folds OpenAPI 3.0's `nullable: true` into
+ * a `type` array, since ajv only understands the keyword `type` (no 3.0 extensions).
+ */
+function deCycle(node: unknown, ancestors: Set<object>): unknown {
+  if (!node || typeof node !== "object") return node;
+  if (ancestors.has(node)) return true; // re-entering an ancestor — stop recursing, accept anything
+  ancestors.add(node);
+  try {
+    if (Array.isArray(node)) return node.map((v) => deCycle(v, ancestors));
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(node)) out[k] = deCycle(v, ancestors);
+    if (out.nullable === true) {
+      const t = out.type;
+      out.type = Array.isArray(t) ? [...t, "null"] : t !== undefined ? [t, "null"] : "null";
+    }
+    return out;
+  } finally {
+    ancestors.delete(node);
+  }
+}
+
+export function validateAgainstSchema(value: unknown, schema: unknown, path = "$"): string[] {
+  if (!schema || typeof schema !== "object") return [];
+  const validate = compile(schema);
+  if (validate(value)) return [];
+  return (validate.errors ?? []).map((e) => formatAjvError(e, path));
+}
+
+function formatAjvError(e: ErrorObject, root: string): string {
+  const dotPath = e.instancePath ? e.instancePath.replace(/\//g, ".") : "";
+  if (e.keyword === "required") {
+    const prop = (e.params as { missingProperty: string }).missingProperty;
+    return `${root}${dotPath}.${prop}: required property missing`;
+  }
+  if (e.keyword === "type") {
+    return `${root}${dotPath}: expected ${(e.params as { type: string }).type}, got ${jsonType(e.data)}`;
+  }
+  if (e.keyword === "enum") {
+    return `${root}${dotPath}: ${JSON.stringify(e.data)} not in enum`;
+  }
+  if (e.keyword === "additionalProperties") {
+    const extra = (e.params as { additionalProperty: string }).additionalProperty;
+    return `${root}${dotPath}: unexpected additional property "${extra}"`;
+  }
+  return `${root}${dotPath}: ${e.message ?? "invalid"}`;
 }
 
 function jsonType(v: unknown): string {
   if (v === null) return "null";
   if (Array.isArray(v)) return "array";
-  if (Number.isInteger(v as number) || typeof v === "number") return "number";
+  if (typeof v === "number") return "number";
   return typeof v; // string | boolean | object | undefined
-}
-
-function deepEqual(a: unknown, b: unknown): boolean {
-  return JSON.stringify(a) === JSON.stringify(b);
 }

--- a/src/artifacts/testcase-md.ts
+++ b/src/artifacts/testcase-md.ts
@@ -91,7 +91,7 @@ export function renderApiTestCaseMd(c: ApiCase, doc: ApiTestCaseDoc): string {
   lines.push(`title: "${c.name.replace(/"/g, "'")}"`);
   lines.push(`suite: ${doc.suite}`);
   lines.push(`technique: ${c.technique}`);
-  lines.push(`type: Positive`);
+  lines.push(`type: ${c.type}`);
   lines.push(`execution: auto`);
   lines.push(`status: ${doc.status}`);
   lines.push("---", "");
@@ -113,7 +113,8 @@ export function renderApiTestCaseMd(c: ApiCase, doc: ApiTestCaseDoc): string {
   lines.push("");
 
   lines.push("## Expected Result", "");
-  lines.push(`- HTTP ${c.expectedStatus}${c.expectedSchema !== undefined ? " conforming to the declared success schema" : ""}`);
+  const schemaNote = c.expectedSchema !== undefined ? ` conforming to the declared ${c.type === "Negative" ? "error" : "success"} schema` : "";
+  lines.push(`- HTTP ${c.expectedStatus}${schemaNote}`);
   lines.push("");
 
   return lines.join("\n");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -139,6 +139,7 @@ export function buildProgram(): Command {
     )
     .option("--out <dir>", "API-3: where to write run evidence (default runs/api-<id>/)")
     .option("--knowledge-dir <dir>", "API-3: dir holding api-scope auth/headers knowledge (default knowledge/)")
+    .option("--negative", "API-8: also generate/run one negative-schema (contract-violation) case per operation")
     .action(async (opts: Record<string, unknown>) => {
       await runModality("api", opts);
     });

--- a/src/core/modalities/api.ts
+++ b/src/core/modalities/api.ts
@@ -5,12 +5,14 @@
  * API-2 (#132): from that model, generate one nominal happy-path case per operation and print them.
  * API-3 (#133): with `--base-url`, execute those cases (auth from config + api-scope knowledge),
  *   assert status + response-schema per case, and capture request/response evidence to disk.
+ * API-8 (#145): with `--negative`, also generate/run one negative-schema (contract-violation) case
+ *   per operation, alongside the happy-path case — same pipeline, distinct `type: "Negative"`.
  */
 import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import { ingestOpenApi, type ApiModel } from "../../api/openapi.js";
-import { generateApiCases, type ApiCase } from "../../api/cases.js";
+import { generateApiCases, generateNegativeCases, type ApiCase } from "../../api/cases.js";
 import { runApiCases, type ApiCaseResult } from "../../api/runner.js";
 import { buildApiTestCaseDocs } from "../../api/testcase-docs.js";
 import { computeApiCoverage, type ApiCoverageReport } from "../../api/coverage.js";
@@ -31,6 +33,8 @@ interface ApiFlags {
   out?: string;
   /** API-3: knowledge dir for api-scope auth/headers (#92). Default `knowledge`. */
   knowledgeDir?: string;
+  /** API-8: also generate/run one negative-schema (contract-violation) case per operation. */
+  negative?: boolean;
 }
 
 /** Parse repeated `--header "Name: Value"` flags into a header map (config auth). */
@@ -96,15 +100,16 @@ export function renderApiSummary(model: ApiModel, source: string): string[] {
   return lines;
 }
 
-/** Render the generated baseline cases — the verifiable artifact of API-2. */
+/** Render the generated cases — the verifiable artifact of API-2 (+ API-8 negative cases, if requested). */
 export function renderApiCases(cases: ApiCase[]): string[] {
+  const negative = cases.filter((c) => c.type === "Negative").length;
   const lines = [
     "",
     "=== Baseline cases (happy-path · 1 per operation) ===",
-    `${cases.length} case(s) generated`,
+    `${cases.length} case(s) generated${negative ? ` (${negative} negative-schema)` : ""}`,
   ];
   for (const c of cases) {
-    lines.push(`  ▸ ${c.name} → ${c.expectedStatus}`);
+    lines.push(`  ▸ ${c.name} [${c.type}] → ${c.expectedStatus}`);
     lines.push(`      [${c.technique}] ${c.rationale}`);
     const sent: Record<string, unknown> = {};
     for (const [where, vals] of Object.entries(c.params)) {
@@ -165,7 +170,7 @@ export const apiModality: Modality = {
       return;
     }
     for (const line of renderApiSummary(model, source)) ctx.out(`${line}\n`);
-    const cases = generateApiCases(model);
+    const cases = [...generateApiCases(model), ...(opts.negative ? generateNegativeCases(model) : [])];
     for (const line of renderApiCases(cases)) ctx.out(`${line}\n`);
 
     // API-3: without --base-url we stop at the generated cases (API-1/2 behaviour, unchanged).

--- a/tests/unit/api-cases.test.ts
+++ b/tests/unit/api-cases.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { ingestOpenApi, type ApiModel } from "../../src/api/openapi.js";
-import { generateApiCases } from "../../src/api/cases.js";
+import { generateApiCases, generateNegativeCases } from "../../src/api/cases.js";
 
 /**
  * C1-04 / API-2 (#132): baseline happy-path case generation. The synthesis is pure/deterministic
@@ -157,5 +157,54 @@ describe("no body / multiple responses (d)", () => {
       security: [],
     });
     expect(generateApiCases(m)[0].expectedStatus).toBe("default");
+  });
+});
+
+describe("generateNegativeCases — one contract-violation case per operation with something to violate (API-8, #145)", () => {
+  it("corrupts a request-body property to the wrong type (createPet: Pet has no required fields, so it violates by type)", async () => {
+    const mAll = await ingestOpenApi(join(fixtures, "petstore.yaml"));
+    const negatives = generateNegativeCases(mAll);
+
+    // getPet/listPets/deletePet have nothing worth violating (no body, no non-path required params).
+    expect(negatives).toHaveLength(1);
+    const [neg] = negatives;
+    expect(neg!.name).toBe("createPet (negative)");
+    expect(neg!.type).toBe("Negative");
+    expect(neg!.technique).toBe("error-guessing");
+    expect(typeof (neg!.body as Record<string, unknown>).id).toBe("number"); // was string — flipped
+    expect((neg!.body as Record<string, unknown>).name).toBe("string"); // untouched, still valid
+    expect(neg!.expectedStatus).toBe("4XX"); // createPet only declares 201 — generic range fallback
+    expect(neg!.expectedSchema).toBeUndefined(); // nothing declared for "4XX" to check against
+  });
+
+  it("omits a required non-path param (query/header/cookie) when there's no body to violate", () => {
+    const m = model({
+      method: "GET",
+      path: "/search",
+      tags: [],
+      parameters: [{ name: "q", in: "query", required: true, schema: { type: "string" } }],
+      responses: [{ status: "200" }, { status: "400" }],
+      security: [],
+    });
+    const [neg] = generateNegativeCases(m);
+    expect(neg!.params.query).toEqual({}); // required "q" dropped
+    expect(neg!.expectedStatus).toBe("400"); // the declared 4xx is used, not the generic range
+  });
+
+  it("skips an operation with nothing to violate (no body, no non-path required params)", async () => {
+    const tiny = await ingestOpenApi(join(fixtures, "tiny.json"));
+    expect(generateNegativeCases(tiny)).toEqual([]);
+  });
+
+  it("does not try to violate a required PATH param (it would just break routing, not the contract)", () => {
+    const m = model({
+      method: "GET",
+      path: "/items/{id}",
+      tags: [],
+      parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+      responses: [{ status: "200" }],
+      security: [],
+    });
+    expect(generateNegativeCases(m)).toEqual([]);
   });
 });

--- a/tests/unit/api-modality.test.ts
+++ b/tests/unit/api-modality.test.ts
@@ -186,6 +186,50 @@ describe("cairn api --base-url run path (API-3, mocked network)", () => {
       await rm(out, { recursive: true, force: true });
     }
   });
+
+  it("(API-8, #145) --negative adds one contract-violation case per operation with something to violate", async () => {
+    const out = await mkdtemp(join(tmpdir(), "qa-api-out3-"));
+    try {
+      // A server that actually enforces its contract: rejects the malformed createPet body (id sent
+      // as a number, not the declared string) with 400 — the case the plain happy-path stub can't catch.
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url: string, init: RequestInit) => {
+          if (init.method === "POST") {
+            const body = JSON.parse(init.body as string) as { id: unknown };
+            const status = typeof body.id === "string" ? 201 : 400;
+            return { status, headers: { get: () => null }, text: async () => "" } as unknown as Response;
+          }
+          const status = init.method === "DELETE" ? 204 : 200;
+          const bodyText = init.method === "GET" ? (_url.includes("{") || _url.endsWith("/pets") ? "[]" : "{}") : "";
+          return { status, headers: { get: () => null }, text: async () => bodyText } as unknown as Response;
+        }),
+      );
+      const { buildProgram } = await import("../../src/cli/index.js");
+      await buildProgram().parseAsync([
+        "node", "cairn", "api", "--spec", join(fixtures, "petstore.yaml"),
+        "--base-url", "https://api.test", "--out", out, "--negative",
+      ]);
+
+      const out0 = outChunks.join("");
+      expect(out0).toContain("5 case(s) generated (1 negative-schema)");
+      expect(out0).toContain("5/5 case(s) passed"); // the malformed body IS correctly rejected (400)
+      expect(process.exitCode ?? 0).toBe(0);
+
+      const report = JSON.parse(await readFile(join(out, "report.json"), "utf8")) as {
+        cases: { name: string; type: string }[];
+      };
+      expect(report.cases).toHaveLength(5);
+      const neg = report.cases.find((c) => c.type === "Negative");
+      expect(neg?.name).toBe("createPet (negative)");
+
+      const { readdir } = await import("node:fs/promises");
+      const tcFileNames = await readdir(join(out, "testcases"));
+      expect(tcFileNames).toHaveLength(5);
+    } finally {
+      await rm(out, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("cairn api source resolution (mocked ingest)", () => {

--- a/tests/unit/api-runner.test.ts
+++ b/tests/unit/api-runner.test.ts
@@ -97,14 +97,45 @@ describe("response-schema conformance (b)", () => {
 
   it("validateAgainstSchema handles enums, arrays, integers, nullable and composition", () => {
     expect(validateAgainstSchema(["a", "b"], { type: "array", items: { type: "string" } })).toEqual([]);
-    expect(validateAgainstSchema([1, "x"], { type: "array", items: { type: "integer" } })).toEqual([expect.stringContaining("[1]: expected number")]);
+    expect(validateAgainstSchema([1, "x"], { type: "array", items: { type: "integer" } })).toEqual([expect.stringContaining(".1: expected integer, got string")]);
     expect(validateAgainstSchema("z", { enum: ["a", "b"] })).toEqual([expect.stringContaining("not in enum")]);
     expect(validateAgainstSchema(7, { type: "integer" })).toEqual([]); // integer satisfied by a JSON number
     expect(validateAgainstSchema(null, { type: "string", nullable: true })).toEqual([]);
-    expect(validateAgainstSchema(null, { type: "string" })).toEqual([expect.stringContaining("null is not")]);
+    expect(validateAgainstSchema(null, { type: "string" })).toEqual([expect.stringContaining("expected string, got null")]);
     expect(validateAgainstSchema({ a: { b: 1 } }, { type: "object", properties: { a: { type: "object", properties: { b: { type: "string" } } } } })).toEqual([expect.stringContaining("$.a.b: expected string")]);
     expect(validateAgainstSchema(5, { oneOf: [{ type: "string" }, { type: "number" }] })).toEqual([]);
-    expect(validateAgainstSchema(true, { oneOf: [{ type: "string" }, { type: "number" }] })).toEqual([expect.stringContaining("matches none")]);
+    expect(validateAgainstSchema(true, { oneOf: [{ type: "string" }, { type: "number" }] })).toEqual(
+      expect.arrayContaining([expect.stringContaining("must match exactly one schema in oneOf")]),
+    );
+  });
+
+  it("(API-8, #145) enforces keywords the old hand-rolled checker skipped — format/pattern/min/max/additionalProperties", () => {
+    expect(validateAgainstSchema("not-an-email", { type: "string", format: "email" })).toEqual([
+      expect.stringContaining('must match format "email"'),
+    ]);
+    expect(validateAgainstSchema("abc", { type: "string", pattern: "^\\d+$" })).toEqual([expect.stringContaining("must match pattern")]);
+    expect(validateAgainstSchema(3, { type: "integer", minimum: 5 })).toEqual([expect.stringContaining(">= 5")]);
+    expect(validateAgainstSchema(11, { type: "integer", maximum: 10 })).toEqual([expect.stringContaining("<= 10")]);
+    expect(validateAgainstSchema({ id: "1", extra: "nope" }, { type: "object", properties: { id: { type: "string" } }, additionalProperties: false })).toEqual([
+      expect.stringContaining('unexpected additional property "extra"'),
+    ]);
+    // valid against every added keyword — no false positives from the upgrade.
+    expect(
+      validateAgainstSchema(
+        { id: "user@example.com" },
+        { type: "object", properties: { id: { type: "string", format: "email" } }, additionalProperties: false },
+      ),
+    ).toEqual([]);
+  });
+
+  it("(API-8, #145) compiles a schema with a real circular $ref (swagger-parser dereference) without infinite recursion", () => {
+    const pet: { type: string; properties: Record<string, unknown> } = {
+      type: "object",
+      properties: { id: { type: "string" } },
+    };
+    pet.properties.friends = { type: "array", items: pet }; // literal object cycle, not a $ref keyword
+    expect(validateAgainstSchema({ id: "1", friends: [{ id: "2", friends: [] }] }, pet)).toEqual([]);
+    expect(validateAgainstSchema({ id: 1 }, pet)).toEqual([expect.stringContaining("expected string, got number")]);
   });
 });
 


### PR DESCRIPTION
Closes #145.

## Summary
- Upgrades `validateAgainstSchema` (`src/api/runner.ts`) from the hand-rolled structural checker to `ajv` + `ajv-formats`, so response-schema conformance now enforces `format`/`pattern`/`minimum`/`maximum`/`additionalProperties` on top of what the old checker already covered (type/required/properties/items/enum/allOf/oneOf/anyOf).
- swagger-parser's `dereference()` turns circular `$ref`s into literal object-identity cycles (e.g. `Pet.friends -> Pet`), which ajv can't compile directly (confirmed: infinite recursion). Added a `deCycle()` pass that walks the schema with a DFS-ancestor set and replaces a re-entered ancestor with `true`, and folds OpenAPI 3.0's `nullable: true` into a `type` array. Compiled validators are cached per schema object.
- New `generateNegativeCases(model)` (`src/api/cases.ts`): one contract-violation case per operation that has something worth violating — flips a request-body property to the wrong JSON type (works even when the spec declares no `required` fields, which is common), or omits a required non-path param. Bodyless operations with no required non-path params are skipped (nothing to force). Expects the lowest declared 4xx, else a generic `4XX` range.
- New case field `type: "Positive" | "Negative"` (reusing the enum from `design/schema.ts`) — a distinct case category, not a parallel pipeline; flows through the existing run/report/coverage/ATC code untouched.
- Opt-in via a new `--negative` CLI flag, so the existing default (1 happy-path case per operation) is unchanged for everyone not passing it.

## Test plan
- [x] `npm run build` — clean
- [x] `npm run lint` — clean (on changed files; one pre-existing unrelated lint error in an untracked scratch file, not part of this change)
- [x] `npm test` — 677 passed (added ajv keyword-coverage tests, a circular-schema compile test, negative-case-generation tests, and a `--negative` CLI wiring test with a fake server that actually rejects the malformed body)
- [x] `npm run smoke:pack` — 8/8 checks pass

## Follow-ups (out of scope here)
- BORROW-07 (#95) adversarial/security styles build on top of this but are attack-intent, not contract conformance — separate slice.