### PR TITLE
cairn api — multi-endpoint scenario chains / journeys (API-9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`cairn api` — multi-endpoint scenario chains / journeys (#146, C1-04 / API-9).** New `--scenarios`
+  flag: given the ingested spec, chains related operations on the same resource (a *collection* path
+  like `/pets` plus an *item* path templated one level deeper, `/pets/{id}`) into an ordered
+  create→read→update→delete scenario, using whichever of those the spec actually declares (a resource
+  with no downstream op — nothing to read/update/delete a created resource with — gets no scenario).
+  Each step is a normal API-2 happy-path case; the runner (`scenario-runner.ts`) threads a value
+  captured from an earlier step's response into a later step's matching param — preferring a declared
+  OpenAPI `links` expression (`$response.body#/...`) when the spec has one, falling back to a
+  same-named response-body field otherwise. A failing step aborts the rest of the scenario (its
+  remaining steps are recorded, not silently dropped, with a `skipped —` reason) rather than
+  cascading one real failure into several meaningless ones. Per-scenario (and per-step) pass/fail is
+  reported alongside the existing per-operation results: a new stdout section, `report.json`'s
+  `scenarios` field, and a `## Scenarios` section in `report.md`. Opt-in, so the existing default
+  (1 case per operation) is unchanged for everyone not passing the flag. Follow-ups (out of scope
+  here): scenario steps aren't folded into the spec-vs-tested coverage report or ATC `.md` docs, both
+  of which are shaped around single operations today.
+
 - **`cairn api` — stricter contract validation + negative-schema cases (#145, C1-04 / API-8).**
   Response-schema conformance now goes through `ajv` (+ `ajv-formats`) instead of the hand-rolled
   structural checker: `format`/`pattern`/`minimum`/`maximum`/`additionalProperties` are now enforced,

--- a/src/api/cases.ts
+++ b/src/api/cases.ts
@@ -16,7 +16,7 @@
  */
 import type { z } from "zod";
 import type { TestTechniqueSchema, TestTypeSchema } from "../design/schema.js";
-import type { ApiEndpoint, ApiModel, ApiParam } from "./openapi.js";
+import type { ApiEndpoint, ApiLink, ApiModel, ApiParam } from "./openapi.js";
 
 /** ISO/IEC/IEEE 29119-4 technique — shared enum with web cases (`design/schema.ts`). */
 export type ApiCaseTechnique = z.infer<typeof TestTechniqueSchema>;
@@ -61,6 +61,9 @@ export interface ApiCase {
   technique: ApiCaseTechnique;
   /** Why this case exists / what it covers — the coverage rationale (API-5). */
   rationale: string;
+  /** Declared `links` on this case's success response (API-9, #146), if the spec has any. A scenario
+   * runner (`scenario-runner.ts`) prefers these over its same-name-field capture heuristic. */
+  responseLinks?: Record<string, ApiLink>;
 }
 
 /** Generate one baseline happy-path case per operation, in the model's (deterministic) order. */
@@ -89,7 +92,9 @@ function synthRequiredParams(e: ApiEndpoint, omit?: ApiParam): ApiCaseParams {
   return params;
 }
 
-function toCase(e: ApiEndpoint): ApiCase {
+/** Build the happy-path case for one operation (API-9, #146: also reused by `scenarios.ts` per step —
+ * a scenario step is a normal case whose path params get overwritten with captured values at run time). */
+export function toCase(e: ApiEndpoint): ApiCase {
   const success = pickSuccess(e);
   const expectedStatus = success?.status ?? "200";
   return {
@@ -101,6 +106,7 @@ function toCase(e: ApiEndpoint): ApiCase {
     body: e.requestBody?.schema !== undefined ? synth(e.requestBody.schema) : undefined,
     expectedStatus,
     expectedSchema: success?.schema,
+    ...(success?.links ? { responseLinks: success.links } : {}),
     type: "Positive",
     // Nominal happy-path = the valid equivalence class for this operation's inputs (ISO 29119-4).
     technique: "equivalence-partitioning",

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -19,12 +19,25 @@ export interface ApiParam {
   schema?: unknown;
 }
 
+/**
+ * An OpenAPI `links` entry (API-9, #146): declares which other operation a response can seed, and
+ * how — `parameters` maps a *target*-operation parameter name to a runtime expression (e.g.
+ * `"$response.body#/id"`) evaluated against this response. The spec-native alternative to guessing
+ * "which field feeds the next request" by name.
+ */
+export interface ApiLink {
+  operationId?: string;
+  parameters: Record<string, string>;
+}
+
 /** One response of an endpoint, keyed by status code (or "default"). */
 export interface ApiResponse {
   status: string;
   description?: string;
   /** Schema of the first response media type, if the response carries a body. */
   schema?: unknown;
+  /** Declared `links` (API-9, #146) — empty when the spec doesn't declare any. */
+  links?: Record<string, ApiLink>;
 }
 
 /** The request body of an endpoint (absent for GET/DELETE-style ops without a body). */
@@ -86,7 +99,10 @@ interface RawOperation {
   tags?: string[];
   parameters?: RawParam[];
   requestBody?: { required?: boolean; content?: Record<string, { schema?: unknown }> };
-  responses?: Record<string, { description?: string; content?: Record<string, { schema?: unknown }> }>;
+  responses?: Record<
+    string,
+    { description?: string; content?: Record<string, { schema?: unknown }>; links?: Record<string, RawLink> }
+  >;
   security?: RawSecurityRequirement[];
   deprecated?: boolean;
 }
@@ -97,6 +113,10 @@ interface RawParam {
   schema?: unknown;
 }
 type RawSecurityRequirement = Record<string, string[]>;
+interface RawLink {
+  operationId?: string;
+  parameters?: Record<string, string>;
+}
 
 const HTTP_METHODS = ["get", "put", "post", "delete", "options", "head", "patch", "trace"] as const;
 
@@ -190,12 +210,22 @@ function toRequestBody(rb: RawOperation["requestBody"]): ApiRequestBody | undefi
 function toResponses(responses: RawOperation["responses"]): ApiResponse[] {
   return Object.entries(responses ?? {}).map(([status, r]) => {
     const first = Object.keys(r.content ?? {})[0];
+    const links = toLinks(r.links);
     return {
       status,
       description: r.description,
       schema: first ? r.content?.[first]?.schema : undefined,
+      ...(links ? { links } : {}),
     };
   });
+}
+
+/** API-9 (#146): declared `links`, if any — `undefined` (not `{}`) when the spec declares none. */
+function toLinks(raw: Record<string, RawLink> | undefined): Record<string, ApiLink> | undefined {
+  if (!raw || Object.keys(raw).length === 0) return undefined;
+  const out: Record<string, ApiLink> = {};
+  for (const [name, l] of Object.entries(raw)) out[name] = { operationId: l.operationId, parameters: l.parameters ?? {} };
+  return out;
 }
 
 /** Flatten security requirement objects to the distinct set of scheme names they reference. */

--- a/src/api/scenario-runner.ts
+++ b/src/api/scenario-runner.ts
@@ -1,0 +1,141 @@
+/**
+ * C1-04 / API-9 (#146) — execute a generated {@link ApiScenario} step by step, threading captured
+ * response values into downstream requests.
+ *
+ * Each step reuses `runApiCases` (API-3) verbatim — a resolved step IS a normal `ApiCase`, so all of
+ * the runner's auth/retry/redaction/schema-assertion behaviour applies unchanged. The only new
+ * behaviour here: (a) before sending a step, overwrite any of its params whose name matches a value
+ * captured earlier; (b) after a step succeeds, capture values for steps still to come — preferring a
+ * declared `links` expression (`ApiCase.responseLinks`) over the fallback heuristic (a response-body
+ * field with the same name as the needed param); (c) a failed step aborts the rest of the scenario —
+ * continuing with an unresolved captured value (e.g. a missing id after a failed create) would just
+ * cascade one real failure into several meaningless ones.
+ */
+import { runApiCases, type ApiCaseResult, type RunnerOptions } from "./runner.js";
+import type { ApiCase, ApiCaseParams } from "./cases.js";
+import type { ApiScenario } from "./scenarios.js";
+
+export interface ApiScenarioResult {
+  name: string;
+  steps: ApiCaseResult[];
+  passed: boolean;
+}
+
+export async function runApiScenarios(scenarios: ApiScenario[], opts: RunnerOptions): Promise<ApiScenarioResult[]> {
+  const results: ApiScenarioResult[] = [];
+  for (const scenario of scenarios) results.push(await runOneScenario(scenario, opts));
+  return results;
+}
+
+async function runOneScenario(scenario: ApiScenario, opts: RunnerOptions): Promise<ApiScenarioResult> {
+  const captured: Record<string, string> = {};
+  const steps: ApiCaseResult[] = [];
+  let aborted = false;
+
+  for (let i = 0; i < scenario.steps.length; i++) {
+    const step = scenario.steps[i]!;
+    if (aborted) {
+      steps.push(skippedResult(step));
+      continue;
+    }
+
+    const [result] = await runApiCases([resolveParams(step, captured)], opts);
+    steps.push(result!);
+    if (!result!.passed) {
+      aborted = true; // an earlier step in the chain failed — later steps have nothing valid to run on
+      continue;
+    }
+    captureValues(step, result!, scenario.steps.slice(i + 1), captured);
+  }
+
+  return { name: scenario.name, steps, passed: steps.every((s) => s.passed) };
+}
+
+function skippedResult(step: ApiCase): ApiCaseResult {
+  return {
+    name: step.name,
+    method: step.method,
+    url: "",
+    request: { headers: {} },
+    attempts: 0,
+    expectedStatus: step.expectedStatus,
+    statusOk: false,
+    schemaOk: false,
+    schemaErrors: [],
+    passed: false,
+    error: "skipped — an earlier step in this scenario failed",
+  };
+}
+
+/** Overwrite any param whose name matches a value captured from an earlier step. */
+function resolveParams(step: ApiCase, captured: Record<string, string>): ApiCase {
+  if (Object.keys(captured).length === 0) return step;
+  const apply = (bucket: Record<string, unknown>): Record<string, unknown> => {
+    const out = { ...bucket };
+    for (const k of Object.keys(out)) if (k in captured) out[k] = captured[k];
+    return out;
+  };
+  const params: ApiCaseParams = {
+    path: apply(step.params.path),
+    query: apply(step.params.query),
+    header: apply(step.params.header),
+    cookie: apply(step.params.cookie),
+  };
+  return { ...step, params };
+}
+
+/** After a step succeeds, capture whatever later steps' params need — links first, name-match second. */
+function captureValues(step: ApiCase, result: ApiCaseResult, laterSteps: ApiCase[], captured: Record<string, string>): void {
+  const neededNames = new Set(
+    laterSteps.flatMap((s) => [
+      ...Object.keys(s.params.path),
+      ...Object.keys(s.params.query),
+      ...Object.keys(s.params.header),
+      ...Object.keys(s.params.cookie),
+    ]),
+  );
+  if (neededNames.size === 0) return;
+
+  const body = result.response?.json;
+  const bodyObj = body && typeof body === "object" && !Array.isArray(body) ? (body as Record<string, unknown>) : undefined;
+
+  for (const name of neededNames) {
+    const viaLink = evalLinkFor(step, name, laterSteps, body);
+    if (viaLink !== undefined) {
+      captured[name] = viaLink;
+      continue;
+    }
+    if (bodyObj && name in bodyObj) captured[name] = String(bodyObj[name]);
+  }
+}
+
+/** A declared `links` expression targeting one of the later steps, for the given param name. */
+function evalLinkFor(step: ApiCase, paramName: string, laterSteps: ApiCase[], body: unknown): string | undefined {
+  if (!step.responseLinks) return undefined;
+  const laterOpIds = new Set(laterSteps.map((s) => s.operationId).filter((id): id is string => !!id));
+  for (const link of Object.values(step.responseLinks)) {
+    if (!link.operationId || !laterOpIds.has(link.operationId)) continue;
+    const expr = link.parameters[paramName];
+    if (!expr) continue;
+    const val = evalResponseBodyPointer(body, expr);
+    if (val !== undefined) return String(val);
+  }
+  return undefined;
+}
+
+/**
+ * ponytail: supports only the `$response.body#/<json-pointer>` runtime-expression form (OpenAPI's
+ * `links` grammar also allows `$request.*`/`$url`/etc.) — the one shape that actually matters for
+ * threading a created resource's id into the next request; add more forms if a real spec needs them.
+ */
+function evalResponseBodyPointer(body: unknown, expr: string): unknown {
+  const m = /^\$response\.body#(\/.*)$/.exec(expr);
+  if (!m) return undefined;
+  let cur: unknown = body;
+  for (const raw of m[1]!.split("/").slice(1)) {
+    const key = raw.replace(/~1/g, "/").replace(/~0/g, "~");
+    if (cur === null || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[key];
+  }
+  return cur;
+}

--- a/src/api/scenarios.ts
+++ b/src/api/scenarios.ts
@@ -1,0 +1,81 @@
+/**
+ * C1-04 / API-9 (#146) — multi-endpoint scenario chains ("journeys" for the API modality): given the
+ * {@link ApiModel}, generate ordered chains of related operations on the same resource (create → read
+ * → update → delete, using whichever of those the spec actually declares), so a scenario can prove a
+ * resource's identifier really flows from one response into the next request — something no
+ * single-operation case (API-2/API-8) can express.
+ *
+ * "Related" = same resource, detected the same way REST APIs are conventionally shaped: a *collection*
+ * path (`/pets`) and an *item* path templated one level deeper (`/pets/{id}`). No LLM, no new schema
+ * keywords — pure structural grouping over the already-ingested model (API-1).
+ *
+ * A scenario step IS a normal {@link ApiCase} (from `toCase()`, API-2's exact synthesis) — nothing new
+ * to learn for rendering/reporting. The only scenario-specific behaviour lives in the runner
+ * (`scenario-runner.ts`): before sending a downstream step, it overwrites any of that step's params
+ * whose name matches a value captured from an earlier step's response (declared `links` first, a
+ * same-name field second — see `ApiCase.responseLinks`).
+ */
+import { apiEndpointKey, toCase, type ApiCase } from "./cases.js";
+import type { ApiEndpoint, ApiModel } from "./openapi.js";
+
+export interface ApiScenario {
+  /** e.g. "pets lifecycle" — derived from the resource's collection path. */
+  name: string;
+  /** In CRUD order (whichever of create/read/update/delete the spec actually declares). */
+  steps: ApiCase[];
+  technique: "state-transition"; // ISO/IEC/IEEE 29119-4: a case exercising a resource's lifecycle
+  rationale: string;
+}
+
+/**
+ * A path's *collection* form: the path with a trailing `{param}` segment stripped, e.g.
+ * `/pets/{id}` → `/pets`. A path with no trailing template segment is already a collection path.
+ */
+function collectionPathOf(path: string): string {
+  const segments = path.split("/");
+  const last = segments[segments.length - 1];
+  if (last && /^\{.+\}$/.test(last)) return segments.slice(0, -1).join("/") || "/";
+  return path;
+}
+
+/** Group endpoints by their collection path — the candidate "same resource" grouping. */
+function groupByResource(model: ApiModel): Map<string, ApiEndpoint[]> {
+  const groups = new Map<string, ApiEndpoint[]>();
+  for (const e of model.endpoints) {
+    const key = collectionPathOf(e.path);
+    const bucket = groups.get(key);
+    if (bucket) bucket.push(e);
+    else groups.set(key, [e]);
+  }
+  return groups;
+}
+
+/** Generate one lifecycle scenario per resource that has both a create op and something to chain it
+ * to — a resource with only a create (nothing to read/update/delete) has no chain worth generating. */
+export function generateApiScenarios(model: ApiModel): ApiScenario[] {
+  const scenarios: ApiScenario[] = [];
+  for (const [collectionPath, endpoints] of groupByResource(model)) {
+    const itemOps = endpoints.filter((e) => e.path !== collectionPath);
+    const create = endpoints.find((e) => e.path === collectionPath && e.method === "POST" && e.requestBody);
+    if (!create) continue;
+
+    const read = itemOps.find((e) => e.method === "GET");
+    const update = itemOps.find((e) => e.method === "PUT" || e.method === "PATCH");
+    const del = itemOps.find((e) => e.method === "DELETE");
+    const downstream = [read, update, del].filter((e): e is ApiEndpoint => e !== undefined);
+    if (downstream.length === 0) continue;
+
+    const resourceName = collectionPath.replace(/^\//, "") || collectionPath;
+    const chain = [create, ...downstream];
+    scenarios.push({
+      name: `${resourceName} lifecycle`,
+      steps: chain.map(toCase),
+      technique: "state-transition",
+      rationale:
+        `Chains ${chain.length} related operations on ${collectionPath} (${chain.map((e) => apiEndpointKey(e)).join(" → ")}), ` +
+        `threading the resource identifier captured from ${apiEndpointKey(create)}'s response into each ` +
+        `downstream request (state-transition, ISO/IEC/IEEE 29119-4) — the API analogue of a multi-page journey.`,
+    });
+  }
+  return scenarios;
+}

--- a/src/artifacts/report.ts
+++ b/src/artifacts/report.ts
@@ -8,6 +8,7 @@ import { METRIC_LEGEND, dirGlyph } from "../eval/legend.js";
 import type { CostReport } from "../llm/cost.js";
 import type { ApiCaseResult } from "../api/runner.js";
 import type { ApiCoverageReport } from "../api/coverage.js";
+import type { ApiScenarioResult } from "../api/scenario-runner.js";
 import { displayPath } from "../agent/summary.js";
 
 /** Generate a Playwright locator for an element (ref → getByRole). */
@@ -185,6 +186,8 @@ export interface ApiReportInput {
   evidencePath: string;
   /** API-6 (#136): spec-vs-tested coverage (playswag-style) — rendered as a gaps section when present. */
   coverage?: ApiCoverageReport;
+  /** API-9 (#146): multi-endpoint scenario chains — rendered as a section only when non-empty. */
+  scenarios?: ApiScenarioResult[];
 }
 
 /** Human-readable Markdown run report for `cairn api`: per-operation pass/fail + evidence link. */
@@ -205,6 +208,21 @@ export function renderApiReportMd(r: ApiReportInput): string {
     lines.push(`| ${x.passed ? "✓" : "✗"} | ${x.method} | ${x.url} | ${x.expectedStatus} | ${got} |`);
   }
   lines.push("");
+
+  // API-9 (#146): per-scenario pass/fail, each step's own row (mirrors the Operations table above).
+  if (r.scenarios && r.scenarios.length > 0) {
+    const scenariosPassed = r.scenarios.filter((s) => s.passed).length;
+    lines.push(`## Scenarios (${scenariosPassed}/${r.scenarios.length} passed)`, "");
+    for (const s of r.scenarios) {
+      lines.push(`### ${s.passed ? "✓" : "✗"} ${s.name}`, "");
+      lines.push("| status | method | url | expected | got |", "|---|---|---|---|---|");
+      for (const step of s.steps) {
+        const got = step.error ? step.error : String(step.response?.status ?? "—");
+        lines.push(`| ${step.passed ? "✓" : "✗"} | ${step.method} | ${step.url || "—"} | ${step.expectedStatus} | ${got} |`);
+      }
+      lines.push("");
+    }
+  }
 
   // API-6 (#136): spec-vs-tested coverage (playswag-style) — gaps only; covered ops need no row.
   if (r.coverage) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -140,6 +140,7 @@ export function buildProgram(): Command {
     .option("--out <dir>", "API-3: where to write run evidence (default runs/api-<id>/)")
     .option("--knowledge-dir <dir>", "API-3: dir holding api-scope auth/headers knowledge (default knowledge/)")
     .option("--negative", "API-8: also generate/run one negative-schema (contract-violation) case per operation")
+    .option("--scenarios", "API-9: also generate/run multi-endpoint scenario chains (e.g. create → read → delete)")
     .action(async (opts: Record<string, unknown>) => {
       await runModality("api", opts);
     });

--- a/src/core/modalities/api.ts
+++ b/src/core/modalities/api.ts
@@ -7,13 +7,17 @@
  *   assert status + response-schema per case, and capture request/response evidence to disk.
  * API-8 (#145): with `--negative`, also generate/run one negative-schema (contract-violation) case
  *   per operation, alongside the happy-path case — same pipeline, distinct `type: "Negative"`.
+ * API-9 (#146): with `--scenarios`, also generate/run multi-endpoint chains on the same resource
+ *   (e.g. create → read → delete), threading a captured response value through each step.
  */
 import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import { ingestOpenApi, type ApiModel } from "../../api/openapi.js";
 import { generateApiCases, generateNegativeCases, type ApiCase } from "../../api/cases.js";
-import { runApiCases, type ApiCaseResult } from "../../api/runner.js";
+import { runApiCases, type ApiCaseResult, type RunnerOptions } from "../../api/runner.js";
+import { generateApiScenarios, type ApiScenario } from "../../api/scenarios.js";
+import { runApiScenarios, type ApiScenarioResult } from "../../api/scenario-runner.js";
 import { buildApiTestCaseDocs } from "../../api/testcase-docs.js";
 import { computeApiCoverage, type ApiCoverageReport } from "../../api/coverage.js";
 import { loadApiCreds } from "../../knowledge/index.js";
@@ -35,6 +39,8 @@ interface ApiFlags {
   knowledgeDir?: string;
   /** API-8: also generate/run one negative-schema (contract-violation) case per operation. */
   negative?: boolean;
+  /** API-9: also generate/run multi-endpoint scenario chains (e.g. create → read → delete). */
+  scenarios?: boolean;
 }
 
 /** Parse repeated `--header "Name: Value"` flags into a header map (config auth). */
@@ -122,6 +128,34 @@ export function renderApiCases(cases: ApiCase[]): string[] {
   return lines;
 }
 
+/** Render the generated scenario chains (API-9, #146) — a cases-only preview when there's no run yet. */
+export function renderApiScenarios(scenarios: ApiScenario[]): string[] {
+  if (scenarios.length === 0) return [];
+  const lines = ["", `=== Scenarios (${scenarios.length} chain(s) generated) ===`];
+  for (const s of scenarios) {
+    lines.push(`  ▸ ${s.name} (${s.steps.map((c) => c.name).join(" → ")})`);
+    lines.push(`      [${s.technique}] ${s.rationale}`);
+  }
+  lines.push("");
+  return lines;
+}
+
+/** Render scenario run results — per-scenario pass/fail + per-step breakdown (API-9 DoD). */
+export function renderApiScenarioRun(results: ApiScenarioResult[]): string[] {
+  if (results.length === 0) return [];
+  const passed = results.filter((r) => r.passed).length;
+  const lines = ["", "=== Scenario results ===", `${passed}/${results.length} scenario(s) passed`];
+  for (const r of results) {
+    lines.push(`  ${r.passed ? "✓" : "✗"} ${r.name}`);
+    for (const step of r.steps) {
+      const mark = step.passed ? "✓" : step.error?.startsWith("skipped") ? "⊘" : "✗";
+      const got = step.error ? `${step.error}` : `${step.response?.status ?? "—"} (want ${step.expectedStatus})`;
+      lines.push(`      ${mark} ${step.name} → ${got}`);
+    }
+  }
+  return lines;
+}
+
 /**
  * Render the spec-vs-tested coverage report (API-6, #136, `playswag`-style) — a summary line plus
  * gaps only (uncovered/partial); fully-covered operations need no per-row listing.
@@ -172,6 +206,8 @@ export const apiModality: Modality = {
     for (const line of renderApiSummary(model, source)) ctx.out(`${line}\n`);
     const cases = [...generateApiCases(model), ...(opts.negative ? generateNegativeCases(model) : [])];
     for (const line of renderApiCases(cases)) ctx.out(`${line}\n`);
+    const scenarios = opts.scenarios ? generateApiScenarios(model) : [];
+    for (const line of renderApiScenarios(scenarios)) ctx.out(`${line}\n`);
 
     // API-3: without --base-url we stop at the generated cases (API-1/2 behaviour, unchanged).
     if (!opts.baseUrl) {
@@ -186,10 +222,14 @@ export const apiModality: Modality = {
     const fromKnowledge = await loadApiCreds(knowledgeDir, { scope: "api", endpoint: opts.baseUrl });
     const headers = { ...fromKnowledge, ...parseHeaderFlags(opts.header) };
 
+    const runnerOpts: RunnerOptions = { baseUrl: opts.baseUrl, auth: { headers } };
     ctx.err(`▸ Running ${cases.length} case(s) against ${opts.baseUrl}…\n`);
-    const results = await runApiCases(cases, { baseUrl: opts.baseUrl, auth: { headers } });
+    const results = await runApiCases(cases, runnerOpts);
     // API-6 (#136): spec-vs-tested coverage, overlaid with this run's pass/fail per operation.
     const coverage = computeApiCoverage(model, cases, results);
+
+    // API-9 (#146): scenario chains run after the per-operation cases — independent of them.
+    const scenarioResults = scenarios.length ? await runApiScenarios(scenarios, runnerOpts) : [];
 
     const outDir = opts.out ? resolve(opts.out) : join(defaultRunsBaseDir(), `api-${randomUUID()}`);
     await mkdir(outDir, { recursive: true });
@@ -214,6 +254,9 @@ export const apiModality: Modality = {
           cases: cases.map((c) => omitExpectedSchema(c)),
           // API-6 (#136): spec-vs-tested coverage (playswag-style) — which operations/statuses are gaps.
           coverage,
+          // API-9 (#146): per-scenario pass/fail alongside the per-operation results — opt-in, so the
+          // key is only present when --scenarios generated something to report.
+          ...(scenarioResults.length ? { scenarios: scenarioResults } : {}),
         },
         null,
         2,
@@ -230,6 +273,7 @@ export const apiModality: Modality = {
         endpointCount: model.endpoints.length,
         evidencePath,
         coverage,
+        scenarios: scenarioResults,
       }),
       "utf8",
     );
@@ -244,6 +288,7 @@ export const apiModality: Modality = {
     for (const d of caseDocs.docs) await writeFile(join(testCasesDir, `${d.id}.md`), d.md, "utf8");
 
     for (const line of renderApiRun(results)) ctx.out(`${line}\n`);
+    for (const line of renderApiScenarioRun(scenarioResults)) ctx.out(`${line}\n`);
     for (const line of renderApiCoverage(coverage)) ctx.out(`${line}\n`);
     for (const line of renderRunSummary({
       runDir: outDir,
@@ -252,6 +297,7 @@ export const apiModality: Modality = {
       ctx.out(`${line}\n`);
     }
     ctx.out(`  Cases (ATC .md): ${displayPath(testCasesDir)}/\n`);
-    if (results.some((r) => !r.passed)) process.exitCode = 1; // any failed assertion → non-zero exit
+    // Any failed assertion (per-operation case or scenario step) → non-zero exit.
+    if (results.some((r) => !r.passed) || scenarioResults.some((r) => !r.passed)) process.exitCode = 1;
   },
 };

--- a/tests/fixtures/api/crud-store.yaml
+++ b/tests/fixtures/api/crud-store.yaml
@@ -1,0 +1,164 @@
+openapi: 3.0.3
+info:
+  title: CRUD Store
+  version: 1.0.0
+paths:
+  /items:
+    post:
+      operationId: createItem
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:
+                  type: string
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, name]
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+          links:
+            GetItem:
+              operationId: getItem
+              parameters:
+                id: "$response.body#/id"
+            UpdateItem:
+              operationId: updateItem
+              parameters:
+                id: "$response.body#/id"
+            DeleteItem:
+              operationId: deleteItem
+              parameters:
+                id: "$response.body#/id"
+  /items/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getItem
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+        '404':
+          description: Not found
+    put:
+      operationId: updateItem
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:
+                  type: string
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+    delete:
+      operationId: deleteItem
+      responses:
+        '204':
+          description: Deleted
+  /widgets:
+    post:
+      operationId: createWidget
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [label]
+              properties:
+                label:
+                  type: string
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, label]
+                properties:
+                  id:
+                    type: string
+                  label:
+                    type: string
+  /widgets/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getWidget
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  label:
+                    type: string
+    delete:
+      operationId: deleteWidget
+      responses:
+        '204':
+          description: Deleted
+  /events:
+    post:
+      operationId: recordEvent
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [kind]
+              properties:
+                kind:
+                  type: string
+      responses:
+        '201':
+          description: Recorded

--- a/tests/unit/api-modality.test.ts
+++ b/tests/unit/api-modality.test.ts
@@ -230,6 +230,93 @@ describe("cairn api --base-url run path (API-3, mocked network)", () => {
       await rm(out, { recursive: true, force: true });
     }
   });
+
+  it("(API-9, #146) --scenarios chains create → read → update → delete, threading the captured id", async () => {
+    const out = await mkdtemp(join(tmpdir(), "qa-api-out4-"));
+    try {
+      // Echoes whatever id is in the URL back in the body — the scenario's downstream URLs only ever
+      // carry "abc123" (createItem's response id) if the runner actually threaded it through; the
+      // base per-operation cases (independent, unthreaded synthetic ids) get a valid response either way.
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string, init: RequestInit) => {
+          const path = new URL(url).pathname;
+          if (path === "/items" && init.method === "POST") {
+            const body = JSON.parse(init.body as string) as { name: string };
+            return { status: 201, headers: { get: () => null }, text: async () => JSON.stringify({ id: "abc123", name: body.name }) } as unknown as Response;
+          }
+          const item = path.match(/^\/items\/([^/]+)$/);
+          if (item && (init.method === "GET" || init.method === "PUT")) {
+            return { status: 200, headers: { get: () => null }, text: async () => JSON.stringify({ id: item[1], name: "string" }) } as unknown as Response;
+          }
+          if (item && init.method === "DELETE") {
+            return { status: 204, headers: { get: () => null }, text: async () => "" } as unknown as Response;
+          }
+          if (path === "/widgets" && init.method === "POST") {
+            return { status: 201, headers: { get: () => null }, text: async () => JSON.stringify({ id: "w1", label: "string" }) } as unknown as Response;
+          }
+          const widget = path.match(/^\/widgets\/([^/]+)$/);
+          if (widget && init.method === "GET") {
+            return { status: 200, headers: { get: () => null }, text: async () => JSON.stringify({ id: widget[1], label: "string" }) } as unknown as Response;
+          }
+          if (widget && init.method === "DELETE") {
+            return { status: 204, headers: { get: () => null }, text: async () => "" } as unknown as Response;
+          }
+          return { status: 201, headers: { get: () => null }, text: async () => "" } as unknown as Response; // recordEvent — no response schema
+        }),
+      );
+
+      const { buildProgram } = await import("../../src/cli/index.js");
+      await buildProgram().parseAsync([
+        "node", "cairn", "api", "--spec", join(fixtures, "crud-store.yaml"),
+        "--base-url", "https://api.test", "--out", out, "--scenarios",
+      ]);
+
+      const out0 = outChunks.join("");
+      expect(out0).toContain("Scenarios (2 chain(s) generated)");
+      expect(out0).toContain("2/2 scenario(s) passed");
+      expect(process.exitCode ?? 0).toBe(0);
+
+      const report = JSON.parse(await readFile(join(out, "report.json"), "utf8")) as {
+        scenarios: { name: string; passed: boolean; steps: { name: string; url: string; passed: boolean }[] }[];
+      };
+      const items = report.scenarios.find((s) => s.name === "items lifecycle")!;
+      expect(items.passed).toBe(true);
+      expect(items.steps.map((s) => s.name)).toEqual(["createItem", "getItem", "updateItem", "deleteItem"]);
+      // Every downstream step's URL carries the id captured from createItem's response — proof the
+      // declared `links` (crud-store.yaml) actually drove the threading, not a coincidence.
+      for (const s of items.steps.slice(1)) expect(s.url).toBe("https://api.test/items/abc123");
+
+      const reportMd = await readFile(join(out, "report.md"), "utf8");
+      expect(reportMd).toContain("## Scenarios (2/2 passed)");
+      expect(reportMd).toContain("### ✓ items lifecycle");
+    } finally {
+      await rm(out, { recursive: true, force: true });
+    }
+  });
+
+  it("(API-9, #146) a failing create step aborts the scenario — later steps recorded as skipped, non-zero exit", async () => {
+    const out = await mkdtemp(join(tmpdir(), "qa-api-out5-"));
+    try {
+      // 200 instead of the declared 201 — a non-transient status mismatch, so it fails fast (no retry).
+      vi.stubGlobal("fetch", vi.fn(async () => ({ status: 200, headers: { get: () => null }, text: async () => "{}" }) as unknown as Response));
+      const { buildProgram } = await import("../../src/cli/index.js");
+      await buildProgram().parseAsync([
+        "node", "cairn", "api", "--spec", join(fixtures, "crud-store.yaml"),
+        "--base-url", "https://api.test", "--out", out, "--scenarios",
+      ]);
+
+      expect(process.exitCode).toBe(1);
+      const report = JSON.parse(await readFile(join(out, "report.json"), "utf8")) as {
+        scenarios: { name: string; passed: boolean; steps: { error?: string }[] }[];
+      };
+      const items = report.scenarios.find((s) => s.name === "items lifecycle")!;
+      expect(items.passed).toBe(false);
+      expect(items.steps[1]!.error).toMatch(/^skipped/);
+    } finally {
+      await rm(out, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("cairn api source resolution (mocked ingest)", () => {

--- a/tests/unit/api-scenario-runner.test.ts
+++ b/tests/unit/api-scenario-runner.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { runApiScenarios } from "../../src/api/scenario-runner.js";
+import type { ApiCase } from "../../src/api/cases.js";
+import type { ApiScenario } from "../../src/api/scenarios.js";
+import type { FetchLike, ResponseLike } from "../../src/api/runner.js";
+
+/**
+ * C1-04 / API-9 (#146): the scenario runner threads a captured response value into a downstream
+ * step, aborts (and marks "skipped") the rest of a scenario when a step fails, and prefers a declared
+ * `links` expression over the name-match fallback when both would apply.
+ */
+
+function fakeFetch(handler: (url: string, init: RequestInit) => ResponseLike): { fetch: FetchLike; calls: { url: string; init: RequestInit }[] } {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const fetch: FetchLike = async (url, init) => {
+    calls.push({ url, init });
+    return handler(url, init);
+  };
+  return { fetch, calls };
+}
+
+function res(status: number, body: unknown = ""): ResponseLike {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  return { status, headers: { get: () => null }, text: async () => text };
+}
+
+function step(over: Partial<ApiCase>): ApiCase {
+  return {
+    name: "step",
+    method: "GET",
+    path: "/x",
+    params: { path: {}, query: {}, header: {}, cookie: {} },
+    expectedStatus: "200",
+    type: "Positive",
+    technique: "state-transition",
+    rationale: "test",
+    ...over,
+  } as ApiCase;
+}
+
+function scenarioOf(steps: ApiCase[]): ApiScenario {
+  return { name: "test lifecycle", steps, technique: "state-transition", rationale: "test" };
+}
+
+describe("runApiScenarios — capture + thread + abort (API-9, #146)", () => {
+  it("captures a response field by name and threads it into a later step's path param (fallback heuristic)", async () => {
+    const create = step({ name: "create", method: "POST", path: "/items", expectedStatus: "201" });
+    const read = step({ name: "read", method: "GET", path: "/items/{id}", params: { path: { id: "PLACEHOLDER" }, query: {}, header: {}, cookie: {} } });
+    const { fetch, calls } = fakeFetch((url) => (url.endsWith("/items") ? res(201, { id: "42", name: "widget" }) : res(200, { id: "42" })));
+
+    const [result] = await runApiScenarios([scenarioOf([create, read])], { baseUrl: "https://api.test", fetch });
+
+    expect(calls[1]!.url).toBe("https://api.test/items/42"); // captured id, not "PLACEHOLDER"
+    expect(result!.passed).toBe(true);
+    expect(result!.steps.map((s) => s.passed)).toEqual([true, true]);
+  });
+
+  it("prefers a declared `links` expression over the same-name-field fallback", async () => {
+    const create = step({
+      name: "create",
+      method: "POST",
+      path: "/items",
+      expectedStatus: "201",
+      responseLinks: { GetItem: { operationId: "getItem", parameters: { id: "$response.body#/realId" } } },
+    });
+    const read = step({
+      name: "read",
+      method: "GET",
+      path: "/items/{id}",
+      operationId: "getItem",
+      params: { path: { id: "PLACEHOLDER" }, query: {}, header: {}, cookie: {} },
+    });
+    // Response has both a decoy top-level "id" and the link-targeted "realId" — the link must win.
+    const { fetch, calls } = fakeFetch((url) => (url.endsWith("/items") ? res(201, { id: "decoy", realId: "99" }) : res(200, {})));
+
+    await runApiScenarios([scenarioOf([create, read])], { baseUrl: "https://api.test", fetch });
+
+    expect(calls[1]!.url).toBe("https://api.test/items/99");
+  });
+
+  it("aborts the rest of the scenario when a step fails, marking later steps skipped", async () => {
+    const create = step({ name: "create", method: "POST", path: "/items", expectedStatus: "201" });
+    const read = step({ name: "read", method: "GET", path: "/items/{id}", params: { path: { id: "x" }, query: {}, header: {}, cookie: {} } });
+    const del = step({ name: "delete", method: "DELETE", path: "/items/{id}", expectedStatus: "204", params: { path: { id: "x" }, query: {}, header: {}, cookie: {} } });
+    // create fails its status assertion (500, not the declared 201) — read/delete must never fire.
+    const { fetch, calls } = fakeFetch(() => res(500, { error: "boom" }));
+
+    const [result] = await runApiScenarios([scenarioOf([create, read, del])], { baseUrl: "https://api.test", fetch, retries: 0 });
+
+    expect(calls).toHaveLength(1); // only the failing create step actually made a request
+    expect(result!.passed).toBe(false);
+    expect(result!.steps[0]!.passed).toBe(false);
+    expect(result!.steps[1]!.error).toMatch(/^skipped/);
+    expect(result!.steps[1]!.passed).toBe(false);
+    expect(result!.steps[2]!.error).toMatch(/^skipped/);
+  });
+
+  it("a fully-passing scenario is passed=true; every step reused the normal runner (auth/redaction apply)", async () => {
+    const create = step({ name: "create", method: "POST", path: "/items", expectedStatus: "201" });
+    const { fetch } = fakeFetch(() => res(201, { id: "1" }));
+
+    const [result] = await runApiScenarios([scenarioOf([create])], {
+      baseUrl: "https://api.test",
+      fetch,
+      auth: { headers: { Authorization: "Bearer secret" } },
+    });
+
+    expect(result!.passed).toBe(true);
+    expect(result!.steps[0]!.request.headers["Authorization"]).toBe("***"); // same redaction as runApiCases
+  });
+});

--- a/tests/unit/api-scenarios.test.ts
+++ b/tests/unit/api-scenarios.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { ingestOpenApi, type ApiModel } from "../../src/api/openapi.js";
+import { generateApiScenarios } from "../../src/api/scenarios.js";
+
+/**
+ * C1-04 / API-9 (#146): multi-endpoint scenario chains. `crud-store.yaml` has three resource groups
+ * exercising the three generation paths: a full CRUD resource with declared `links` (items), a
+ * partial resource (create+read+delete, no update) with no links, relying on the name-match fallback
+ * (widgets), and a create-only resource with nothing to chain to (events).
+ */
+const fixtures = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "api");
+
+async function crudStore(): Promise<ApiModel> {
+  return ingestOpenApi(join(fixtures, "crud-store.yaml"));
+}
+
+describe("generateApiScenarios — resource grouping + CRUD ordering (a)", () => {
+  it("chains a full CRUD resource in create → read → update → delete order", async () => {
+    const model = await crudStore();
+    const scenarios = generateApiScenarios(model);
+    const items = scenarios.find((s) => s.name === "items lifecycle")!;
+    expect(items).toBeDefined();
+    expect(items.steps.map((c) => c.name)).toEqual(["createItem", "getItem", "updateItem", "deleteItem"]);
+    expect(items.technique).toBe("state-transition");
+  });
+
+  it("carries the create step's declared `links` for the runner to prefer over the name-match fallback", async () => {
+    const model = await crudStore();
+    const [create] = generateApiScenarios(model).find((s) => s.name === "items lifecycle")!.steps;
+    expect(create!.responseLinks).toBeDefined();
+    expect(Object.keys(create!.responseLinks!)).toEqual(["GetItem", "UpdateItem", "DeleteItem"]);
+    expect(create!.responseLinks!.GetItem).toEqual({ operationId: "getItem", parameters: { id: "$response.body#/id" } });
+  });
+
+  it("chains a partial resource (create+read+delete, no update) in the same order, skipping what's absent", async () => {
+    const model = await crudStore();
+    const widgets = generateApiScenarios(model).find((s) => s.name === "widgets lifecycle")!;
+    expect(widgets.steps.map((c) => c.name)).toEqual(["createWidget", "getWidget", "deleteWidget"]);
+    expect(widgets.steps[0]!.responseLinks).toBeUndefined(); // no links declared on this resource
+  });
+
+  it("generates no scenario for a create-only resource — nothing to chain to", async () => {
+    const model = await crudStore();
+    const scenarios = generateApiScenarios(model);
+    expect(scenarios.some((s) => s.name.startsWith("events"))).toBe(false);
+  });
+
+  it("generates exactly the two chainable resources, in model order", async () => {
+    const model = await crudStore();
+    const scenarios = generateApiScenarios(model);
+    expect(scenarios.map((s) => s.name)).toEqual(["items lifecycle", "widgets lifecycle"]);
+  });
+
+  it("each step is a normal happy-path ApiCase — same synthesis as generateApiCases (API-2)", async () => {
+    const model = await crudStore();
+    const [create] = generateApiScenarios(model).find((s) => s.name === "items lifecycle")!.steps;
+    expect(create!.type).toBe("Positive");
+    expect(create!.method).toBe("POST");
+    expect(create!.body).toEqual({ name: "string" });
+    expect(create!.expectedStatus).toBe("201");
+  });
+
+  it("a resource with no create op (only item-level ops) is skipped — nothing to seed the chain", () => {
+    const model: ApiModel = {
+      openapiVersion: "3.0.0",
+      tags: [],
+      securitySchemes: [],
+      endpoints: [
+        {
+          method: "GET",
+          path: "/orphans/{id}",
+          tags: [],
+          parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+          responses: [{ status: "200" }],
+          security: [],
+          deprecated: false,
+        },
+      ],
+    };
+    expect(generateApiScenarios(model)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #146.

## Summary
- New `--scenarios` flag: groups operations by resource (a *collection* path like `/pets` plus an *item* path templated one level deeper, `/pets/{id}`), and for any resource with a create op and at least one downstream op, generates an ordered `create → read → update → delete` scenario using whichever of those the spec actually declares.
- Each step is a normal API-2 happy-path `ApiCase` (`toCase()` is now exported and reused verbatim — no duplicated synthesis logic).
- `src/api/scenario-runner.ts` executes a scenario step by step, reusing `runApiCases` for each individual step (so auth/retry/redaction/schema-assertion behavior is identical to a normal case run). After a step succeeds, it captures values for later steps — preferring a declared OpenAPI `links` expression (`$response.body#/<pointer>`) over a same-named response-body field fallback. A failing step aborts the rest of the scenario; remaining steps are recorded with a `skipped — ...` reason rather than silently dropped.
- `src/api/openapi.ts` now parses `responses[status].links` into the model (`ApiLink`), so the runner has spec-declared linkage to prefer when present.
- Reporting: new stdout section, `report.json`'s `scenarios` field, and a `## Scenarios` section in `report.md` — per-scenario and per-step pass/fail, alongside the existing per-operation results.
- New fixture `tests/fixtures/api/crud-store.yaml` (kept separate from the shared `petstore.yaml` to avoid touching hardcoded counts in other API-N tests): a full CRUD resource with declared `links`, a partial resource (create+read+delete, no update) with no links to exercise the fallback, and a create-only resource to verify "nothing to chain to" is skipped.

Design decisions were resolved with the requester before implementation (both confirmed): "related operations" detection prefers declared OpenAPI `links`, falling back to path-prefix/shared-param-name heuristics when a spec doesn't declare them; a failing step aborts the rest of the scenario rather than continuing best-effort.

## Test plan
- [x] `npm run build` — clean
- [x] `npm run lint` — clean (one pre-existing unrelated lint error in an untracked scratch file, not part of this change)
- [x] `npm test` — 690 passed, incl. new `api-scenarios.test.ts` (resource grouping/ordering/skip rules), `api-scenario-runner.test.ts` (capture-and-thread, links-over-fallback precedence, abort+skip on failure), and two new `--scenarios` CLI wiring tests in `api-modality.test.ts` (a full green create→read→update→delete run through the real CLI, and a failing-create-aborts-scenario case)
- [x] `npm run smoke:pack` — 8/8 checks pass

## Follow-ups (out of scope here)
- Scenario steps aren't folded into the spec-vs-tested coverage report (#136) or ATC `.md` docs (#135) — both are shaped around single operations today; the DoD here only asked for per-scenario pass/fail reporting.
- BORROW-07 (#95) adversarial styles remain a separate slice.