### PR TITLE
feat: cairn api — multipart/form-data request encoding (API-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`cairn api` — `multipart/form-data` request encoding (#150, C1-04 / API-10).** The runner
+  (`runner.ts`) now encodes a case's body as real `multipart/form-data` (boundary, per-part
+  `Content-Disposition`, correct `Content-Type`) when the operation declares it, instead of always
+  JSON-encoding — via Node's native `FormData`/`File` (undici), which generates the wire format
+  itself rather than a hand-rolled encoder. Case generation (`cases.ts`) synthesises a `format:
+  binary` property (e.g. a file-upload field) as a real in-memory `Buffer` instead of the literal
+  string `"string"`, so a multipart body has actual file content to send. A new fixture spec
+  (`tests/fixtures/api/multipart-upload.yaml`) exercises this end to end: generate → run against a
+  mocked server → correct encoding asserted. Follow-ups (out of scope here): `--negative` (API-8)
+  doesn't yet propagate `bodyMediaType` to its corrupted-body case for a multipart operation, and
+  array-of-files (`items: { format: binary }`) synthesises only one file, mirroring the existing
+  one-element array behaviour for every schema type.
+
 - **`cairn api` — multi-endpoint scenario chains / journeys (#146, C1-04 / API-9).** New `--scenarios`
   flag: given the ingested spec, chains related operations on the same resource (a *collection* path
   like `/pets` plus an *item* path templated one level deeper, `/pets/{id}`) into an ordered

--- a/src/api/cases.ts
+++ b/src/api/cases.ts
@@ -64,6 +64,10 @@ export interface ApiCase {
   /** Declared `links` on this case's success response (API-9, #146), if the spec has any. A scenario
    * runner (`scenario-runner.ts`) prefers these over its same-name-field capture heuristic. */
   responseLinks?: Record<string, ApiLink>;
+  /** The media type `body` was synthesised from (API-10, #150) — the operation's first declared
+   * `requestBody.mediaTypes` entry. The runner encodes as `multipart/form-data` when this says so,
+   * JSON otherwise (including when the operation declares no body at all). */
+  bodyMediaType?: string;
 }
 
 /** Generate one baseline happy-path case per operation, in the model's (deterministic) order. */
@@ -107,6 +111,7 @@ export function toCase(e: ApiEndpoint): ApiCase {
     expectedStatus,
     expectedSchema: success?.schema,
     ...(success?.links ? { responseLinks: success.links } : {}),
+    ...(e.requestBody?.mediaTypes[0] !== undefined ? { bodyMediaType: e.requestBody.mediaTypes[0] } : {}),
     type: "Positive",
     // Nominal happy-path = the valid equivalence class for this operation's inputs (ISO 29119-4).
     technique: "equivalence-partitioning",
@@ -255,7 +260,8 @@ function synth(schema: unknown, seen: Set<object> = new Set()): unknown {
 
   switch (type) {
     case "string":
-      return synthString(s.format);
+      // `format: binary` (e.g. a multipart file field) needs real bytes, not the literal word "string".
+      return s.format === "binary" ? synthBinary() : synthString(s.format);
     case "integer":
     case "number":
       return s.minimum ?? 0;
@@ -286,6 +292,13 @@ function mergeAllOf(parts: Schema[]): Schema {
     if (p.required) merged.required!.push(...p.required);
   }
   return merged;
+}
+
+/** A small in-memory placeholder for a `format: binary` property (API-10, #150) — real bytes so a
+ * multipart file field has actual "file" content to send; the runner (`runner.ts`) recognises a
+ * `Buffer` value and encodes it as a file part instead of a stringified form field. */
+function synthBinary(): Buffer {
+  return Buffer.from("cairn placeholder file content");
 }
 
 /** A format-appropriate sample string (valid for the common OpenAPI string formats). */

--- a/src/api/runner.ts
+++ b/src/api/runner.ts
@@ -102,10 +102,11 @@ async function runOne(c: ApiCase, opts: RunnerOptions): Promise<ApiCaseResult> {
   const url = buildUrl(opts.baseUrl, c);
   const headers = buildHeaders(c, opts.auth);
   const hasBody = c.body !== undefined;
+  const isMultipart = c.bodyMediaType === "multipart/form-data";
   const init: RequestInit = {
     method: c.method,
     headers,
-    ...(hasBody ? { body: JSON.stringify(c.body) } : {}),
+    ...(hasBody ? { body: isMultipart ? toFormData(c.body) : JSON.stringify(c.body) } : {}),
   };
 
   const evidence: ApiCaseResult = {
@@ -211,16 +212,39 @@ function buildUrl(baseUrl: string, c: ApiCase): string {
   return `${base}${sep}${path}${query ? `?${query}` : ""}`;
 }
 
-/** Merge auth headers, case header-params and a Cookie header from cookie-params; add JSON content-type. */
+/**
+ * Merge auth headers, case header-params and a Cookie header from cookie-params; add a JSON
+ * content-type for a body case — UNLESS the operation declares `multipart/form-data` (API-10,
+ * #150), where `fetch`/undici must generate its own `Content-Type: multipart/form-data; boundary=…`
+ * from the `FormData` body; a manually-set header here would just fight (and lose to) that.
+ */
 function buildHeaders(c: ApiCase, auth?: ApiAuth): Record<string, string> {
   const headers: Record<string, string> = { ...(auth?.headers ?? {}) };
   for (const [k, v] of Object.entries(c.params.header)) headers[k] = String(v);
   const cookies = Object.entries(c.params.cookie);
   if (cookies.length) headers["Cookie"] = cookies.map(([k, v]) => `${k}=${v}`).join("; ");
-  if (c.body !== undefined && !Object.keys(headers).some((h) => h.toLowerCase() === "content-type")) {
+  const hasContentType = Object.keys(headers).some((h) => h.toLowerCase() === "content-type");
+  if (c.body !== undefined && !hasContentType && c.bodyMediaType !== "multipart/form-data") {
     headers["Content-Type"] = "application/json";
   }
   return headers;
+}
+
+/**
+ * C1-04 / API-10 (#150) — encode a synthesised body object as `multipart/form-data`. A `Buffer`
+ * value (from `synth()`'s `format: binary` handling, `cases.ts`) becomes a file part; every other
+ * value is a stringified form field. Relies on Node's native `FormData`/`File` (undici, global since
+ * Node 18+) so `fetch` itself generates the boundary and per-part `Content-Disposition` — no
+ * hand-rolled multipart encoder.
+ */
+function toFormData(body: unknown): FormData {
+  const fd = new FormData();
+  if (!body || typeof body !== "object") return fd;
+  for (const [k, v] of Object.entries(body as Record<string, unknown>)) {
+    if (v === undefined) continue;
+    fd.append(k, Buffer.isBuffer(v) ? new File([v], `${k}.bin`, { type: "application/octet-stream" }) : String(v));
+  }
+  return fd;
 }
 
 /**

--- a/src/core/modalities/api.ts
+++ b/src/core/modalities/api.ts
@@ -89,6 +89,20 @@ function omitExpectedSchema(c: ApiCase): Omit<ApiCase, "expectedSchema"> {
   return rest as Omit<ApiCase, "expectedSchema">;
 }
 
+/**
+ * `JSON.stringify` replacer (API-10, #150): a `format: binary` property synthesises to a real
+ * `Buffer` (so the runner can send actual file bytes) — but a raw byte-array dump is noise in a
+ * rendered/persisted artifact (CLI preview, `api-evidence.json`, `report.json`). `Buffer` already
+ * ran through its own `toJSON()` (`{ type: "Buffer", data: [...] }`) by the time a replacer sees it,
+ * which is the shape this recognises and swaps for a short marker.
+ */
+function jsonSafe(_key: string, value: unknown): unknown {
+  if (value && typeof value === "object" && (value as { type?: unknown }).type === "Buffer" && Array.isArray((value as { data?: unknown }).data)) {
+    return `<binary ${(value as { data: unknown[] }).data.length}b>`;
+  }
+  return value;
+}
+
 /** Print the parsed-model summary — the verifiable artifact of this slice. */
 export function renderApiSummary(model: ApiModel, source: string): string[] {
   const lines = [
@@ -122,7 +136,7 @@ export function renderApiCases(cases: ApiCase[]): string[] {
       if (Object.keys(vals as object).length) sent[where] = vals;
     }
     if (c.body !== undefined) sent.body = c.body;
-    if (Object.keys(sent).length) lines.push(`      ${JSON.stringify(sent)}`);
+    if (Object.keys(sent).length) lines.push(`      ${JSON.stringify(sent, jsonSafe)}`);
   }
   lines.push("");
   return lines;
@@ -234,7 +248,7 @@ export const apiModality: Modality = {
     const outDir = opts.out ? resolve(opts.out) : join(defaultRunsBaseDir(), `api-${randomUUID()}`);
     await mkdir(outDir, { recursive: true });
     const evidencePath = join(outDir, "api-evidence.json");
-    await writeFile(evidencePath, JSON.stringify(results, null, 2), "utf8");
+    await writeFile(evidencePath, JSON.stringify(results, jsonSafe, 2), "utf8");
 
     // API-4 (#134): report.json/report.md in the same shape/location the run summary and the TUI's
     // past-run browser already read for web runs — no parallel reporting layer.
@@ -258,7 +272,7 @@ export const apiModality: Modality = {
           // key is only present when --scenarios generated something to report.
           ...(scenarioResults.length ? { scenarios: scenarioResults } : {}),
         },
-        null,
+        jsonSafe,
         2,
       ),
       "utf8",

--- a/tests/fixtures/api/multipart-upload.yaml
+++ b/tests/fixtures/api/multipart-upload.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.3
+info:
+  title: Upload Service
+  version: 1.0.0
+paths:
+  /upload:
+    post:
+      operationId: uploadFile
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                description:
+                  type: string
+      responses:
+        '201':
+          description: Uploaded
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id]
+                properties:
+                  id:
+                    type: string

--- a/tests/unit/api-cases.test.ts
+++ b/tests/unit/api-cases.test.ts
@@ -116,6 +116,53 @@ describe("respects required / enum / types / example / format (b)", () => {
   });
 });
 
+describe("multipart/form-data request bodies (API-10, #150)", () => {
+  function multipartModel(): ApiModel {
+    return model({
+      method: "POST",
+      path: "/upload",
+      tags: [],
+      parameters: [],
+      requestBody: {
+        required: true,
+        mediaTypes: ["multipart/form-data"],
+        schema: {
+          type: "object",
+          required: ["file"],
+          properties: { file: { type: "string", format: "binary" }, description: { type: "string" } },
+        },
+      },
+      responses: [{ status: "201" }],
+      security: [],
+    });
+  }
+
+  it("synthesises a format:binary property as real bytes (a Buffer), not the literal string \"string\"", () => {
+    const [c] = generateApiCases(multipartModel());
+    const body = c!.body as Record<string, unknown>;
+    expect(Buffer.isBuffer(body.file)).toBe(true);
+    expect((body.file as Buffer).length).toBeGreaterThan(0);
+    expect(body.description).toBe("string"); // unaffected — only `format: binary` changes
+  });
+
+  it("tags the case with bodyMediaType from the operation's first declared media type", () => {
+    const [c] = generateApiCases(multipartModel());
+    expect(c!.bodyMediaType).toBe("multipart/form-data");
+  });
+
+  it("leaves bodyMediaType as application/json for a plain JSON operation (unchanged default)", async () => {
+    const m = await ingestOpenApi(join(fixtures, "petstore.yaml"));
+    const createPet = generateApiCases(m).find((c) => c.name === "createPet")!;
+    expect(createPet.bodyMediaType).toBe("application/json");
+  });
+
+  it("leaves bodyMediaType undefined for a bodyless operation", async () => {
+    const tiny = await ingestOpenApi(join(fixtures, "tiny.json"));
+    const [health] = generateApiCases(tiny);
+    expect(health!.bodyMediaType).toBeUndefined();
+  });
+});
+
 describe("determinism (c)", () => {
   it("same model → identical synthesised cases across runs", async () => {
     const m = await ingestOpenApi(join(fixtures, "petstore.yaml"));

--- a/tests/unit/api-runner.test.ts
+++ b/tests/unit/api-runner.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import { runApiCases, validateAgainstSchema, type FetchLike, type ResponseLike } from "../../src/api/runner.js";
-import type { ApiCase } from "../../src/api/cases.js";
+import { generateApiCases, type ApiCase } from "../../src/api/cases.js";
+import { ingestOpenApi } from "../../src/api/openapi.js";
+
+const fixtures = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "api");
 
 /**
  * C1-04 / API-3 (#133): the runner executes generated cases against a base URL and asserts each
@@ -65,6 +70,55 @@ describe("runApiCases — execution + status assertion (a)", () => {
     await runApiCases([c], { baseUrl: "https://api.test", fetch });
     expect(calls[0]!.init.body).toBe(JSON.stringify({ name: "Rex" }));
     expect((calls[0]!.init.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+  });
+});
+
+describe("multipart/form-data encoding (API-10, #150)", () => {
+  it("encodes a multipart case as FormData — a Buffer field becomes a File part, others stringified fields — without forcing JSON content-type", async () => {
+    const { fetch, calls } = fakeFetch([res(201, { id: "f1" })]);
+    const c = caseOf({
+      method: "POST",
+      path: "/upload",
+      expectedStatus: "201",
+      bodyMediaType: "multipart/form-data",
+      body: { file: Buffer.from("hello"), description: "a file" },
+      params: { path: {}, query: {}, header: {}, cookie: {} },
+    });
+    const [r] = await runApiCases([c], { baseUrl: "https://api.test", fetch });
+
+    const sentBody = calls[0]!.init.body as FormData;
+    expect(sentBody).toBeInstanceOf(FormData);
+    expect(sentBody.get("description")).toBe("a file");
+    const filePart = sentBody.get("file") as File;
+    expect(filePart).toBeInstanceOf(File);
+    expect(await filePart.text()).toBe("hello");
+
+    // fetch/undici must generate its own multipart boundary — a manual JSON header would fight it.
+    expect((calls[0]!.init.headers as Record<string, string>)["Content-Type"]).toBeUndefined();
+    expect(r!.passed).toBe(true);
+  });
+
+  it("still JSON-encodes a case with no bodyMediaType (default, unchanged behaviour)", async () => {
+    const { fetch, calls } = fakeFetch([res(201, { id: "x" })]);
+    const c = caseOf({ method: "POST", path: "/pets", expectedStatus: "201", body: { name: "Rex" }, params: { path: {}, query: {}, header: {}, cookie: {} } });
+    await runApiCases([c], { baseUrl: "https://api.test", fetch });
+    expect(calls[0]!.init.body).toBe(JSON.stringify({ name: "Rex" }));
+    expect((calls[0]!.init.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+  });
+
+  it("ingest → generate → run end to end against a real multipart fixture spec", async () => {
+    const m = await ingestOpenApi(join(fixtures, "multipart-upload.yaml"));
+    const [c] = generateApiCases(m);
+    expect(c!.bodyMediaType).toBe("multipart/form-data");
+
+    const { fetch, calls } = fakeFetch([res(201, { id: "f2" })]);
+    const [r] = await runApiCases([c!], { baseUrl: "https://api.test", fetch });
+
+    const sentBody = calls[0]!.init.body as FormData;
+    const filePart = sentBody.get("file") as File;
+    expect(filePart).toBeInstanceOf(File);
+    expect((await filePart.arrayBuffer()).byteLength).toBeGreaterThan(0);
+    expect(r!.passed).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #150

## What changed
The runner (`src/api/runner.ts`) always sent a case's request body as `Content-Type: application/json` regardless of what the operation's `requestBody.mediaTypes` actually declared. A real server checking `Content-Type` on a `multipart/form-data` (file-upload) operation rejected the generated happy-path case outright (400 instead of the declared 2xx) — confirmed live while demoing API-8 (#145). Case generation (`src/api/cases.ts`) had the same gap one layer up: a `format: binary` property synthesised to the literal string `"string"`, not any kind of file content.

- **`src/api/cases.ts`** — `ApiCase` now carries `bodyMediaType` (the operation's first declared media type, i.e. whichever one `body` was actually synthesised from); `synth()` returns a small in-memory `Buffer` for a `format: binary` property instead of `"string"`.
- **`src/api/runner.ts`** — when `bodyMediaType === "multipart/form-data"`, the body is encoded as a native `FormData` (Buffer fields become `File` parts with `application/octet-stream`, everything else a stringified field) instead of `JSON.stringify`. `Content-Type` is left unset in that case so `fetch`/undici generates its own boundary + per-part `Content-Disposition` — a manual header would only fight it. Every other case keeps the existing JSON behaviour unchanged.
- **`src/core/modalities/api.ts`** — a `jsonSafe` `JSON.stringify` replacer renders a synthesised `Buffer` as a short `<binary Nb>` marker instead of its default `{"type":"Buffer","data":[...]}` dump, applied everywhere a case's body gets serialised: the CLI cases preview, `api-evidence.json`, and `report.json`. Without this, the very feature that makes `format: binary` real would make those existing artifacts noisy/unreadable.
- **`tests/fixtures/api/multipart-upload.yaml`** — new fixture: one `POST /upload` operation with a `multipart/form-data` body (`file: binary` + `description: string`).

## How I verified it (against the DoD)
- `npm run typecheck` / `npm run build` / `npm run lint` (repo-wide, unrelated pre-existing lint error in the untracked `playwright.config.demo.cjs` aside) / `npm test` (697 passed, 3 pre-existing skips) all green.
- `npm run smoke:pack` — packs and smokes clean.
- Unit tests: `synth()` produces a real `Buffer` for `format: binary` (not `"string"`); `bodyMediaType` propagates correctly for multipart / plain-JSON / bodyless operations; the runner builds a `FormData` with a `File` part for a `Buffer` field and a plain field otherwise, and does **not** force a JSON content-type for multipart.
- New end-to-end test: ingest the multipart fixture → generate → run against a mocked `fetch`, asserting the sent body is a `FormData` with the right file/field parts.
- **Live check beyond mocks:** ran `cairn api` against a real local Node `http` server (not the test mocks) that inspects the raw request — confirmed the wire body actually contains `Content-Type: multipart/form-data; boundary=...`, `Content-Disposition: form-data; name="file"; filename="file.bin"` + `Content-Type: application/octet-stream` for the file part, and a plain `Content-Disposition: form-data; name="description"` field — the case passed 201 (this is the exact bug scenario from the issue, now fixed). Also confirmed `api-evidence.json` shows `"file": "<binary 30b>"` rather than a byte-array dump.

## Follow-ups (out of scope here, noted in CHANGELOG)
- `--negative` (API-8) doesn't yet propagate `bodyMediaType` to its corrupted-body case for a multipart operation — not one of this issue's listed dependencies (API-2/API-3 only); a negative case against a multipart op currently still gets JSON-encoded (which incidentally still yields a 4xx, since sending JSON where multipart is expected is itself a contract violation — not silently broken, but not intentionally handled either).
- Array-of-files (`items: { type: string, format: binary } }`) synthesises only one file, mirroring the pre-existing one-element-array behaviour `synth()` already has for every schema type — not something this issue's DoD asked for.