### PR TITLE
feat: cairn api — adversarial testing styles (BORROW-07)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`cairn api` — adversarial testing styles (#95, BORROW-07).** New `--adversarial [styles]` flag —
+  generates/runs cases in one or more of four named styles (bare flag = all; comma-separated to pick
+  specific ones), taxonomy borrowed from testomatio/explorbot's Chief+Curler (explorbot's own styles
+  are LLM-driven; only the taxonomy is ported, translated into cairn's existing schema-driven, no-LLM
+  case generation): `normal` (the always-generated happy path, just tagged — no new cases), `curious`
+  (exhaustive valid-data coverage: every parameter including optional ones, one case per additional
+  declared enum value), `psycho` (invalid/malformed/extreme input: SQL-injection and XSS payloads in
+  the first string body property, an extreme boundary value in the first numeric one, plus API-8's
+  existing negative case re-tagged rather than reimplemented — payloads and OWASP WSTG test IDs
+  harvested from AZANIR/qa-skills via BORROW-08/#96), and `hacker` (a deliberate subset: strips
+  configured auth headers from an otherwise-valid request and expects rejection — `ApiCase.stripAuth`,
+  honoured by the runner). Every generated case carries `adversarialStyle` + (where applicable)
+  `wstgId`, flowing through the existing run/report/coverage/ATC pipeline unmodified — a distinct case
+  category, not a parallel one. The coverage half of this issue's DoD needed no new code: API-6's
+  `computeApiCoverage` is endpoint/status-driven, already covers however many cases target an
+  operation. **Deliberately out of scope** (follow-up): `hacker`'s IDOR and privilege-escalation
+  checks are genuinely stateful/multi-request in explorbot's own implementation (≥2 identities,
+  resource creation + adjacent-ID probing, response-field replay) — closer to API-9's scenario-chain
+  machinery than a single independent case, so only the deterministic auth-strip check ships here.
+
 - **`cairn api` — `multipart/form-data` request encoding (#150, C1-04 / API-10).** The runner
   (`runner.ts`) now encodes a case's body as real `multipart/form-data` (boundary, per-part
   `Content-Disposition`, correct `Content-Type`) when the operation declares it, instead of always

--- a/src/api/adversarial.ts
+++ b/src/api/adversarial.ts
@@ -1,0 +1,207 @@
+/**
+ * BORROW-07 (#95) — adversarial API testing styles, borrowed conceptually from testomatio/explorbot's
+ * Chief+Curler (4 named styles: normal/curious/psycho/hacker) and AZANIR/qa-skills' OWASP WSTG payload
+ * set (both harvested via BORROW-08, #96). Explorbot's own styles are LLM-driven — Chief plans and
+ * Curler composes each request's literal payload at generation time, with no deterministic
+ * style→value mapping anywhere to port. This ports the TAXONOMY only, translated into cairn's
+ * existing schema-driven, no-LLM case generation (same "no LLM" reasoning as API-2/API-8).
+ *
+ * - normal   — happy path. Already always-generated (API-2) — this module doesn't re-emit it as a
+ *   separate case; the CLI layer just tags the existing base cases when "normal" is requested.
+ * - curious  — exhaustive VALID coverage: a case with every param (not just required), and one case
+ *   per additional declared enum value. Body completeness needed no new code — `synth()` (`cases.ts`)
+ *   already includes every synthesisable property regardless of required-ness.
+ * - psycho   — invalid/malformed/extreme input: a SQL-injection case, an XSS case, a boundary-numeric
+ *   case (each targeting the first suitable body property), plus API-8's existing negative case
+ *   (missing-required-field / wrong-type), re-tagged rather than reimplemented.
+ * - hacker   — ships only the deterministic, single-request slice: strip auth from an otherwise-valid
+ *   request, expect rejection. IDOR / privilege-escalation-via-response-replay are genuinely
+ *   stateful/multi-request in explorbot's own implementation (≥2 identities, resource chaining,
+ *   reading prior responses) — closer to API-9's scenario-chain machinery than a single case, so
+ *   they're a follow-up, not shipped here.
+ *
+ * Every case is tagged `adversarialStyle` (+ `wstgId` where a specific OWASP WSTG test ID applies) so
+ * it flows through the existing run/report/coverage/ATC pipeline untouched — a distinct category, not
+ * a parallel one (same principle API-8's `type: "Negative"` established). Coverage (API-6,
+ * `computeApiCoverage`) needs no changes — it's endpoint/status-driven, not case-count-driven.
+ */
+import {
+  apiEndpointKey,
+  corruptibleProps,
+  enumProps,
+  generateNegativeCases,
+  pickErrorSchema,
+  pickErrorStatus,
+  synthAllParams,
+  toCase,
+  type ApiCase,
+  type ApiCaseTechnique,
+} from "./cases.js";
+import type { ApiEndpoint, ApiModel } from "./openapi.js";
+
+export type AdversarialStyle = "normal" | "curious" | "psycho" | "hacker";
+export const ADVERSARIAL_STYLES: readonly AdversarialStyle[] = ["normal", "curious", "psycho", "hacker"];
+
+/** Known-safe (non-destructive) payloads, per qa-skills' own convention: verify rejection/sanitisation
+ * happened, never assert that an attack actually succeeded. */
+const SQLI_PAYLOAD = "' OR '1'='1";
+const XSS_PAYLOAD = "<script>alert(1)</script>";
+const BOUNDARY_INTEGER = Number.MAX_SAFE_INTEGER;
+
+/**
+ * Generate `curious`/`psycho`/`hacker` adversarial cases for the requested styles ("normal" is a
+ * no-op here — see module doc). Cases are additive, meant to sit alongside the always-generated
+ * happy-path cases in the same flat array (same pattern as API-8's `--negative`).
+ */
+export function generateAdversarialCases(model: ApiModel, styles: readonly AdversarialStyle[]): ApiCase[] {
+  const cases: ApiCase[] = [];
+  if (styles.includes("curious")) cases.push(...model.endpoints.flatMap(toCuriousCases));
+  if (styles.includes("psycho")) cases.push(...model.endpoints.flatMap(toPsychoCases), ...reusedNegativeCases(model, "psycho"));
+  if (styles.includes("hacker")) cases.push(...model.endpoints.map(toHackerCase).filter((c): c is ApiCase => c !== undefined));
+  return cases;
+}
+
+/**
+ * Exhaustive-valid-data cases for one operation (`curious`): a full-params variant (only when the op
+ * actually has an optional param to add) and one case per additional declared enum value (only when
+ * the body schema actually declares one) — an operation with neither contributes nothing, same
+ * "nothing to add, skip" convention as API-8's negative cases.
+ */
+function toCuriousCases(e: ApiEndpoint): ApiCase[] {
+  const base = toCase(e);
+  const cases: ApiCase[] = [];
+
+  if (e.parameters.some((p) => !p.required)) {
+    cases.push({
+      ...base,
+      name: `${apiEndpointKey(e)} (curious: all params)`,
+      params: synthAllParams(e),
+      adversarialStyle: "curious",
+      technique: "equivalence-partitioning",
+      rationale:
+        `Exhaustive-coverage case (curious style) for ${e.method} ${e.path}: exercises every ` +
+        `parameter, including optional ones the happy path omits, still with schema-valid values.`,
+    });
+  }
+
+  for (const [prop, values] of enumProps(e.requestBody?.schema)) {
+    for (const value of values.slice(1)) {
+      const body = { ...(base.body as Record<string, unknown>), [prop]: value };
+      cases.push({
+        ...base,
+        name: `${apiEndpointKey(e)} (curious: ${prop}=${String(value)})`,
+        body,
+        adversarialStyle: "curious",
+        technique: "equivalence-partitioning",
+        rationale:
+          `Exhaustive-coverage case (curious style) for ${e.method} ${e.path}: sends "${prop}" as the ` +
+          `declared enum value ${JSON.stringify(value)} (the happy path only exercises the first).`,
+      });
+    }
+  }
+
+  return cases;
+}
+
+/**
+ * Invalid/malformed/extreme-input cases for one operation (`psycho`): SQL injection and XSS in the
+ * first string body property, an extreme boundary value in the first numeric one — each only when
+ * such a property actually exists. Missing-required-field/wrong-type is NOT reimplemented here;
+ * `reusedNegativeCases` re-tags API-8's existing negative case instead.
+ */
+function toPsychoCases(e: ApiEndpoint): ApiCase[] {
+  const base = toCase(e);
+  if (base.body === undefined || typeof base.body !== "object") return [];
+
+  const props = corruptibleProps(e.requestBody?.schema);
+  const stringProp = props.find(([, type]) => type === "string");
+  const numericProp = props.find(([, type]) => type === "integer" || type === "number");
+  const expectedStatus = pickErrorStatus(e);
+  const expectedSchema = pickErrorSchema(e, expectedStatus);
+  const cases: ApiCase[] = [];
+
+  if (stringProp) {
+    const [name] = stringProp;
+    cases.push(
+      psychoCase(e, base, "sqli", name, SQLI_PAYLOAD, expectedStatus, expectedSchema, "WSTG-INPV-05",
+        `sends a SQL-injection payload in "${name}", expecting the API to reject or sanitise it ` +
+          `(${expectedStatus}) rather than execute it`),
+    );
+    cases.push(
+      psychoCase(e, base, "xss", name, XSS_PAYLOAD, expectedStatus, expectedSchema, "WSTG-INPV-01",
+        `sends an XSS payload in "${name}", expecting the API to reject or sanitise it ` +
+          `(${expectedStatus}) rather than reflect it unescaped`),
+    );
+  }
+  if (numericProp) {
+    const [name] = numericProp;
+    cases.push(
+      psychoCase(e, base, "boundary", name, BOUNDARY_INTEGER, expectedStatus, expectedSchema, undefined,
+        `sends an extreme boundary value (${BOUNDARY_INTEGER}) for "${name}", expecting the API to ` +
+          `reject it (${expectedStatus}) rather than accept an out-of-range number`),
+    );
+  }
+  return cases;
+}
+
+function psychoCase(
+  e: ApiEndpoint,
+  base: ApiCase,
+  attack: string,
+  prop: string,
+  value: unknown,
+  expectedStatus: string,
+  expectedSchema: unknown,
+  wstgId: string | undefined,
+  rationale: string,
+): ApiCase {
+  const body = { ...(base.body as Record<string, unknown>), [prop]: value };
+  const technique: ApiCaseTechnique = wstgId ? "error-guessing" : "boundary-value";
+  return {
+    ...base,
+    name: `${apiEndpointKey(e)} (psycho: ${attack})`,
+    body,
+    expectedStatus,
+    expectedSchema,
+    type: "Negative", // expects rejection, same category as an API-8 negative case
+    adversarialStyle: "psycho",
+    technique,
+    ...(wstgId ? { wstgId } : {}),
+    rationale: `Adversarial case (psycho style${wstgId ? `, ${wstgId}` : ""}) for ${e.method} ${e.path}: ${rationale}.`,
+  };
+}
+
+/**
+ * Auth-header-stripped case for one operation (`hacker`, deterministic subset — see module doc): only
+ * for operations that actually declare `security`, since a public operation has nothing to strip.
+ */
+function toHackerCase(e: ApiEndpoint): ApiCase | undefined {
+  if (e.security.length === 0) return undefined;
+  const base = toCase(e);
+  const expectedStatus = pickErrorStatus(e);
+  return {
+    ...base,
+    name: `${apiEndpointKey(e)} (hacker: no-auth)`,
+    expectedStatus,
+    expectedSchema: pickErrorSchema(e, expectedStatus),
+    type: "Negative", // expects rejection, same category as an API-8 negative case
+    adversarialStyle: "hacker",
+    wstgId: "WSTG-ATHN-04",
+    stripAuth: true,
+    technique: "error-guessing",
+    rationale:
+      `Adversarial case (hacker style, WSTG-ATHN-04) for ${e.method} ${e.path}: resends the ` +
+      `happy-path request with authentication stripped, expecting the API to reject it ` +
+      `(${expectedStatus}) rather than allow unauthenticated access.`,
+  };
+}
+
+/** Re-tag API-8's existing negative cases (missing-required-field / wrong-type) as the given
+ * adversarial style, rather than reimplementing the same "corrupt one property" logic. Renamed (not
+ * just re-tagged) so a case list stays unique-by-name even when `--negative` and `--adversarial` are
+ * both passed and would otherwise generate the identical underlying case twice — `renderApiCases`
+ * already shows the style as its own `[psycho]` tag, so the name suffix here is a plain disambiguator
+ * rather than repeating that same bracket. */
+function reusedNegativeCases(model: ApiModel, style: AdversarialStyle): ApiCase[] {
+  return generateNegativeCases(model).map((c) => ({ ...c, name: `${c.name}, reused`, adversarialStyle: style }));
+}

--- a/src/api/cases.ts
+++ b/src/api/cases.ts
@@ -68,6 +68,13 @@ export interface ApiCase {
    * `requestBody.mediaTypes` entry. The runner encodes as `multipart/form-data` when this says so,
    * JSON otherwise (including when the operation declares no body at all). */
   bodyMediaType?: string;
+  /** Which adversarial style (BORROW-07, #95) generated this case, if any. */
+  adversarialStyle?: "normal" | "curious" | "psycho" | "hacker";
+  /** OWASP WSTG test ID this case exercises (BORROW-07, #95), when one specifically applies. */
+  wstgId?: string;
+  /** Send this request with auth headers stripped (BORROW-07, #95 `hacker` style) — the runner skips
+   * merging `RunnerOptions.auth.headers` when true, instead of the normal always-applied behaviour. */
+  stripAuth?: boolean;
 }
 
 /** Generate one baseline happy-path case per operation, in the model's (deterministic) order. */
@@ -96,6 +103,27 @@ function synthRequiredParams(e: ApiEndpoint, omit?: ApiParam): ApiCaseParams {
   return params;
 }
 
+/** ALL params (required AND optional) with schema-synthesised values — the "curious" adversarial
+ * style's full-coverage variant of `synthRequiredParams` (BORROW-07, #95): optional params get
+ * exercised too, instead of the happy path's omit-if-optional convention. */
+export function synthAllParams(e: ApiEndpoint): ApiCaseParams {
+  const params: ApiCaseParams = { path: {}, query: {}, header: {}, cookie: {} };
+  for (const p of e.parameters) params[p.in][p.name] = synth(p.schema);
+  return params;
+}
+
+/** Body-schema properties that declare an `enum` with more than one value — the "curious" style's
+ * one-case-per-additional-value expansion needs the full list (the happy path's `synth()` only ever
+ * sends the first). */
+export function enumProps(schema: unknown): [string, unknown[]][] {
+  if (!schema || typeof schema !== "object") return [];
+  const out: [string, unknown[]][] = [];
+  for (const [name, sub] of Object.entries((schema as Schema).properties ?? {})) {
+    if (sub.enum && sub.enum.length > 1) out.push([name, sub.enum]);
+  }
+  return out;
+}
+
 /** Build the happy-path case for one operation (API-9, #146: also reused by `scenarios.ts` per step —
  * a scenario step is a normal case whose path params get overwritten with captured values at run time). */
 export function toCase(e: ApiEndpoint): ApiCase {
@@ -122,10 +150,12 @@ export function toCase(e: ApiEndpoint): ApiCase {
   };
 }
 
-/** Body-schema properties whose declared (primitive) type we can flip to something invalid. */
-function corruptibleProps(schema: Schema): [string, string][] {
+/** Body-schema properties whose declared (primitive) type we can flip to something invalid — reused
+ * by the "psycho"/"hacker" adversarial styles (BORROW-07, #95) to target a string/numeric property. */
+export function corruptibleProps(schema: unknown): [string, string][] {
+  if (!schema || typeof schema !== "object") return [];
   const out: [string, string][] = [];
-  for (const [name, sub] of Object.entries(schema.properties ?? {})) {
+  for (const [name, sub] of Object.entries((schema as Schema).properties ?? {})) {
     const type = Array.isArray(sub.type) ? sub.type.find((t) => t !== "null") : sub.type;
     if (typeof type === "string") out.push([name, type]);
   }
@@ -147,14 +177,16 @@ function wrongTypeValue(type: string): unknown {
   }
 }
 
-/** The lowest declared 4xx status, else the generic "4XX" range (matched by the runner's `statusMatches`). */
-function pickErrorStatus(e: ApiEndpoint): string {
+/** The lowest declared 4xx status, else the generic "4XX" range (matched by the runner's `statusMatches`).
+ * Reused by the "psycho"/"hacker" adversarial styles (BORROW-07, #95) — same "expect rejection"
+ * convention as a negative case. */
+export function pickErrorStatus(e: ApiEndpoint): string {
   const fourXX = e.responses.filter((r) => /^4\d\d$/.test(r.status)).sort((a, b) => a.status.localeCompare(b.status));
   return fourXX[0]?.status ?? "4XX";
 }
 
 /** The declared response schema for an EXACT status match, if the case picked one (not the "4XX" fallback). */
-function pickErrorSchema(e: ApiEndpoint, expectedStatus: string): unknown {
+export function pickErrorSchema(e: ApiEndpoint, expectedStatus: string): unknown {
   return e.responses.find((r) => r.status === expectedStatus)?.schema;
 }
 

--- a/src/api/runner.ts
+++ b/src/api/runner.ts
@@ -217,9 +217,11 @@ function buildUrl(baseUrl: string, c: ApiCase): string {
  * content-type for a body case — UNLESS the operation declares `multipart/form-data` (API-10,
  * #150), where `fetch`/undici must generate its own `Content-Type: multipart/form-data; boundary=…`
  * from the `FormData` body; a manually-set header here would just fight (and lose to) that.
+ * `stripAuth` (BORROW-07, #95 `hacker` style) skips the configured auth headers entirely — the case
+ * is deliberately testing whether the operation actually rejects an unauthenticated request.
  */
 function buildHeaders(c: ApiCase, auth?: ApiAuth): Record<string, string> {
-  const headers: Record<string, string> = { ...(auth?.headers ?? {}) };
+  const headers: Record<string, string> = c.stripAuth ? {} : { ...(auth?.headers ?? {}) };
   for (const [k, v] of Object.entries(c.params.header)) headers[k] = String(v);
   const cookies = Object.entries(c.params.cookie);
   if (cookies.length) headers["Cookie"] = cookies.map(([k, v]) => `${k}=${v}`).join("; ");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -141,6 +141,10 @@ export function buildProgram(): Command {
     .option("--knowledge-dir <dir>", "API-3: dir holding api-scope auth/headers knowledge (default knowledge/)")
     .option("--negative", "API-8: also generate/run one negative-schema (contract-violation) case per operation")
     .option("--scenarios", "API-9: also generate/run multi-endpoint scenario chains (e.g. create → read → delete)")
+    .option(
+      "--adversarial [styles]",
+      "BORROW-07: also generate/run adversarial-style cases — normal,curious,psycho,hacker (bare flag = all four; comma-separated to pick specific styles)",
+    )
     .action(async (opts: Record<string, unknown>) => {
       await runModality("api", opts);
     });

--- a/src/core/modalities/api.ts
+++ b/src/core/modalities/api.ts
@@ -9,12 +9,15 @@
  *   per operation, alongside the happy-path case — same pipeline, distinct `type: "Negative"`.
  * API-9 (#146): with `--scenarios`, also generate/run multi-endpoint chains on the same resource
  *   (e.g. create → read → delete), threading a captured response value through each step.
+ * BORROW-07 (#95): with `--adversarial`, also generate/run cases in one or more named styles —
+ *   normal/curious/psycho/hacker (`src/api/adversarial.ts`) — alongside the existing cases.
  */
 import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import { ingestOpenApi, type ApiModel } from "../../api/openapi.js";
 import { generateApiCases, generateNegativeCases, type ApiCase } from "../../api/cases.js";
+import { generateAdversarialCases, ADVERSARIAL_STYLES, type AdversarialStyle } from "../../api/adversarial.js";
 import { runApiCases, type ApiCaseResult, type RunnerOptions } from "../../api/runner.js";
 import { generateApiScenarios, type ApiScenario } from "../../api/scenarios.js";
 import { runApiScenarios, type ApiScenarioResult } from "../../api/scenario-runner.js";
@@ -41,6 +44,23 @@ interface ApiFlags {
   negative?: boolean;
   /** API-9: also generate/run multi-endpoint scenario chains (e.g. create → read → delete). */
   scenarios?: boolean;
+  /** BORROW-07 (#95): also generate/run adversarial-style cases. `true` (bare flag) = all four
+   * styles; a comma-separated string picks specific ones. */
+  adversarial?: boolean | string;
+}
+
+/**
+ * Parse `--adversarial` into the requested style list. A bare flag means all four; a comma-separated
+ * value picks specific styles. Unrecognised names are dropped, NOT a signal to fall back to "all" —
+ * a typo should generate fewer cases than intended, never silently more.
+ */
+function parseAdversarialFlag(flag: boolean | string | undefined): AdversarialStyle[] {
+  if (!flag) return [];
+  if (flag === true) return [...ADVERSARIAL_STYLES];
+  return flag
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s): s is AdversarialStyle => (ADVERSARIAL_STYLES as readonly string[]).includes(s));
 }
 
 /** Parse repeated `--header "Name: Value"` flags into a header map (config auth). */
@@ -123,13 +143,17 @@ export function renderApiSummary(model: ApiModel, source: string): string[] {
 /** Render the generated cases — the verifiable artifact of API-2 (+ API-8 negative cases, if requested). */
 export function renderApiCases(cases: ApiCase[]): string[] {
   const negative = cases.filter((c) => c.type === "Negative").length;
+  // "normal"-tagged cases ARE the baseline happy path (tagged in place, not additional) — only
+  // curious/psycho/hacker are genuinely extra cases worth calling out in the summary count.
+  const adversarial = cases.filter((c) => c.adversarialStyle && c.adversarialStyle !== "normal").length;
   const lines = [
     "",
     "=== Baseline cases (happy-path · 1 per operation) ===",
-    `${cases.length} case(s) generated${negative ? ` (${negative} negative-schema)` : ""}`,
+    `${cases.length} case(s) generated${negative ? ` (${negative} negative-schema)` : ""}${adversarial ? ` (${adversarial} adversarial)` : ""}`,
   ];
   for (const c of cases) {
-    lines.push(`  ▸ ${c.name} [${c.type}] → ${c.expectedStatus}`);
+    const style = c.adversarialStyle ? `[${c.adversarialStyle}${c.wstgId ? ` ${c.wstgId}` : ""}] ` : "";
+    lines.push(`  ▸ ${c.name} ${style}[${c.type}] → ${c.expectedStatus}`);
     lines.push(`      [${c.technique}] ${c.rationale}`);
     const sent: Record<string, unknown> = {};
     for (const [where, vals] of Object.entries(c.params)) {
@@ -218,7 +242,18 @@ export const apiModality: Modality = {
       return;
     }
     for (const line of renderApiSummary(model, source)) ctx.out(`${line}\n`);
-    const cases = [...generateApiCases(model), ...(opts.negative ? generateNegativeCases(model) : [])];
+    // BORROW-07 (#95): "normal" style is the always-generated happy path itself — tag in place rather
+    // than re-emitting duplicate cases when both are on (e.g. bare `--adversarial`).
+    const adversarialStyles = parseAdversarialFlag(opts.adversarial);
+    const baseCases = generateApiCases(model);
+    const taggedBaseCases = adversarialStyles.includes("normal")
+      ? baseCases.map((c): ApiCase => ({ ...c, adversarialStyle: "normal" }))
+      : baseCases;
+    const cases = [
+      ...taggedBaseCases,
+      ...(opts.negative ? generateNegativeCases(model) : []),
+      ...generateAdversarialCases(model, adversarialStyles),
+    ];
     for (const line of renderApiCases(cases)) ctx.out(`${line}\n`);
     const scenarios = opts.scenarios ? generateApiScenarios(model) : [];
     for (const line of renderApiScenarios(scenarios)) ctx.out(`${line}\n`);

--- a/tests/unit/api-adversarial.test.ts
+++ b/tests/unit/api-adversarial.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { generateAdversarialCases, ADVERSARIAL_STYLES } from "../../src/api/adversarial.js";
+import { ingestOpenApi, type ApiModel } from "../../src/api/openapi.js";
+
+/**
+ * BORROW-07 (#95): adversarial-style case generation — curious (exhaustive valid coverage), psycho
+ * (invalid/malformed/extreme input), hacker (deterministic auth-strip subset). "normal" is a no-op
+ * here by design (see adversarial.ts's module doc) — covered instead where the CLI tags base cases.
+ */
+const fixtures = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "api");
+
+function model(...endpoints: ApiModel["endpoints"]): ApiModel {
+  return { openapiVersion: "3.0.0", endpoints, tags: [], securitySchemes: [] };
+}
+
+describe("curious — exhaustive valid coverage", () => {
+  it("adds a full-params case only when an optional param exists", () => {
+    const withOptional = model({
+      method: "GET",
+      path: "/x",
+      tags: [],
+      parameters: [
+        { name: "id", in: "path", required: true, schema: { type: "string" } },
+        { name: "detail", in: "query", required: false, schema: { type: "string" } },
+      ],
+      responses: [{ status: "200" }],
+      security: [],
+    });
+    const cases = generateAdversarialCases(withOptional, ["curious"]);
+    const full = cases.find((c) => c.name.includes("all params"));
+    expect(full).toBeDefined();
+    expect(full!.params.query).toEqual({ detail: "string" });
+    expect(full!.adversarialStyle).toBe("curious");
+
+    const allRequired = model({
+      method: "GET",
+      path: "/y",
+      tags: [],
+      parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+      responses: [{ status: "200" }],
+      security: [],
+    });
+    expect(generateAdversarialCases(allRequired, ["curious"])).toEqual([]);
+  });
+
+  it("adds one case per additional enum value (not the first, already covered by the happy path)", () => {
+    const m = model({
+      method: "POST",
+      path: "/x",
+      tags: [],
+      parameters: [],
+      requestBody: {
+        required: true,
+        mediaTypes: ["application/json"],
+        schema: { type: "object", properties: { status: { type: "string", enum: ["active", "archived", "deleted"] } } },
+      },
+      responses: [{ status: "201" }],
+      security: [],
+    });
+    const cases = generateAdversarialCases(m, ["curious"]);
+    expect(cases).toHaveLength(2); // "archived" + "deleted" — "active" is the happy path's first value
+    expect(cases.every((c) => c.adversarialStyle === "curious")).toBe(true);
+    expect(cases.map((c) => (c.body as { status: string }).status).sort()).toEqual(["archived", "deleted"]);
+    // Names stay unique per value.
+    expect(new Set(cases.map((c) => c.name)).size).toBe(2);
+  });
+
+  it("contributes nothing for an operation with only required params and no enum", () => {
+    const m = model({
+      method: "GET",
+      path: "/health",
+      tags: [],
+      parameters: [],
+      responses: [{ status: "200" }],
+      security: [],
+    });
+    expect(generateAdversarialCases(m, ["curious"])).toEqual([]);
+  });
+});
+
+describe("psycho — invalid/malformed/extreme input", () => {
+  it("generates a SQLi case and an XSS case targeting the first string body property", () => {
+    const m = model({
+      method: "POST",
+      path: "/pets",
+      tags: [],
+      parameters: [],
+      requestBody: {
+        required: true,
+        mediaTypes: ["application/json"],
+        schema: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
+      },
+      responses: [{ status: "201" }],
+      security: [],
+    });
+    const cases = generateAdversarialCases(m, ["psycho"]);
+    const sqli = cases.find((c) => c.wstgId === "WSTG-INPV-05")!;
+    const xss = cases.find((c) => c.wstgId === "WSTG-INPV-01")!;
+    expect(sqli).toBeDefined();
+    expect(xss).toBeDefined();
+    expect((sqli.body as { name: string }).name).toBe("' OR '1'='1");
+    expect((xss.body as { name: string }).name).toBe("<script>alert(1)</script>");
+    expect(sqli.adversarialStyle).toBe("psycho");
+    expect(sqli.expectedStatus).toBe("4XX"); // no declared 4xx on this op → generic range fallback
+    expect(sqli.name).not.toBe(xss.name); // distinct cases targeting the same property must not collide
+    expect(sqli.type).toBe("Negative"); // expects rejection — must not inherit the base case's "Positive"
+    expect(xss.type).toBe("Negative");
+  });
+
+  it("generates a boundary-value case targeting the first numeric body property (no wstgId — not a WSTG category)", () => {
+    const m = model({
+      method: "POST",
+      path: "/x",
+      tags: [],
+      parameters: [],
+      requestBody: {
+        required: true,
+        mediaTypes: ["application/json"],
+        schema: { type: "object", properties: { count: { type: "integer" } } },
+      },
+      responses: [{ status: "201" }],
+      security: [],
+    });
+    const [boundary] = generateAdversarialCases(m, ["psycho"]).filter((c) => c.technique === "boundary-value");
+    expect(boundary).toBeDefined();
+    expect((boundary!.body as { count: number }).count).toBe(Number.MAX_SAFE_INTEGER);
+    expect(boundary!.wstgId).toBeUndefined();
+    expect(boundary!.type).toBe("Negative"); // expects rejection — must not inherit the base case's "Positive"
+  });
+
+  it("re-tags the existing API-8 negative case as psycho, renamed so it never collides with a plain --negative case", async () => {
+    const petstore = await ingestOpenApi(join(fixtures, "petstore.yaml"));
+    const psychoCases = generateAdversarialCases(petstore, ["psycho"]);
+    const reused = psychoCases.find((c) => c.name.includes("(negative)"));
+    expect(reused).toBeDefined();
+    expect(reused!.adversarialStyle).toBe("psycho");
+    expect(reused!.name).toBe("createPet (negative), reused"); // distinct from plain "createPet (negative)"
+    expect(reused!.type).toBe("Negative"); // unchanged from the original API-8 negative case
+  });
+
+  it("skips an operation with nothing corruptible (no body at all)", async () => {
+    const tiny = await ingestOpenApi(join(fixtures, "tiny.json"));
+    // tiny.json's one bodyless op contributes no SQLi/XSS/boundary case — only a possible reused negative one.
+    const cases = generateAdversarialCases(tiny, ["psycho"]);
+    expect(cases.some((c) => c.wstgId)).toBe(false);
+  });
+});
+
+describe("hacker — deterministic auth-strip subset", () => {
+  it("generates a stripAuth case only for operations that declare security", async () => {
+    const petstore = await ingestOpenApi(join(fixtures, "petstore.yaml"));
+    const cases = generateAdversarialCases(petstore, ["hacker"]);
+    // petstore: getPet/listPets/createPet inherit the spec-level `security: [apiKey]`; deletePet
+    // explicitly overrides to `security: []` (public) and must be skipped.
+    expect(cases).toHaveLength(3);
+    expect(cases.every((c) => c.stripAuth === true)).toBe(true);
+    expect(cases.every((c) => c.adversarialStyle === "hacker")).toBe(true);
+    expect(cases.every((c) => c.wstgId === "WSTG-ATHN-04")).toBe(true);
+    expect(cases.every((c) => c.type === "Negative")).toBe(true); // expects rejection, not the base case's "Positive"
+    expect(cases.some((c) => c.name.startsWith("deletePet"))).toBe(false);
+  });
+
+  it("expects rejection (4xx), not the happy path's declared success", async () => {
+    const petstore = await ingestOpenApi(join(fixtures, "petstore.yaml"));
+    const [hackerCase] = generateAdversarialCases(petstore, ["hacker"]);
+    expect(hackerCase!.expectedStatus).not.toBe("200");
+    expect(/^4/.test(hackerCase!.expectedStatus) || hackerCase!.expectedStatus === "4XX").toBe(true);
+  });
+});
+
+describe("style selection", () => {
+  it("generates nothing when no styles are requested", async () => {
+    const petstore = await ingestOpenApi(join(fixtures, "petstore.yaml"));
+    expect(generateAdversarialCases(petstore, [])).toEqual([]);
+  });
+
+  it("ADVERSARIAL_STYLES lists all four named styles", () => {
+    expect(ADVERSARIAL_STYLES).toEqual(["normal", "curious", "psycho", "hacker"]);
+  });
+
+  it("combining all styles produces no duplicate case names for one spec", async () => {
+    const petstore = await ingestOpenApi(join(fixtures, "petstore.yaml"));
+    const cases = generateAdversarialCases(petstore, ADVERSARIAL_STYLES);
+    const names = cases.map((c) => c.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/tests/unit/api-runner.test.ts
+++ b/tests/unit/api-runner.test.ts
@@ -209,6 +209,23 @@ describe("auth / headers application (c)", () => {
   });
 });
 
+describe("auth stripping (BORROW-07, #95 hacker style)", () => {
+  it("omits configured auth headers entirely when the case sets stripAuth", async () => {
+    const { fetch, calls } = fakeFetch([res(401, { error: "unauthorized" })]);
+    const c = caseOf({ stripAuth: true, expectedStatus: "401" });
+    const [r] = await runApiCases([c], { baseUrl: "https://api.test", fetch, auth: { headers: { Authorization: "Bearer t0ken" } } });
+    const sent = calls[0]!.init.headers as Record<string, string>;
+    expect(sent["Authorization"]).toBeUndefined();
+    expect(r!.passed).toBe(true); // 401 matches the case's own expectedStatus
+  });
+
+  it("still applies auth headers normally when stripAuth is absent (unchanged default)", async () => {
+    const { fetch, calls } = fakeFetch([res(200, {})]);
+    await runApiCases([caseOf()], { baseUrl: "https://api.test", fetch, auth: { headers: { Authorization: "Bearer t0ken" } } });
+    expect((calls[0]!.init.headers as Record<string, string>)["Authorization"]).toBe("Bearer t0ken");
+  });
+});
+
 describe("transient recovery then fail (d) — reuses the #90 ladder", () => {
   it("retries on a 5xx and passes once the service recovers", async () => {
     const { fetch, calls } = fakeFetch([res(503), res(503), res(200, {})]);


### PR DESCRIPTION
Closes #95

## What changed
Ports the taxonomy of testomatio/explorbot's Chief+Curler adversarial styles (`normal`/`curious`/`psycho`/`hacker`) into cairn's existing schema-driven, no-LLM case generation. Explorbot's own styles are LLM-driven (Chief plans, Curler composes the literal payload at generation time) — there's no deterministic style→value mapping to port directly, so this ports the taxonomy and re-implements each style's *intent* deterministically.

- **`src/api/adversarial.ts`** (new) — `generateAdversarialCases(model, styles)`:
  - `normal` — the always-generated happy path (API-2), tagged in place. No new cases (would just duplicate what's already always generated).
  - `curious` — exhaustive valid-data coverage: a case with every parameter (not just required), and one case per additional declared enum value.
  - `psycho` — invalid/malformed/extreme input: a SQL-injection case and an XSS case targeting the first string body property, a boundary-numeric case (`Number.MAX_SAFE_INTEGER`) targeting the first numeric one, plus API-8's existing negative case (missing-required-field/wrong-type) re-tagged rather than reimplemented.
  - `hacker` — **deliberately a subset** (see "Out of scope" below): strips configured auth headers from an otherwise-valid request and expects rejection.
- **`src/api/cases.ts`** — exports `corruptibleProps`/`pickErrorStatus`/`pickErrorSchema` for reuse (no logic changes); adds `synthAllParams`/`enumProps`; `ApiCase` gains `adversarialStyle` / `wstgId` / `stripAuth`.
- **`src/api/runner.ts`** — honours `stripAuth` (skips merging `RunnerOptions.auth.headers`).
- **`src/cli/index.ts`** + **`src/core/modalities/api.ts`** — `--adversarial [styles]` flag (bare = all four, comma-separated to pick specific ones), folded into the same flat case array as `--negative` (no parallel reporting layer, reuses the entire existing run/report/coverage/ATC pipeline); `renderApiCases` shows the style + WSTG tag.

Concrete payloads and OWASP WSTG test IDs (`WSTG-INPV-05` SQLi, `WSTG-INPV-01` XSS, `WSTG-ATHN-04` auth bypass) harvested from `AZANIR/qa-skills` via BORROW-08 (#96) — see the research comment on #95 for the full sourcing. The coverage half of this issue's DoD needed no new code: API-6's `computeApiCoverage` is endpoint/status-driven, already correct for however many cases target an operation.

## How I verified it (against the DoD)
- `npm run typecheck` / `npm run build` / `npm run lint` (repo-wide; the one lint error is the pre-existing, unrelated, untracked `playwright.config.demo.cjs`) / `npm test` (711 passed, 3 pre-existing skips) all green. `npm run smoke:pack` clean.
- Unit tests per style: curious's full-params/enum-variant generation (incl. "nothing to add → skip"), psycho's SQLi/XSS/boundary cases + the reused-negative re-tag, hacker's security-gated auth-strip — plus a runner test that `stripAuth` actually omits the configured auth header.
- **Caught in self-review, before finalizing** (see commit message for detail): (1) psycho/hacker cases were inheriting `type: "Positive"` from their happy-path base instead of `"Negative"` — a real bug (this field feeds ATC/MTC methodology tagging), (2) a reused negative case's name collided with the plain `--negative` version when both flags were passed together, (3) an unrecognised `--adversarial` style name was silently falling back to running *every* style instead of none — a typo would have accidentally run more than requested, not less. All three fixed, with regression assertions added, and confirmed live against the real CLI (not just mocks) — including deliberately passing a typo'd style name to confirm the fallback bug is gone.
- Live-ran `cairn api --spec tests/fixtures/api/petstore.yaml --adversarial` (bare, all styles) and `--adversarial psycho,hacker` (specific styles) against the real CLI binary — inspected the actual printed case list, confirmed correct `[style WSTG-id][Negative/Positive]` tagging and correct case counts.

## Follow-ups (out of scope here, noted in CHANGELOG)
- `hacker` style ships only the deterministic, single-request auth-strip check. IDOR and privilege-escalation-via-response-replay are genuinely stateful/multi-request in explorbot's own implementation (≥2 identities, resource creation + adjacent-ID probing, replaying GET-response fields into a later write) — architecturally closer to API-9's scenario-chain machinery (#146) than a single independent case, so building it properly is a bigger, separate feature rather than a rushed half-version here.
- `psycho`'s SQLi/XSS cases are a heuristic: a schema only declares `type: string`, so a server with no WAF/input-sanitisation may legitimately accept the payload as an opaque string (200, not the expected 4xx) — that's not a false positive in the tool, it's itself a useful finding about the target, but worth knowing going in.