### PR TITLE
fix: hacker-style adversarial case expects the wrong status on some specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`cairn api --adversarial hacker` expected the wrong status code on some specs (#154).** The
+  auth-header-stripped case (added in #95) reused `pickErrorStatus`'s generic "lowest declared 4xx" —
+  right for a schema-violation case, wrong here: an operation can legitimately declare an unrelated
+  4xx (e.g. `404 Not found`, or a lexically-lower `400 Bad request`) that has nothing to do with
+  authentication. `toHackerCase` now prefers a declared `401`, then `403` — the specific "auth
+  rejection" codes — over the generic fallback, which only still applies when neither is declared.
+  Found live: a real mock server correctly rejecting an unauthenticated request with `401` was
+  failing the case, which expected `404` instead.
+
 - **OpenRouter codegen/reasoning latency — `explore`/`design` no longer hang (#110).** On the
   `openrouter` profile / `volume` routing, `deepseek-chat` (codegen) ran 4.5–13 min and `deepseek-r1`
   (reasoner) overran interactive/MCP timeouts without finishing. Two fixes:

--- a/src/api/adversarial.ts
+++ b/src/api/adversarial.ts
@@ -172,13 +172,24 @@ function psychoCase(
 }
 
 /**
+ * A declared 401, else 403 — the specific "auth rejection" codes — over `pickErrorStatus`'s generic
+ * "lowest declared 4xx" (bug #154): an operation can legitimately declare an unrelated 4xx (e.g. a
+ * `404` for "resource not found") that has nothing to do with authentication, and reusing that here
+ * would expect the wrong failure mode from a server that's actually enforcing auth correctly.
+ */
+function pickAuthRejectionStatus(e: ApiEndpoint): string {
+  const auth = e.responses.find((r) => r.status === "401") ?? e.responses.find((r) => r.status === "403");
+  return auth?.status ?? pickErrorStatus(e);
+}
+
+/**
  * Auth-header-stripped case for one operation (`hacker`, deterministic subset — see module doc): only
  * for operations that actually declare `security`, since a public operation has nothing to strip.
  */
 function toHackerCase(e: ApiEndpoint): ApiCase | undefined {
   if (e.security.length === 0) return undefined;
   const base = toCase(e);
-  const expectedStatus = pickErrorStatus(e);
+  const expectedStatus = pickAuthRejectionStatus(e);
   return {
     ...base,
     name: `${apiEndpointKey(e)} (hacker: no-auth)`,

--- a/tests/unit/api-adversarial.test.ts
+++ b/tests/unit/api-adversarial.test.ts
@@ -168,6 +168,42 @@ describe("hacker — deterministic auth-strip subset", () => {
     expect(hackerCase!.expectedStatus).not.toBe("200");
     expect(/^4/.test(hackerCase!.expectedStatus) || hackerCase!.expectedStatus === "4XX").toBe(true);
   });
+
+  // Bug #154, found live: an operation can declare a 4xx unrelated to auth (e.g. petstore's getPet
+  // only declares 404 "not found") — the auth-strip case must not blindly reuse "the lowest declared
+  // 4xx" for that, since a server correctly enforcing auth (401) would then fail a case that expected
+  // the wrong failure mode entirely.
+  it("(#154) prefers a declared 401 over any other declared 4xx", () => {
+    const m = model({
+      method: "GET",
+      path: "/x",
+      tags: [],
+      parameters: [],
+      responses: [{ status: "200" }, { status: "404" }, { status: "401" }],
+      security: ["apiKey"],
+    });
+    const [hackerCase] = generateAdversarialCases(m, ["hacker"]);
+    expect(hackerCase!.expectedStatus).toBe("401");
+  });
+
+  it("(#154) prefers a declared 403 when no 401 is declared", () => {
+    const m = model({
+      method: "GET",
+      path: "/x",
+      tags: [],
+      parameters: [],
+      responses: [{ status: "200" }, { status: "404" }, { status: "403" }],
+      security: ["apiKey"],
+    });
+    const [hackerCase] = generateAdversarialCases(m, ["hacker"]);
+    expect(hackerCase!.expectedStatus).toBe("403");
+  });
+
+  it("(#154) falls back to the generic lowest-4xx when neither 401 nor 403 is declared (petstore's getPet: only 404)", async () => {
+    const petstore = await ingestOpenApi(join(fixtures, "petstore.yaml"));
+    const getPetCase = generateAdversarialCases(petstore, ["hacker"]).find((c) => c.name.startsWith("getPet"));
+    expect(getPetCase!.expectedStatus).toBe("404");
+  });
 });
 
 describe("style selection", () => {


### PR DESCRIPTION
Closes #154

## Symptom
`cairn api --adversarial hacker` generates one auth-header-stripped case per operation that declares
`security`. For an operation whose declared 4xx responses don't include 401/403 (e.g.
`tests/fixtures/api/petstore.yaml`'s `getPet`, which only declares `200`/`404`), the case expected
`404` instead of `401`/`403`. Running it against a real server that correctly rejects the
unauthenticated request with `401` failed the assertion — a false failure, even though the server
behaved exactly as it should.

## Cause
`toHackerCase()` (`src/api/adversarial.ts`) reused `pickErrorStatus(e)` — the "lowest declared 4xx"
heuristic API-8's schema-violation negative cases use. Right for "the API rejected a malformed request
somehow" (any 4xx is a reasonable signal); wrong for an auth-strip case, which tests a *specific*
failure mode. An operation can legitimately declare an unrelated 4xx that has nothing to do with auth.

## Fix
New `pickAuthRejectionStatus(e)`: prefers a declared `401`, then `403`, over the generic
`pickErrorStatus()` fallback — which still applies, unchanged, when neither is declared.

## How I verified it
- `npm run typecheck` / `npm run build` / `npm run lint` (repo-wide; only the pre-existing, unrelated,
  untracked `playwright.config.demo.cjs` lint error) / `npm test` (714 passed, 3 pre-existing skips) —
  all green. `npm run smoke:pack` clean.
- 3 new regression tests: prefers a declared 401 over another declared 4xx; prefers 403 when no 401 is
  declared; falls back to the generic lowest-4xx unchanged when neither is declared (petstore's
  `getPet`, locking in the existing/intended behaviour for specs with no auth-specific response).
- **Live-verified the actual bug and the fix**, not just unit tests: a hand-written spec declaring
  `200`/`400`/`401` on one operation — before this fix, `pickErrorStatus`'s lexical sort would have
  picked `400` (since `"400" < "401"`); confirmed the running CLI now picks `401`.

This was found while live-demoing #95 against a real mock server enforcing real auth — exactly the
kind of gap type-checking and green unit tests don't catch (my original test only asserted "some 4xx",
not the specific code).