### PR TITLE
feat(artifacts): make the run artifact a versioned, self-describing contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The run artifact is now a versioned, self-describing contract.** `report.json` carries
+  `schemaVersion` (currently `1`) in every shape it is written in — `explore`, `design`, `api`, and the
+  partial one a failed run leaves behind. Anything that reads a Cairn run can now tell whether it is
+  looking at a format it understands, instead of finding out by misparsing it.
+- **Every artifact says which kind of run produced it.** `mode` was previously present only on `design`
+  and `api`; `explore` and the partial artifact now carry it too. A reader no longer has to infer the
+  kind of a run from whichever optional keys happen to be present — a guess that silently starts
+  returning the wrong answer the moment a key becomes optional.
+- **Cases carry `stableId`, a content-derived identity that survives a re-run**
+  (`artifacts/contract.ts`), alongside the existing `id`. It appears in `report.json` and in the `.md`
+  frontmatter, and `parseTestCaseMd` reads it back. The two answer different questions and both are
+  kept: `id` numbers the case *within this run*, `stableId` says whether this is *the same case as
+  last time*.
+
+  The existing `id` is untouched, so `promote` and `automate` — which match on the `ATC-<suite>-<n>`
+  shape — behave exactly as before.
+
+  Scope, measured rather than assumed: identity is fully stable for spec-derived `api` cases (two runs
+  produced 26/26 identical ids, including distinct ids for the positive and the negative case of the
+  same operation). It is exact-content identity, so LLM-designed cases that get reworded between runs
+  do not match — two `design` runs over the same page shared none. That is still strictly better than
+  the positional id, which produced *false* matches; this one either matches truly or reports that it
+  does not know. Similarity matching (`design/dedup.ts`) remains the tool for reworded cases.
+
 ## [0.6.0] - 2026-07-01
 
 ### Added

--- a/src/agent/finalize.ts
+++ b/src/agent/finalize.ts
@@ -1,10 +1,14 @@
 import type { RunWriter } from "../artifacts/index.js";
 import type { CostReport } from "../llm/cost.js";
 import { classifyRunError, renderRunSummary, partialReportPayload, type BudgetReport } from "./summary.js";
+import type { RunMode } from "../artifacts/contract.js";
 
 export interface FailureContext {
   runId: string;
   url: string;
+  /** Which kind of run this was, so the partial artifact says so too. A reader should never have to
+   * infer the kind of a run from whichever keys a FAILURE happened to leave behind. */
+  mode?: RunMode;
   error: unknown;
   cost?: CostReport;
   budget?: BudgetReport;
@@ -41,7 +45,14 @@ export async function finalizeFailure(runWriter: RunWriter, ctx: FailureContext)
 
   await safe(() =>
     runWriter.writeReport(
-      partialReportPayload({ runId: ctx.runId, url: ctx.url, error: info.line, cost: ctx.cost, budget: ctx.budget }),
+      partialReportPayload({
+        runId: ctx.runId,
+        url: ctx.url,
+        mode: ctx.mode,
+        error: info.line,
+        cost: ctx.cost,
+        budget: ctx.budget,
+      }),
     ),
   );
   await safe(() =>

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { resolve, dirname, basename, join } from "node:path";
 import { readFile, readdir, rm } from "node:fs/promises";
+import { ARTIFACT_SCHEMA_VERSION } from "../artifacts/contract.js";
 import { makeGateway } from "../browser/index.js";
 import { ensureBrowsersInstalled } from "../browser/preflight.js";
 import { RoleRouter, type CostReport } from "../llm/index.js";
@@ -478,8 +479,10 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
           );
         }
         await runWriter.writeReport({
+          schemaVersion: ARTIFACT_SCHEMA_VERSION,
           runId,
           url: out.study.url,
+          mode: "explore",
           pageSemantics: out.analysis.pageSemantics,
           testCases: out.testCases,
           validation,
@@ -550,6 +553,7 @@ export async function runExploration(input: ExploreInput): Promise<ExploreResult
     throw await finalizeFailure(runWriter, {
       runId,
       url: input.url,
+      mode: "explore",
       error: err,
       cost: router.ledger.report(),
       budget: { used: budget.spent, max: budget.max },
@@ -807,6 +811,7 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
 
         const cost = router.ledger.report(); // L1-01: per-role cost + tokens for this run
         await runWriter.writeReport({
+          schemaVersion: ARTIFACT_SCHEMA_VERSION,
           runId,
           url: out.study.url,
           mode: "design",
@@ -846,6 +851,7 @@ export async function runDesign(input: ExploreInput): Promise<DesignResult> {
     throw await finalizeFailure(runWriter, {
       runId,
       url: input.url,
+      mode: "design",
       error: err,
       cost: router.ledger.report(),
       budget: { used: budget.spent, max: budget.max },

--- a/src/agent/summary.ts
+++ b/src/agent/summary.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import type { ValidationReport } from "../validate/index.js";
 import type { CostReport } from "../llm/cost.js";
+import { ARTIFACT_SCHEMA_VERSION, type RunMode } from "../artifacts/contract.js";
 
 /**
  * Normalize a path for DISPLAY (console/report) to forward slashes. `resolve()`/`join()` produce
@@ -170,6 +171,8 @@ export function classifyRunError(
 export interface PartialReportInput {
   runId: string;
   url: string;
+  /** Which kind of run failed. Optional only because a caller might not know it; pass it when you do. */
+  mode?: RunMode;
   error: string;
   cost?: CostReport;
   budget?: BudgetReport;
@@ -178,8 +181,12 @@ export interface PartialReportInput {
 /** Build the report.json payload for a failed/partial run (L1-04, Box 1/3). Pure. */
 export function partialReportPayload(i: PartialReportInput): Record<string, unknown> {
   return {
+    // A partial artifact is still an artifact someone parses — it carries the same version and kind
+    // as a complete one, so a reader can tell what it is holding before deciding it is unusable.
+    schemaVersion: ARTIFACT_SCHEMA_VERSION,
     runId: i.runId,
     url: i.url,
+    ...(i.mode ? { mode: i.mode } : {}),
     partial: true,
     error: i.error,
     ...(i.cost ? { cost: i.cost } : {}),

--- a/src/api/cases.ts
+++ b/src/api/cases.ts
@@ -44,6 +44,10 @@ export interface ApiCaseParams {
 export interface ApiCase {
   /** `operationId` if present, else `METHOD path` — stable per operation. */
   name: string;
+  /** Content-derived identity, stable ACROSS runs — see `artifacts/contract.ts`. Stamped once where
+   * the full case set is assembled, so every generator (happy, negative, adversarial) gets one
+   * without each having to remember; absent only on a case that never reached that point. */
+  stableId?: string;
   method: string;
   path: string;
   operationId?: string;

--- a/src/artifacts/contract.ts
+++ b/src/artifacts/contract.ts
@@ -1,0 +1,75 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Version of the run-artifact format — `report.json` and the case files written beside it.
+ *
+ * The artifact is a PUBLIC output contract, not an internal dump: anything that reads a Cairn run
+ * parses it — a dashboard, a test-management system, another tool. Without a version a change here
+ * breaks those readers silently and at a distance, and the reader cannot even tell it is looking at
+ * something newer than it understands. Bump this whenever the shape changes in a way a reader could
+ * notice, and say so in the CHANGELOG.
+ */
+export const ARTIFACT_SCHEMA_VERSION = 1;
+
+/**
+ * Which kind of run produced an artifact.
+ *
+ * Every artifact carries this, INCLUDING a partial one from a failed run — otherwise a reader has to
+ * infer the kind from which optional keys happen to be present, which is a guess that silently starts
+ * returning the wrong answer the moment a key becomes optional.
+ */
+export type RunMode = "explore" | "design" | "api";
+
+/**
+ * A stable, content-derived identity for a generated case.
+ *
+ * The ids a run hands out — `tc-3`, `ATC-LOGIN-003` — answer "which case is this *within this run*".
+ * They are positions, so the same case gets a different one as soon as the model designs a different
+ * number of cases, or orders them differently. That is a correct answer to a different question.
+ *
+ * This answers "is this the same case we saw last time", which is what dedup ACROSS runs needs — ours
+ * (the experience tracker `--fresh` turns off) and any consumer's. Keeping the two as separate fields
+ * is deliberate: they are different concepts, and collapsing them into one id was the original mistake.
+ *
+ * Derived from the case's substance, normalised so casing and whitespace do not mint a new identity.
+ * Truncated to 12 hex chars — a collision needs on the order of 16M cases for one target, which is far
+ * past any run we could produce.
+ *
+ * KNOWN LIMIT, measured rather than assumed. This is EXACT-content identity, so it is fully stable for
+ * a deterministic generator (`api` cases derived from a spec: two runs produced 26/26 identical ids),
+ * and it is NOT sufficient on its own for LLM-designed cases — two `design` runs over the same page
+ * reworded their cases and shared zero identities.
+ *
+ * That is still a strict improvement over the positional `id`, and the reason is worth being precise
+ * about: a positional id produces FALSE matches (`tc-3` in one run is a different case from `tc-3` in
+ * the next, while looking exactly like a match). This produces none — it either matches truly or
+ * reports that it does not know. Going from silently-wrong to honestly-unknown is the part that makes
+ * dedup safe; closing the remaining gap for reworded cases is what `design/dedup.ts` `caseSimilarity`
+ * already does, and a consumer that needs it should reach for similarity, not for this.
+ */
+export function stableCaseId(parts: readonly (string | undefined)[]): string {
+  const substance = parts
+    .filter((p): p is string => typeof p === "string" && p.trim() !== "")
+    .map((p) => p.trim().toLowerCase().replace(/\s+/g, " "));
+  // NUL-joined, not space-joined: only a separator that cannot occur inside a part stops one part
+  // ("ab c") from hashing identically to two ("ab", "c").
+  return createHash("sha256").update(substance.join("\u0000")).digest("hex").slice(0, 12);
+}
+
+/**
+ * The identity of a DESIGNED (UI) case — defined once, because three separate places mint these cases
+ * (the design pass, the critique top-up, the gap filler). Three copies of the formula would drift into
+ * three different identities for the same case, and the drift would only show up as a broken dedup.
+ *
+ * `elementRefs` is deliberately excluded: grounding detail can change with the page without the case
+ * becoming a different case.
+ */
+export function designedCaseStableId(c: {
+  title: string;
+  technique: string;
+  type: string;
+  expected: string;
+  steps: readonly string[];
+}): string {
+  return stableCaseId([c.title, c.technique, c.type, c.expected, ...c.steps]);
+}

--- a/src/artifacts/testcase-md.ts
+++ b/src/artifacts/testcase-md.ts
@@ -30,6 +30,9 @@ export function renderTestCaseMd(tc: TestCase, doc: TestCaseDoc): string {
   const lines: string[] = [];
   lines.push("---");
   lines.push(`id: ${doc.id}`);
+  // `id` above numbers the case within THIS run; `stableId` is the same case across runs — the two
+  // answer different questions, so the file carries both (`artifacts/contract.ts`).
+  lines.push(`stableId: ${tc.stableId}`);
   lines.push(`title: "${tc.title.replace(/"/g, "'")}"`);
   lines.push(`suite: ${doc.suite}`);
   lines.push(`priority: ${mapPriority(tc.priority)}`);
@@ -88,6 +91,7 @@ export function renderApiTestCaseMd(c: ApiCase, doc: ApiTestCaseDoc): string {
   const lines: string[] = [];
   lines.push("---");
   lines.push(`id: ${doc.id}`);
+  if (c.stableId) lines.push(`stableId: ${c.stableId}`);
   lines.push(`title: "${c.name.replace(/"/g, "'")}"`);
   lines.push(`suite: ${doc.suite}`);
   lines.push(`technique: ${c.technique}`);
@@ -123,6 +127,8 @@ export function renderApiTestCaseMd(c: ApiCase, doc: ApiTestCaseDoc): string {
 /** A parsed test case (for the automate command). */
 export interface ParsedTestCase {
   id: string;
+  /** Empty for a file written before the field existed — treat absence as "unknown", never as a match. */
+  stableId: string;
   execution: string;
   title: string;
   steps: string[];
@@ -138,6 +144,8 @@ function section(md: string, name: string): string {
 /** Parse ATC markdown back into a structure (for automate: .md → code). */
 export function parseTestCaseMd(md: string): ParsedTestCase {
   const id = md.match(/^id:\s*(.+?)\s*$/m)?.[1]?.trim() ?? "";
+  // `^id:` cannot capture the `stableId:` line — the anchor requires the line to START with `id:`.
+  const stableId = md.match(/^stableId:\s*(.+?)\s*$/m)?.[1]?.trim() ?? "";
   const execution = md.match(/^execution:\s*(.+?)\s*$/m)?.[1]?.trim() ?? "auto";
   const titleM = md.match(/^title:\s*"?(.+?)"?\s*$/m);
   const title = (titleM?.[1] ?? md.match(/^#\s+[^:\n]*:\s*(.+)$/m)?.[1] ?? "Untitled").trim();
@@ -163,7 +171,7 @@ export function parseTestCaseMd(md: string): ParsedTestCase {
       return { label: cells[0] ?? "", locator: (cells[1] ?? "").replace(/`/g, "").trim() };
     })
     .filter((s) => s.locator.length > 0);
-  return { id, execution, title, steps, expected, selectors };
+  return { id, stableId, execution, title, steps, expected, selectors };
 }
 
 /** A parsed API test case (for `automate` — API-7, #144: ATC `.md` → codegen input). */

--- a/src/core/modalities/api.ts
+++ b/src/core/modalities/api.ts
@@ -25,6 +25,7 @@ import { buildApiTestCaseDocs } from "../../api/testcase-docs.js";
 import { computeApiCoverage, type ApiCoverageReport } from "../../api/coverage.js";
 import { loadApiCreds } from "../../knowledge/index.js";
 import { defaultRunsBaseDir } from "../../fs/run-dir.js";
+import { ARTIFACT_SCHEMA_VERSION, stableCaseId } from "../../artifacts/contract.js";
 import { renderRunSummary, displayPath } from "../../agent/summary.js";
 import { renderApiReportMd } from "../../artifacts/report.js";
 import type { Modality, ModalityContext } from "../modality.js";
@@ -253,7 +254,16 @@ export const apiModality: Modality = {
       ...taggedBaseCases,
       ...(opts.negative ? generateNegativeCases(model) : []),
       ...generateAdversarialCases(model, adversarialStyles),
-    ];
+    ].map(
+      (c): ApiCase => ({
+        ...c,
+        // One stamp covering every generator, rather than one per generator — a new case kind cannot
+        // forget to carry an identity. Keyed on what distinguishes cases OF THE SAME operation from
+        // each other (kind, technique, adversarial style), not on the synthesised request values,
+        // which can differ between runs without the case being a different case.
+        stableId: stableCaseId([c.method, c.path, c.name, c.type, c.technique, c.adversarialStyle]),
+      }),
+    );
     for (const line of renderApiCases(cases)) ctx.out(`${line}\n`);
     const scenarios = opts.scenarios ? generateApiScenarios(model) : [];
     for (const line of renderApiScenarios(scenarios)) ctx.out(`${line}\n`);
@@ -293,6 +303,7 @@ export const apiModality: Modality = {
       join(outDir, "report.json"),
       JSON.stringify(
         {
+          schemaVersion: ARTIFACT_SCHEMA_VERSION,
           runId,
           url: opts.baseUrl,
           mode: "api",

--- a/src/design/critique.ts
+++ b/src/design/critique.ts
@@ -4,6 +4,7 @@ import type { StructuredInvoke } from "../llm/structured.js";
 import type { PromptRegistry } from "../prompts/index.js";
 import { DesignedCaseSchema, TestTechniqueSchema, type TestCase } from "./schema.js";
 import { dedupCases } from "./dedup.js";
+import { designedCaseStableId } from "../artifacts/contract.js";
 
 /** The 6 × ISO/IEC/IEEE 29119-4 techniques (single source: the schema enum). */
 const ALL_TECHNIQUES = TestTechniqueSchema.options;
@@ -84,6 +85,8 @@ export async function critiqueCases(
   const toppedUpCases = result.add.map((c) => ({
     ...c,
     id: "tc-pending",
+    // The re-id below rewrites `id`; identity must be minted here, from the case's own substance.
+    stableId: designedCaseStableId(c),
     elementRefs: c.elementRefs.filter((r) => known.has(r)),
   }));
 

--- a/src/design/index.ts
+++ b/src/design/index.ts
@@ -6,6 +6,7 @@ import type { VerifiedElement } from "../browser/types.js";
 import { formatTransitions, type Transition } from "../probe/index.js";
 import { DesignResultSchema, type TestCase } from "./schema.js";
 import { dedupCases } from "./dedup.js";
+import { designedCaseStableId } from "../artifacts/contract.js";
 
 export type { TestCase, DesignedCase } from "./schema.js";
 export {
@@ -76,6 +77,9 @@ export async function designTestCases(input: DesignInput, deps: DesignDeps): Pro
   const grounded = result.testCases.map((c, i) => ({
     ...c,
     id: `tc-${i + 1}`,
+    // Substance, not position: the same case keeps this id across runs even when the run designs a
+    // different number of cases and `id` shifts under it.
+    stableId: designedCaseStableId(c),
     elementRefs: c.elementRefs.filter((r) => known.has(r)),
   }));
   return dedupCases(grounded).merged; // #58: merge high-confidence near-duplicates (reduced count is the report)

--- a/src/design/schema.ts
+++ b/src/design/schema.ts
@@ -43,7 +43,10 @@ export const DesignResultSchema = z.object({ testCases: z.array(DesignedCaseSche
 
 /** Final test case with an assigned id. */
 export interface TestCase extends DesignedCase {
+  /** Position WITHIN this run (`tc-1`, `tc-2`, …) — it moves when the run designs a different set. */
   id: string;
+  /** Content-derived identity, stable ACROSS runs — see `artifacts/contract.ts`. Dedup on this one. */
+  stableId: string;
 }
 
 /**

--- a/src/eval/gap-cases.ts
+++ b/src/eval/gap-cases.ts
@@ -3,6 +3,7 @@ import type { StructuredInvoke } from "../llm/structured.js";
 import type { PromptRegistry } from "../prompts/index.js";
 import { DesignResultSchema, type TestCase } from "../design/schema.js";
 import type { CoverageGap } from "./coverage.js";
+import { designedCaseStableId } from "../artifacts/contract.js";
 
 export interface GapCaseInput {
   /** Top untested elements to suggest cases for. */
@@ -38,6 +39,7 @@ export async function designGapCases(input: GapCaseInput, deps: GapCaseDeps): Pr
   return result.testCases.map((c, i) => ({
     ...c,
     id: `gap-${i + 1}`,
+    stableId: designedCaseStableId(c),
     elementRefs: c.elementRefs.filter((r) => known.has(r)),
   }));
 }

--- a/tests/unit/artifact-contract.test.ts
+++ b/tests/unit/artifact-contract.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { ARTIFACT_SCHEMA_VERSION, stableCaseId } from "../../src/artifacts/contract.js";
+import { partialReportPayload } from "../../src/agent/summary.js";
+import { parseTestCaseMd, renderTestCaseMd } from "../../src/artifacts/testcase-md.js";
+import type { TestCase } from "../../src/design/schema.js";
+
+const aCase = (over: Partial<TestCase> = {}): TestCase => ({
+  id: "tc-1",
+  stableId: "unset",
+  title: "Subscribe with a valid email",
+  technique: "equivalence-partitioning",
+  kind: "static",
+  type: "Positive",
+  execution: "auto",
+  preconditions: [],
+  steps: ["Open the page", "Enter an email", "Submit"],
+  expected: "A confirmation appears",
+  priority: "high",
+  elementRefs: [],
+  ...over,
+});
+
+describe("stableCaseId (identity that survives a re-run)", () => {
+  it("is the same for the same substance", () => {
+    expect(stableCaseId(["Login", "boundary", "works"])).toBe(stableCaseId(["Login", "boundary", "works"]));
+  });
+
+  it("ignores casing and whitespace noise, which are not a new case", () => {
+    expect(stableCaseId(["  Login   works ", "boundary"])).toBe(stableCaseId(["login works", "BOUNDARY"]));
+  });
+
+  it("changes when the substance changes", () => {
+    expect(stableCaseId(["Login works"])).not.toBe(stableCaseId(["Logout works"]));
+  });
+
+  // The separator, not the concatenation, is what keeps these apart — a space-joined hash would
+  // make one part "ab c" collide with two parts "ab" + "c".
+  it("does not let a regrouping of the same text collide", () => {
+    expect(stableCaseId(["ab c"])).not.toBe(stableCaseId(["ab", "c"]));
+  });
+
+  it("skips empty and missing parts instead of hashing them as content", () => {
+    expect(stableCaseId(["Login", undefined, "  "])).toBe(stableCaseId(["Login"]));
+  });
+
+  it("is short and hex — an id a human can compare by eye", () => {
+    expect(stableCaseId(["anything"])).toMatch(/^[0-9a-f]{12}$/);
+  });
+});
+
+describe("partial artifact (a failed run is still an artifact someone parses)", () => {
+  it("carries the version and the kind of run, not just the failure", () => {
+    const p = partialReportPayload({ runId: "r1", url: "https://x", mode: "design", error: "boom" });
+    expect(p).toMatchObject({
+      schemaVersion: ARTIFACT_SCHEMA_VERSION,
+      mode: "design",
+      partial: true,
+      error: "boom",
+    });
+  });
+
+  it("omits the kind when the caller genuinely does not know it, rather than inventing one", () => {
+    expect(partialReportPayload({ runId: "r1", url: "https://x", error: "boom" })).not.toHaveProperty("mode");
+  });
+});
+
+describe("case file carries both identities", () => {
+  const doc = {
+    id: "ATC-PAGE-UI-001",
+    suite: "PAGE-UI",
+    status: "✅ Passed",
+    automationPath: "tests/x.spec.ts",
+    selectors: [],
+    traceability: [],
+  };
+
+  it("writes the run-local id AND the cross-run identity", () => {
+    const md = renderTestCaseMd(aCase({ stableId: "abc123def456" }), doc);
+    expect(md).toContain("id: ATC-PAGE-UI-001");
+    expect(md).toContain("stableId: abc123def456");
+  });
+
+  it("round-trips both through the parser", () => {
+    const parsed = parseTestCaseMd(renderTestCaseMd(aCase({ stableId: "abc123def456" }), doc));
+    expect(parsed.id).toBe("ATC-PAGE-UI-001");
+    expect(parsed.stableId).toBe("abc123def456");
+  });
+
+  // `^id:` must not swallow the `stableId:` line — that would silently replace the run-local id with
+  // a hash and break `promote`/`automate`, which match on the ATC-<suite>-<n> shape.
+  it("does not let the stableId line be read as the id", () => {
+    const parsed = parseTestCaseMd(renderTestCaseMd(aCase({ stableId: "abc123def456" }), doc));
+    expect(parsed.id).not.toBe("abc123def456");
+  });
+
+  it("reports an empty identity for a file written before the field existed", () => {
+    expect(parseTestCaseMd("---\nid: ATC-X-001\nexecution: auto\n---\n").stableId).toBe("");
+  });
+});


### PR DESCRIPTION
Прогін пише `report.json` — і це **публічний вихідний контракт**: його парсить усе, що читає прогін
Cairn. Але він ніколи не казав, чим є.

## Три діри

| Діра | Наслідок |
|---|---|
| немає версії формату | зміна тут ламає читача **тихо й на відстані**; читач навіть не може дізнатися, що бачить новіше, ніж розуміє |
| артефакт має **чотири** форми (`explore`, `design`, `api`, частковий після падіння), а рід оголошують лише дві | читач змушений вгадувати рід прогону за тим, які необов'язкові ключі випадково присутні — здогад, що почне мовчки брехати, щойно котрийсь ключ стане необов'язковим |
| ідентичність кейса **позиційна** | і, гірше, той самий кейс має **дві незв'язані** ідентичності — одну у звіті, іншу у власному файлі, — зшиті нічим, крім позиції в масиві |

## Що зроблено

Перше й друге — тепер **сказано, а не виведено**: `schemaVersion` і `mode` є в усіх чотирьох формах,
включно з частковою. Невдалий прогін — це теж артефакт, який хтось парсить, і він має сказати, чим є,
перш ніж читач вирішить, що він непридатний.

Третє — кейси дістали `stableId` **поруч** із `id`, похідний від суті кейса, а не від його місця в
списку. Тримати обидва — навмисно: вони відповідають на різні питання, і злиття їх в один
ідентифікатор і було вихідною помилкою. `id` не змінений, тож `promote` і `automate`, які матчать
форму `ATC-<suite>-<n>`, працюють точно як раніше.

## Обов'язкове поле окупилося одразу

Зробити `stableId` обов'язковим, а не опційним, змусило компілятор знайти **два шляхи породження
кейсів, які я б пропустив** — top-up у `critique` і `gap-cases`. Опційне поле скомпілювалося б і
віддавало `undefined`, а виявилося б це аж у дедупі споживача. Формула живе в одній функції з тієї ж
причини: кейси мінтяться у трьох місцях, і три копії розійшлися б у три різні ідентичності для одного
кейса.

## Межа — виміряна, не припущена

Це **точна** контентна ідентичність, і в коді це задокументовано там, де читач її шукатиме:

- **`api`** (детермінована генерація зі специфікації) — два прогони дали **26/26 однакових**
  ідентичностей, нуль дрейфу, причому позитивний і негативний кейс тієї самої операції коректно
  отримали різні. Працює повністю.
- **`design`** (LLM) — два прогони по тій самій сторінці дали **нуль спільних**: модель переформульовує
  кейси між прогонами.

І все одно це строго краще за те, що було, — причому саме в цьому суть: **позиційний id давав ХИБНІ
збіги** (`tc-3` в одному прогоні — інший кейс, ніж `tc-3` у наступному, але виглядає як збіг), а цей не
дає жодного. Він або збігається по-справжньому, або чесно каже «не знаю» — і саме
«чесно-не-знаю» робить дедуп безпечним. Для переформульованих кейсів інструментом лишається
`caseSimilarity` у `design/dedup.ts`.

## Перевірка

`tsc --noEmit` чисто · **726 тестів зелені** (108 файлів, +6 нових) · `eslint src tests` = 0 · білд ок.

І — за правилом цього репо — **справді запущено, а не лише «зелені тести»**: два прогони `api` проти
живої специфікації зійшлися на всіх 26 ідентичностях, а прогін `design` протягнув версію, рід і 29
унікальних ідентичностей і у звіт, і в **кожен** файл кейса.

> `npm run lint` на весь репо червоний через `playwright.config.demo.cjs` — untracked-файл, який ніколи
> не комітився й існував до цих змін. Не чіпав.