### PR TITLE
ci: stop the publish job from chasing npm@latest onto an unsupported engine

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,8 +42,6 @@ jobs:
           node-version: "20"
           cache: npm
 
-      - run: npm install -g npm@latest
-
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
Реліз **v0.7.0 впав** — і не дійшов навіть до встановлення залежностей.

## Що сталося

Джоба робила `npm install -g npm@latest` на Node 20. `latest` тепер — **npm 12**, який вимагає
Node `^22.22.2 || ^24.15.0 || >=26.0.0`:

```
npm error code EBADENGINE
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

У релізі нічого не змінювалося — **зрушив npm**. Останній успішний публіш був 0.6.0 (01.07), і це
зламало б будь-який реліз від моменту виходу npm 12.

## Чому крок ВИДАЛЕНО, а не запінено

Йому вже нічого було робити:

- Node 20 несе **npm 10.8.2**, а `--provenance` є з npm 9.5;
- лок-файл — `lockfileVersion: 3`, npm 10 читає його нативно;
- пакет декларує `node >= 20`.

Тобто апгрейд не давав нічого, а натомість вішав реліз на те, яку версію npm випустить наступною.
Пін теж спрацював би — і лишив би ту саму пастку тому, хто колись підніматиме пін.

Після мерджу публікацію можна перезапустити ідемпотентно:
`gh workflow run publish.yml -f tag=v0.7.0 --ref main`.