### PR TITLE
docs: an ADR index, and seven decisions recorded since v0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,13 +49,15 @@ graphify-out/
 /observe-screenshot.png
 
 # Internal dev docs — kept local, NOT in the public repo (keep only architecture/adr/runbooks)
+# `docs/README.md` is deliberately NOT here: it is the published entry point to docs/, and it must
+# link only to paths that survive this list. It used to be ignored because it indexed the internal
+# files below and would have shipped as a page of broken links.
 docs/sprints/
 docs/tasks/
 docs/research/
 docs/prompts/
 docs/PLAN.md
 docs/traceability.md
-docs/README.md
 
 # npm pack artifacts
 *.tgz

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ const result = await runDesign({ url, config, sessionName: "myapp", checklistTex
 - **[Authenticated targets](docs/sessions.md)** · **[Configuration & role routing](docs/configuration.md)** · **[Prompts & styles](docs/prompts-and-styles.md)** · **[Interactive TUI](docs/tui.md)** · **[MCP server](docs/mcp.md)**
 - **[Metrics](docs/metrics.md)** · **[Cost benchmark](docs/cost.md)** · **[Langfuse](docs/langfuse.md)**
 - **[Architecture overview](docs/architecture/overview.md)** — the plain async pipeline, locator grounding, self-improvement.
-- **[Architecture Decision Records](docs/adr/)** — why it's built this way (0001–0013).
+- **[Architecture Decision Records](docs/adr/README.md)** — why it's built this way (0001–0020, indexed).
+- **[All documentation](docs/README.md)** — the full map of `docs/`.
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,80 @@
+# Cairn — documentation
+
+Cairn is an autonomous TypeScript agent that studies a running application and generates tests for it:
+`@playwright/test` suites and methodology-tagged test cases, over a plain async pipeline
+(ADR-0013) on Anthropic Claude / OpenRouter / Groq, with self-improvement via Langfuse.
+
+Package: **`@plune-ai/cairn`** · CLI: **`cairn`** · License: Apache-2.0.
+Start at the [root README](../README.md) for the 30-second pitch; this page is the map of everything below `docs/`.
+
+## Where to look
+
+| I want… | See |
+|---|---|
+| To install it and get a first suite out | [`getting-started.md`](./getting-started.md) |
+| To point it at an app behind a login | [`sessions.md`](./sessions.md) |
+| To configure providers, profiles and role routing | [`configuration.md`](./configuration.md) |
+| To change the house style of generated cases | [`prompts-and-styles.md`](./prompts-and-styles.md) |
+| To drive it from a terminal UI | [`tui.md`](./tui.md) |
+| To call it from another agent (Claude Code, Cursor) | [`mcp.md`](./mcp.md) |
+| To read the run metrics and scores | [`metrics.md`](./metrics.md) |
+| To know what a run costs | [`cost.md`](./cost.md) |
+| To wire up tracing and experiments | [`langfuse.md`](./langfuse.md) |
+| To see it move | [`demo/`](./demo/) |
+| **Why it is built this way** | [`adr/README.md`](./adr/README.md) — the decision index |
+| How the pieces fit together | [`architecture/overview.md`](./architecture/overview.md) |
+| To run a specific procedure step by step | [`runbooks/`](./runbooks/) |
+
+## Architecture
+
+| Document | What it covers |
+|---|---|
+| [`architecture/overview.md`](./architecture/overview.md) | The system in one page |
+| [`architecture/module-map.md`](./architecture/module-map.md) | Which module owns what |
+| [`architecture/state-machine.md`](./architecture/state-machine.md) | The pipeline stages and their order |
+| [`architecture/browser-gateway.md`](./architecture/browser-gateway.md) | The two browser backends behind one seam |
+| [`architecture/self-improvement.md`](./architecture/self-improvement.md) | Scores, judges, datasets, experiments |
+| [`architecture/data-contracts.md`](./architecture/data-contracts.md) | The zod schemas that cross module boundaries |
+
+## Runbooks
+
+Operational procedures, each self-contained:
+[save a session](./runbooks/save-session.md) ·
+[run an exploration](./runbooks/run-exploration.md) ·
+[design then automate](./runbooks/design-and-automate.md) ·
+[run API cases](./runbooks/run-api-cases.md) ·
+[smoke a real site](./runbooks/real-site-smoke.md) ·
+[curate a dataset](./runbooks/curate-dataset.md) ·
+[run an experiment](./runbooks/run-experiment.md) ·
+[promote a prompt](./runbooks/promote-prompt.md).
+
+## Decisions
+
+Locked decisions live in [`adr/`](./adr/) — **19 records**, indexed in [`adr/README.md`](./adr/README.md).
+The index also carries the reverse view: which shipped features were judged **not** to need an ADR, and why.
+
+The ones worth reading first:
+
+- [ADR-0013](./adr/0013-drop-langgraph.md) — why there is no graph framework, just async functions.
+- [ADR-0014](./adr/0014-versioned-artifact-contract.md) — `report.json` is a public contract with a version.
+- [ADR-0012](./adr/0012-relicense-to-apache-2.0.md) — why Apache-2.0 and not MIT or GPL.
+- [ADR-0002](./adr/0002-llm-anthropic-tiering.md) + [ADR-0011](./adr/0011-per-role-model-routing.md) — how a model gets picked for a step.
+
+## Directory layout
+
+```
+docs/
+├─ README.md              ← this file
+├─ getting-started.md     ← onboarding
+├─ sessions.md · configuration.md · prompts-and-styles.md · tui.md · mcp.md
+├─ metrics.md · cost.md · langfuse.md
+├─ adr/                   ← Architecture Decision Records (+ README index)
+├─ architecture/          ← system design
+├─ runbooks/              ← operational procedures
+├─ demo/                  ← recorded demo
+└─ assets/                ← images
+```
+
+Some working documents (the roadmap, sprint plans, task files, prompt specs) are kept local to the
+authoring checkout and are not published — see `.gitignore` for the exact list. Nothing on this page
+links to them, which is the point.

--- a/docs/adr/0014-versioned-artifact-contract.md
+++ b/docs/adr/0014-versioned-artifact-contract.md
@@ -1,0 +1,93 @@
+# ADR-0014: The run artifact is a versioned, self-describing contract
+
+- **Status:** Accepted
+- **Date:** 2026-07-30
+- **Decision in code:** `src/artifacts/contract.ts`, `src/artifacts/report.ts`, `src/artifacts/testcase-md.ts`, `src/agent/{finalize,summary}.ts`, `src/core/modalities/api.ts`
+- **Applies from:** 0.7.0 · **PR:** #165
+- **Relationship to prior ADRs:** extends ADR-0005 (the *generated tests* are a contract) to the *run artifact* itself. ADR-0005 froze what Cairn writes for a human to run; this freezes what Cairn writes for a machine to read.
+
+## Context
+
+`runs/<id>/report.json` had quietly become Cairn's most important output for anything that is not a
+person. The Plune platform reads it — and *only* it — to ingest a run (`plune ingest <dir>`, see Plune's
+`ADR-CI-02`, "read `report.json` only, do not depend on the Cairn package"). The TUI reads it. The
+`automate` command reads it to find a previous run's cases. The experience tracker reads it to dedupe
+against earlier runs.
+
+Three properties a contract needs, and none of them held:
+
+1. **No version.** A change to the shape broke every reader silently and at a distance. Worse, a reader
+   could not tell that it was looking at something *newer* than it understood — it just saw a missing key
+   and guessed.
+2. **The kind of run was inferred, not stated.** The artifact came in four shapes — `explore`, `design`,
+   `api`, and the partial one a failed run leaves behind — and only two of them said which they were.
+   A reader had to deduce the kind from whichever optional keys happened to be present. That deduction
+   starts returning the wrong answer the moment a key becomes optional, which is exactly the kind of change
+   nobody thinks of as breaking.
+3. **Case identity was positional.** Cases were identified by `tc-3` / `ATC-LOGIN-003` — an answer to
+   "which case is this *within this run*". Dedup across runs needs the other question, and we already do
+   that dedup ourselves (`--fresh` exists to turn it off). The same case also carried two unrelated
+   identities, one in `report.json` and another in its own `.md` file, joined by nothing but array position.
+
+## Decision
+
+**Every run artifact states its version, its kind, and a content-derived identity for each case.**
+
+1. **`schemaVersion`** — `ARTIFACT_SCHEMA_VERSION = 1`, on every shape. Bump it whenever the shape changes
+   in a way a reader could notice, and say so in the CHANGELOG. One integer, not semver: readers need
+   "can I parse this", not a compatibility algebra.
+2. **`mode: "explore" | "design" | "api"`** — on every shape, **including the partial artifact a failed
+   run leaves behind**. A failed run is still an artifact someone parses, and it should say what it is
+   before a reader decides it is unusable.
+3. **`stableId` beside `id`** — a content-derived case identity: `sha256` over the case's normalised
+   substance (title, technique, type, expected, steps), NUL-joined so `["ab c"]` cannot hash identically to
+   `["ab","c"]`, truncated to 12 hex chars. `id` is untouched, so `promote` and `automate`, which match on
+   the `ATC-<suite>-<n>` shape, behave exactly as before.
+4. **The derivation lives in one function** (`designedCaseStableId`). Three separate sites mint designed
+   cases — the design pass, the critique top-up (ADR-0017), the gap filler — and three copies of the
+   formula would drift into three identities for the same case, surfacing only as a broken dedup.
+5. **The field is required, not optional.** Making it required is what made the compiler point at the two
+   case-minting paths that would otherwise have been missed.
+
+### The known limit, measured rather than assumed
+
+This is **exact-content** identity. It is fully stable for a deterministic generator and not sufficient on
+its own for an LLM-designed one:
+
+| Generator | Two runs, same input | Identities shared |
+|---|---|---|
+| `api` cases (spec-derived, ADR-0015) | 26 cases | **26 / 26**, with the positive and negative case of one operation correctly distinct |
+| `design` cases (LLM-designed) | 29 cases | **0 / 29** — the model rewords between runs |
+
+That is still strictly better than what it replaces, and the reason is the whole point: a positional id
+produces **false** matches (`tc-3` in one run is a different case from `tc-3` in the next, while looking
+exactly like a match). This produces none — it either matches truly or reports that it does not know.
+Going from silently-wrong to honestly-unknown is what makes a dedup safe. Closing the remaining gap for
+reworded cases is what `design/dedup.ts` `caseSimilarity` already does; a consumer that needs it should
+reach for similarity, not for this.
+
+## Consequences
+
+- **Cairn owes downstream a bump.** `report.json` is no longer an internal dump we may reshape freely.
+  Any noticeable shape change now costs a `ARTIFACT_SCHEMA_VERSION` bump plus a CHANGELOG line.
+- **Plune ingest gets a version gate for free.** It can refuse, warn, or degrade on an unknown version
+  instead of parsing a newer artifact with older assumptions.
+- **Two identities per case, deliberately.** `id` answers "where in this run"; `stableId` answers "is this
+  the same case". Collapsing them into one identifier was the original mistake; keeping both is the fix.
+- **Failed runs became parseable.** A partial artifact now says what it is, so a consumer can classify it
+  rather than reject it.
+
+## Rejected alternatives
+
+- **Semver the artifact (`"1.2.0"`).** A reader's only real question is "do I understand this shape".
+  An integer answers it; a three-part version invites a compatibility policy nobody would implement.
+- **Replace `id` with `stableId`.** Would have broken `promote` and `automate`, which match on the
+  `ATC-<suite>-<n>` shape, and would have destroyed the "which case is this within this run" answer that
+  reports and human review actually use.
+- **Make `stableId` optional.** It would have compiled and shipped `undefined` identities from the two
+  case-minting paths nobody remembered, surfacing later inside a consumer's dedup.
+- **Hash the whole case object, including `elementRefs`.** Grounding detail changes with the page without
+  the case becoming a different case; including it would mint a new identity on every re-run.
+- **Publish a JSON Schema / TypeScript package for the contract.** Would couple readers to a Cairn release.
+  Plune's `ADR-CI-02` explicitly chose not to depend on the Cairn package; a self-describing artifact is
+  what lets both sides keep that independence.

--- a/docs/adr/0015-api-modality-schema-driven.md
+++ b/docs/adr/0015-api-modality-schema-driven.md
@@ -1,0 +1,79 @@
+# ADR-0015: The `api` modality generates from the spec, not from an LLM
+
+- **Status:** Accepted
+- **Date:** 2026-06-30 (API-1 landed the decision) — completed 2026-07-01 (API-2…API-10)
+- **Decision in code:** `src/api/`, `src/core/modalities/api.ts`, `src/core/registry.ts`, `src/artifacts/testcase-md.ts`, `src/codegen/index.ts`
+- **Applies from:** 0.6.0 · **Issues:** #22 (umbrella), #132…#150 · **Slices:** API-1…API-10
+- **Relationship to prior ADRs:** the first modality to join `explore` in the registry created by C1-01. Shares ADR-0002/0011 (providers, routing) and ADR-0005 (`@playwright/test` output), and writes through the ADR-0014 artifact contract.
+
+## Context
+
+ADR-0010 renamed the tool to Cairn on the explicit premise that it would be an **umbrella** — "a container
+for many modalities, not a label for one". Until 0.6.0 that premise was unpaid: `explore` (UI) was the only
+real modality, and `ui`/`api`/`unit`/`docs` were gated stubs that printed a coming-soon notice. A named user
+pulled `api`, so it had to be built.
+
+The obvious way to build it was to point the existing machinery at an OpenAPI spec: give the LLM the spec,
+ask for test cases. That is what most tools in this space do, and it is wrong here.
+
+An OpenAPI spec is **already the structured artifact** an LLM would be asked to produce. The happy-path
+request for an operation follows mechanically from the schema — `example` → `default` → `enum` → type. Asking
+a model to do that derivation buys nothing and costs three things: money per operation, non-determinism (the
+same spec yields different cases on different runs), and a failure mode where the model invents an endpoint,
+a parameter, or a status code that the spec does not declare. For UI exploration an LLM is unavoidable —
+there is no machine-readable description of a running page. For an API there is one, and it is the input.
+
+## Decision
+
+**The `api` modality is a deterministic, schema-driven generator.** It becomes a real entry in the modality
+registry (`cairn api --spec <path|url>`, parity with `cairn explore`), and it reuses Cairn's existing
+boundaries rather than growing a parallel stack.
+
+1. **Ingest** (API-1) — `@apidevtools/swagger-parser` dereferences an OpenAPI 3.x spec (JSON or YAML, file or
+   `http(s)` URL, `$ref` including circular) into an internal endpoint model. A malformed or unsupported spec
+   fails with a clear message and a non-zero exit, never a crash.
+2. **Case synthesis is pure** (API-2, API-8) — one nominal case per operation, values synthesised straight
+   from the dereferenced schema; negative and contract-validation cases derived the same way. **No LLM call.**
+   Same spec ⇒ same cases. The `StructuredInvoke` seam stays wired for later, genuinely fuzzy slices, so the
+   "any LLM use is mockable" requirement holds — vacuously, for now.
+3. **Cases are methodology-tagged** (API-5) — each carries an ISO/IEC/IEEE 29119-4 technique plus a per-case
+   rationale, the same tagging web cases carry. A case states *why* it exists, not only what it sends.
+4. **Cases are emitted through the same ATC boundary as web cases** (API-5) — `runs/api-<id>/testcases/<id>.md`.
+   This is the decision that keeps the platform simple: **Plune ingests API cases through the identical path
+   as web cases**, not a parallel one. Status on an ATC is provenance-checked — it reads "Passed" only when a
+   same-named, positively-asserted result exists, never inferred from the absence of a failure.
+5. **Codegen is templating, not generation** (API-7) — `cairn automate --run <dir>` on an `api` run emits
+   `tests/api.spec.ts` using `@playwright/test`'s `request` fixture, one test per case. The case already
+   carries every field a request needs, so there is nothing to infer. The generated suite does not depend on
+   Cairn and runs standalone in CI; `API_BASE_URL` overrides the base per environment.
+6. **The runner, coverage and chains stay in the same discipline** — response assertions (API-3), reporting
+   into `report.json`/TUI (API-4), spec-vs-tested coverage (API-6), multi-endpoint create→read→update→delete
+   scenario chains threading a captured value through a declared OpenAPI `links` expression or a same-named
+   response field (API-9), and `multipart/form-data` encoding with real bytes for `format: binary` (API-10).
+7. **Print-only until a base URL is given.** Without `--base-url` there is no run directory and no artifacts —
+   consistent across API-1…API-10.
+
+## Consequences
+
+- **An `api` run is reproducible and cheap.** Two runs over the same spec produce byte-identical cases —
+  which is what let ADR-0014's `stableId` be verified at 26/26 on `api` and 0/29 on LLM-designed cases.
+- **The umbrella claim in ADR-0010 is now paid for once.** `unit` and `docs` remain gated stubs; adding one
+  is appending a registry entry plus a `run` that consumes the shared core.
+- **The LLM budget is unspent here.** An `api` run costs no tokens for generation, so cost reporting
+  (ADR-0011) shows near-zero on this modality — expected, not a bug.
+- **Spec quality is now the ceiling.** A spec that lies about its own shapes produces cases that faithfully
+  test the lie. Coverage (API-6) reports spec-vs-tested, not spec-vs-reality; nothing here detects an
+  undocumented endpoint.
+- **`--validate` is a no-op on an `api` run.** It is a browser/session concept and stays web-only.
+
+## Rejected alternatives
+
+- **LLM-designed API cases from the spec.** Costs money per operation, breaks determinism, and can invent
+  endpoints and status codes the spec never declared. The spec is the structured artifact already.
+- **A separate `cairn-api` package.** Contradicts ADR-0007 (one layered package) and would fork the config,
+  routing, cost, reporting and artifact layers that this modality reuses unchanged.
+- **A parallel artifact/report path for API runs.** Would have forced Plune to grow a second ingest path for
+  the same conceptual object. Reusing `testcases/<id>.md` cost less on both sides of the boundary.
+- **Generating requests with an HTTP client library of its own.** `@playwright/test`'s `request` fixture is
+  already a dependency, already in CI everywhere Cairn's other output runs, and produces a suite the user's
+  existing Playwright setup executes without new tooling.

--- a/docs/adr/0016-integration-surfaces-thin-adapters.md
+++ b/docs/adr/0016-integration-surfaces-thin-adapters.md
@@ -1,0 +1,89 @@
+# ADR-0016: Integration surfaces (MCP, CI/PR bot, `--into-project`) are thin adapters over the core
+
+- **Status:** Accepted
+- **Date:** 2026-06-24 (`cairn mcp`) → 2026-06-25 (`cairn ci` + GitHub Action, `--into-project`)
+- **Decision in code:** `src/mcp/`, `src/ci/`, `action/`, `src/project/`
+- **Applies from:** 0.5.0 · **Issues:** #49 (MCP), #50 (CI/PR bot), #51 (`--into-project`) · **PRs:** #109, #112, #113
+- **Relationship to prior ADRs:** applies ADR-0007's "one layered package, boundaries by directory" to a new class of module, and reuses ADR-0009's optional-dependency pattern (Ink/React) for `@modelcontextprotocol/sdk`.
+
+## Context
+
+Through 0.4.x Cairn had exactly one way in — a human typing `cairn` — and one place out: `runs/<id>/`.
+Three demands arrived in the same week, and they looked like three different features:
+
+- **#49** — other agents (Claude Code, Cursor) should be able to call test generation as a tool.
+- **#50** — a pull request should get generated tests and a summary comment without anyone typing anything.
+- **#51** — the output should land in an existing Playwright project's own `testDir`, in its conventions,
+  not in a greenfield folder the user then has to move files out of.
+
+The risk was three parallel implementations, each re-deriving config, routing, cost and run orchestration —
+and each free to drift into slightly different generation behaviour. The second risk was dependency weight:
+an MCP SDK and a GitHub API client are irrelevant to someone who only wants a CLI or a library import.
+
+## Decision
+
+**Every integration surface is a thin adapter over the public core. It adds no generation logic.**
+Four rules, applied to all three surfaces:
+
+1. **One subcommand per surface, over the same entry points.** `cairn mcp` and `cairn ci` mirror each other:
+   inputs are mapped onto the *same* `runExploration` / `runDesign` / `runAutomate` the CLI uses, through the
+   same `resolveConfig` (config, routing, cost). A surface never reaches past the public API.
+2. **Heavy or host-specific dependencies are optional and lazily imported.**
+   `@modelcontextprotocol/sdk` is an `optionalDependency`, loaded only on the `cairn mcp` path — the same
+   treatment Ink/React got in ADR-0013. The CI bot goes further and adds **no** dependency: its GitHub client
+   is ~170 lines of `fetch` against the REST and Git Data APIs, not Octokit.
+3. **Side effects sit behind an injectable seam.** MCP handlers take a `ToolDeps` core; the CI bot takes a
+   `GitHubClient`. Both are therefore unit-testable with no browser, no LLM and no network — which is how
+   comment idempotency, the changed-surface gate, and fork safety are actually covered by tests.
+4. **A surface that cannot safely act declines and says why, rather than failing.** Fork PRs and missing
+   tokens skip write effects with a logged reason. `--into-project` with no `playwright.config.*` found logs
+   the fallback and writes greenfield. Nothing here turns a missing integration into a failed run.
+
+### Per surface, the decisions that are not shared
+
+**MCP server** — three tools (`explore`, `design`, `automate`) over `StdioServerTransport`, which is what
+Claude Code and Cursor speak locally and needs no listening socket. `automate` takes a run directory instead
+of a URL, so the decoupled `design → automate` flow (ADR-0005) survives across tool calls.
+
+**CI / PR bot** — a **composite** GitHub Action wrapping `cairn ci` as a subprocess, not a JavaScript action
+bundling the tool. v1 is *generation-on-PR*: run, post an **idempotent** summary comment (marker-based
+upsert, so re-running a job edits the comment instead of stacking a new one), and — only when explicitly
+toggled — open a follow-up PR with the generated tests. A `paths` gate skips runs whose changed files touch
+no relevant surface. Provider keys come from env/secrets through `resolveConfig`; nothing is hardcoded.
+
+**`--into-project`** — detection walks up for `playwright.config.{ts,js,mjs,cjs}` and best-effort parses
+`testDir` and the `.spec.ts`/`.test.ts` suffix from `testMatch`. The safety rule is the load-bearing part:
+**validation and repair stay in an isolated `runs/<id>/tests` sandbox** — the same Playwright, identical
+result — so the user's own suite is never run and never deleted. Only after convergence are the specs placed
+into the project's `testDir`, and **a pre-existing spec is never overwritten** (Cairn writes
+`login.cairn.spec.ts` beside it). Generated specs are self-contained — each imports `@playwright/test`
+directly, with no inter-file POM imports — so a collision rename cannot break an import.
+
+## Consequences
+
+- **Generation behaviour cannot drift per surface.** A fix in the core reaches the CLI, MCP, CI and library
+  embedders at once, because there is only one implementation to fix.
+- **Install weight is unchanged for people who use none of this.** Optional deps, lazy imports, zero new
+  dependencies for CI.
+- **Cairn now ships its own GitHub Action, and Plune ships `eval-action`.** They are different jobs — Cairn's
+  *generates tests on a PR*, Plune's *evaluates and diffs runs* — but the overlap in the name space is real
+  and worth stating out loud so nobody merges them by accident.
+- **Three more public surfaces to keep compatible.** The CLI `--help` snapshot test locks the flag surface;
+  the MCP `tools/list` smoke test locks the tool surface. Both fail loudly on an accidental change.
+- **The CI bot's REST client is ours to maintain.** ~170 lines against endpoints GitHub has kept stable for
+  years, in exchange for zero dependency weight in the default install. Revisit if it grows past
+  comment upsert, changed-file listing and the Git Data PR flow.
+
+## Rejected alternatives
+
+- **A JavaScript GitHub Action bundling Cairn.** Ties the action's release cycle to a bundle rebuild and
+  hides which version actually ran. A composite action calling the published CLI shows the version in the log.
+- **Octokit in the CI bot.** A large dependency tree for three endpoints, in a package whose default install
+  weight is a stated concern (ADR-0009, ADR-0013).
+- **HTTP/SSE transport for MCP.** Would need a listening port and an auth story for a tool whose callers are
+  local editors. stdio is what they already speak.
+- **Making MCP re-implement the flags as tool inputs.** The tools accept a *subset* of the flags, mapped onto
+  the same core call. Re-deriving the surface would have created a second definition of what a run is.
+- **Writing generated specs straight into the host project and validating there.** Would mean running and
+  deleting files inside a user's own suite. The sandbox costs one directory and removes that entire class of
+  accident.

--- a/docs/adr/0017-opt-in-pipeline-passes.md
+++ b/docs/adr/0017-opt-in-pipeline-passes.md
@@ -1,0 +1,77 @@
+# ADR-0017: The pipeline grows by opt-in passes, and a flag-off run is byte-identical
+
+- **Status:** Accepted
+- **Date:** 2026-06-22 (the rule was set by `--critique`, `--flow`, `--setup`, `--gaps` landing together) · extended 2026-06-29 (`--goal`), 2026-06-30 (`--screencast`)
+- **Decision in code:** `src/design/critique.ts`, `src/flow/`, `src/eval/{coverage,gap-cases}.ts`, `src/agent/graph.ts`, `src/cli/index.ts`
+- **Applies from:** 0.5.0 · **Issues:** #82, #59, #60, #61, #63, #94 · **PRs:** #83, #86, #87, #88, #114, #130
+- **Relationship to prior ADRs:** governs how ADR-0013's plain async pipeline is extended. The stage order itself is ADR-0013; this is the rule for adding to it.
+
+## Context
+
+Dropping LangGraph (ADR-0013) left a linear async pipeline that is easy to read and easy to extend — which
+is the danger. Six capabilities queued up at once, each of which *could* have been made the new default:
+
+| Flag | What it adds |
+|---|---|
+| `--critique` | a design-time self-critique pass: prune trivial/contradictory/unverifiable cases, top up under-represented 29119-4 techniques |
+| `--flow` | crawl the in-app link graph and design journeys spanning ≥2 pages |
+| `--setup` | turn a journey's prose preconditions into structured, runnable setup |
+| `--gaps` | suggest cases for the untested surface the coverage view exposes |
+| `--goal` | bias observation and planning toward a natural-language goal |
+| `--screencast` | record a `.webm` per scenario during validation, with step chapters |
+
+Turning any of them on by default would have raised the cost and latency of every run, changed the shape of
+every artifact, and made regressions impossible to attribute — six new LLM passes cannot be A/B'd against a
+baseline that keeps moving. It would also have broken the thing the self-improvement layer (ADR-0006) depends
+on: comparing runs.
+
+## Decision
+
+**A new capability enters as an opt-in pass, default OFF, and a run without its flag produces a
+byte-identical artifact to the run before the pass existed.**
+
+The rules, in the order they bind:
+
+1. **Default off, one flag.** The flag appears on the modalities it applies to (`explore`, `design`, or
+   `automate`) and nowhere else. `--goal` and `--max-pages` take a value; the rest are booleans.
+2. **No artifact differs without the flag.** Not "roughly the same" — byte-identical. `--goal` is the sharpest
+   case: `formatGoal("")` yields `""`, so the prompts are literally unchanged when no goal is passed.
+3. **Each pass is bounded.** `--critique` is exactly one LLM call. `--flow` is bounded by `--max-pages`
+   (default 3). `--gaps` designs for the top-N untested elements only. Cost is a design input, not an outcome.
+4. **A pass hangs off a seam, not off the middle of a stage.** Each is gated by its own dependency
+   (`deps.critique`, `deps.flow`, `deps.setup`, …) so the stage it follows stays testable without it.
+5. **Best-effort passes never sink a run.** Journey design and screencast recording are best-effort: a
+   recorder or IO failure is logged, and the run's primary output still lands.
+6. **A read-only view may ship on by default; a generated artifact may not.** The coverage view is the one
+   deliberate exception — `computeCoverage` is a pure set difference over data the run already has (observed
+   interactive surface and transitions, minus what any case or journey references), it costs no LLM call, and
+   it changes no generated file. It is emitted on **every** run into `report.json` and `report.md`. The
+   *cases* that fill those gaps are what `--gaps` gates.
+7. **Safety rules are not opt-in.** The flow crawler never follows destructive links (log out, delete), stays
+   in-origin, and dedupes revisits — with or without any flag. `--setup` downgrades an `api-seed` precondition
+   with no concrete endpoint to `manual` rather than fabricating a seeding call. These are properties of the
+   pass, not options on it.
+
+## Consequences
+
+- **Regressions stay attributable.** A baseline run is still the same run it was six features ago, so
+  Langfuse experiments and dataset comparisons (ADR-0006) remain meaningful.
+- **Cost is opt-in too.** Someone running `cairn explore --url …` in 0.6.0 pays what they paid in 0.4.0.
+- **The flag surface grows, and is locked by a test.** The CLI `--help` snapshot fails on any accidental
+  change to the surface — which is the price of this rule and worth paying.
+- **Discovery gets harder.** Six useful capabilities are invisible unless the user reads the docs. The
+  coverage view partly compensates: it ships on by default and shows the user what they are not testing,
+  which is the natural prompt to reach for `--gaps`.
+- **Defaults can still be revisited, once.** Promoting a pass to on-by-default is itself a decision that
+  changes the artifact for everyone, so it needs its own ADR, not a quiet flip.
+
+## Rejected alternatives
+
+- **Make the good passes default and add `--no-*` opt-outs.** Every existing user's cost, latency and artifact
+  shape would have changed under them, and the self-improvement baseline would have moved six times in ten days.
+- **A single `--deep` / preset flag bundling several passes.** Hides which pass caused a change and makes each
+  one impossible to evaluate on its own. Presets are worth revisiting once the individual passes have evidence.
+- **Config-file-only switches.** The passes are per-run decisions ("crawl this app's flows", "record this
+  review"), not per-project settings; a config key would have made a per-run choice sticky.
+- **Gating the coverage view behind `--gaps` too.** It costs nothing, generates nothing and is the single most
+  useful default addition of the six. Hiding it would have been consistency for its own sake.

--- a/docs/adr/0018-documentarian-page-understanding-cache.md
+++ b/docs/adr/0018-documentarian-page-understanding-cache.md
@@ -1,0 +1,75 @@
+# ADR-0018: Page understanding is a first-class artifact, cached across runs by ARIA fingerprint
+
+- **Status:** Accepted
+- **Date:** 2026-06-29
+- **Decision in code:** `src/documentarian/index.ts`, `src/agent/graph.ts`, `src/artifacts/index.ts`
+- **Applies from:** 0.6.0 · **Issue:** #93 (BORROW-06) · **PR:** #116
+- **Relationship to prior ADRs:** adds a cross-run cache to ADR-0013's pipeline. Cross-run *semantic* memory (MEM-02, #64) is deliberately out of scope and remains unbuilt.
+
+## Context
+
+Every run re-learned the page from zero. Observe, identify elements, verify locators, probe interactions —
+then a `analyzePage` LLM call to turn all of that into an understanding of what the page *is*. Run the same
+command twice against the same unchanged page and Cairn paid for that grounding call twice, having thrown
+away an answer it had already computed.
+
+Two things were wrong, and only one of them is about cost:
+
+1. **The understanding was not an artifact.** It existed as intermediate state inside a run and vanished with
+   it. A human reviewing a run could see the cases and the code, but not the interaction map the agent had
+   built to design them — which is the artifact that explains *why* those cases and not others.
+2. **It was recomputed unconditionally**, with no notion of whether anything had changed.
+
+The naive fix — cache by URL — is worse than no cache: the page behind a URL changes, and a stale
+understanding produces cases grounded in elements that no longer exist. Any cache here needs an
+invalidation signal that is actually correlated with what the understanding depends on.
+
+## Decision
+
+**A run emits a `page-understanding.json` artifact and caches it across runs, keyed by URL plus a fingerprint
+of the page's ARIA snapshot.**
+
+1. **The understanding is a first-class artifact** — `runs/<id>/page-understanding.json`: a strict-schema
+   interaction map, element → locator + container + candidate actions, alongside the page's semantics.
+2. **It is assembled deterministically** from outputs the run already has (observe, verify, probe). The
+   documentarian introduces **no additional LLM call** — it structures what was computed anyway.
+3. **The cache key is `url` + page fingerprint, where the fingerprint is a hash of the ARIA snapshot.** This is
+   the load-bearing choice: the understanding is a map over ARIA refs, so *same ARIA ⇒ same refs ⇒ the cached
+   understanding is still valid*. The invalidation signal is the same thing the artifact is derived from,
+   rather than a proxy like a timestamp or an ETag.
+4. **A hit skips the ground call.** A second run on an unchanged page reuses the cached understanding and
+   skips `analyzePage` — fewer observe/ground calls, same output. A changed page misses (the fingerprint
+   differs) and re-grounds. That is deliberate invalidation, not a cache failure.
+5. **The cache lives outside the run** — `.cairn-cache/understanding`, gitignored, cross-run and cross-command.
+6. **`--fresh` bypasses it**, consistent with what `--fresh` already means for the experience tracker: ignore
+   prior-run state for a clean A/B.
+7. **A cache write failure never breaks a run.** Best-effort persistence, in line with ADR-0017's rule for
+   auxiliary passes.
+
+## Consequences
+
+- **Repeat runs on a stable page are cheaper and faster** without any change to what they produce.
+- **A reviewer can read what the agent understood**, separately from what it generated — the missing middle
+  artifact between the screenshot and the test case.
+- **The fingerprint is conservative in the right direction.** A cosmetic ARIA change (a re-ordered list, a
+  changed label) invalidates the cache even though the understanding might still have been valid. Re-grounding
+  unnecessarily costs one call; using a stale map costs a wrong test suite.
+- **The cache is a local directory, not shared state.** Nothing is coordinated between machines or CI runs;
+  a cold CI environment always misses. Fine for the current cost profile, and the reason a real cross-run
+  memory (MEM-02) is still a separate, unbuilt thing.
+- **`.cairn-cache/` is now a directory Cairn owns on the user's disk.** It is gitignored and safe to delete;
+  deleting it costs one grounding call on the next run.
+
+## Rejected alternatives
+
+- **Cache by URL alone.** Fastest to write and actively harmful: a changed page silently yields an
+  understanding grounded in elements that are gone.
+- **Cache by DOM/HTML hash.** Far too sensitive — a session token in a `data-` attribute or an ad slot
+  invalidates on every load, which is a cache that never hits. ARIA is both stabler and closer to what the
+  understanding is actually made of.
+- **Time-based expiry (TTL).** Time is uncorrelated with page change; a TTL either serves stale maps or
+  discards valid ones, tuned by guesswork.
+- **An extra LLM call to summarise the page into the artifact.** The point was to spend fewer calls, not to
+  add one for a document. Deterministic assembly from existing outputs gives a strict-schema artifact for free.
+- **Storing the understanding only inside `report.json`.** It is consumed independently (cache lookup, human
+  review) and would have bloated an artifact that ADR-0014 later froze as a contract.

--- a/docs/adr/0019-adversarial-styles-port-taxonomy-not-mechanism.md
+++ b/docs/adr/0019-adversarial-styles-port-taxonomy-not-mechanism.md
@@ -1,0 +1,85 @@
+# ADR-0019: Adversarial styles — port the taxonomy, not the mechanism
+
+- **Status:** Accepted
+- **Date:** 2026-07-01
+- **Decision in code:** `src/api/adversarial.ts`, `src/api/cases.ts`, `src/api/runner.ts`, `src/core/modalities/api.ts`
+- **Applies from:** 0.6.0 · **Issues:** #95 (BORROW-07), #96 (BORROW-08) · **PR:** #153
+- **Relationship to prior ADRs:** the same move as ADR-0008 (port a methodology, not an implementation), applied to an adjacent tool instead of the author's own skill library. Stays inside ADR-0015's no-LLM discipline.
+
+## Context
+
+`testomatio/explorbot` frames adversarial exploration as four named personas — **normal**, **curious**,
+**psycho**, **hacker** — which is a genuinely good taxonomy. It gives a user one word for a cost/risk
+posture, and it maps onto how testers actually talk about coverage.
+
+The implementation behind those names does not port. Explorbot's styles are **LLM-driven**: the persona is a
+prompt, and the model decides what a "psycho" input looks like on this endpoint. There is no deterministic
+style→value mapping to lift. Copying the mechanism would have meant putting an LLM call back into the middle
+of a generator that ADR-0015 had just established as pure — losing determinism and reproducible identities
+(ADR-0014) to buy a naming scheme.
+
+Separately, `AZANIR/qa-skills` (the same source ADR-0008 ported the web methodology from) already carries a
+payload library indexed by **OWASP WSTG** test IDs. That is the deterministic half the taxonomy was missing.
+
+## Decision
+
+**Take the four names from explorbot, and fill them from the schema and the WSTG payload library —
+deterministically, with no LLM call.** `--adversarial [styles]` on `cairn api`.
+
+| Style | What it deterministically produces |
+|---|---|
+| `normal` | the always-generated happy path (API-2), **tagged in place** — no new case is minted |
+| `curious` | exhaustive *valid* coverage: a case with every param including optional ones, plus one case per additional `enum` value |
+| `psycho` | SQL-injection and XSS payloads (`WSTG-INPV-05`, `WSTG-INPV-01`) plus a boundary-numeric case on the first suitable body property, and API-8's existing negative case **re-tagged rather than reimplemented** |
+| `hacker` | the deterministic subset only: strip auth from an otherwise-valid request and expect rejection |
+
+Supporting rules:
+
+1. **One flat case list.** Adversarial cases fold into the same list as `--negative`, with an
+   `adversarialStyle` tag and a `wstgId` where a specific WSTG test applies. There is **no parallel reporting
+   layer** — coverage, the report and the ATC artifacts (ADR-0015) handle them unchanged. API-6's
+   `computeApiCoverage` needed no new code at all: it is endpoint/status-driven already.
+2. **Reuse over re-derivation.** `psycho` re-tags the existing negative case instead of minting a duplicate;
+   `normal` tags the base case rather than re-emitting it.
+3. **The scope cut is explicit.** `hacker`'s IDOR and privilege-escalation checks are **not** shipped. In
+   explorbot they are stateful and multi-request — two identities, resource chaining, response-field replay —
+   which is API-9 scenario-chain machinery, not a single case. Only the deterministic single-request
+   auth-strip check ships here.
+4. **An unrecognised style name generates nothing**, and says so. It does not silently fall back to running
+   every style.
+
+### What self-review caught before this shipped
+
+Worth recording, because all three are the failure mode this design invites — derived cases inheriting the
+wrong metadata from the case they were derived from:
+
+- new `psycho`/`hacker` cases were inheriting `type: "Positive"` from their happy-path base, though they
+  expect rejection;
+- a reused negative case's name collided with the plain `--negative` version when both flags were passed;
+- `--adversarial` with an unknown style silently ran *every* style instead of none.
+
+All three were fixed with regression coverage and a live CLI run confirming each.
+
+## Consequences
+
+- **The names are borrowed; the behaviour is ours.** A user coming from explorbot recognises the vocabulary
+  and gets different, more predictable output: same spec plus same styles ⇒ same cases, every run.
+- **Security cases carry a standard reference.** A `wstgId` makes a generated case traceable to OWASP WSTG,
+  which is what makes it defensible in a review rather than "the tool made this up".
+- **The ceiling is deterministic payloads.** These cases find the classes of bug a fixed payload finds. They
+  are not a fuzzer and not a pentest, and the WSTG tag should not be read as coverage of that WSTG item.
+- **`hacker` is honestly incomplete.** The auth-strip check is a real check; IDOR and privilege escalation are
+  the interesting half and remain unbuilt. Building them means building on API-9, not on this module.
+- **No LLM cost is added to `api` runs**, so ADR-0015's determinism and ADR-0014's `stableId` guarantees hold
+  for adversarial cases too.
+
+## Rejected alternatives
+
+- **Port explorbot's LLM-driven styles as prompts.** Would have reintroduced non-determinism and per-operation
+  token cost into a generator deliberately built without them, and made `stableId` unstable for these cases.
+- **A parallel adversarial report section.** Duplicates coverage, reporting and artifact code for cases that
+  are ordinary cases with an extra tag.
+- **Skip the taxonomy and expose flags like `--sqli --xss --no-auth`.** Loses the one thing worth borrowing:
+  a single word for a posture that a user can reason about without knowing the payload catalogue.
+- **Ship `hacker` with an LLM-driven IDOR attempt.** The stateful part is real work with real
+  false-positive risk; shipping a plausible-looking version of it would be worse than not shipping it.

--- a/docs/adr/0020-untrusted-llm-verdicts-and-data-protection.md
+++ b/docs/adr/0020-untrusted-llm-verdicts-and-data-protection.md
@@ -1,0 +1,85 @@
+# ADR-0020: An LLM verdict is an untrusted input; only self-created data is disposable
+
+- **Status:** Accepted
+- **Date:** 2026-06-23
+- **Decision in code:** `src/safety/guardrails.ts`, `src/eval/pilot.ts`, `src/agent/index.ts`, `src/flow/setup.ts`, `prompts/local/pilot-review`
+- **Applies from:** 0.5.0 · **Issue:** #91 (BORROW-04) · **PR:** #100
+- **Relationship to prior ADRs:** constrains ADR-0006's judge/Pilot layer and ADR-0017's `--setup` pass. Neither is optional; these rules apply on every run.
+
+## Context
+
+Two capabilities had just landed or were about to, and both created a class of failure that testing cannot
+catch after the fact.
+
+**The Pilot verdict.** ADR-0006 gives Cairn an LLM supervisor that reviews a run and returns a verdict. A
+"pass" is the input to everything downstream — scores, experiments, whether a suite is considered good. The
+verdict was accepted at face value. The specific failure it invites is well known and cheap to produce: the
+model reports success naming an entity ("created the *Acme Corp* record") that the run never touched. Nothing
+checked. A false pass is worse than a false fail, because a false fail gets investigated.
+
+**Journey setup.** `--setup` (ADR-0017) turns a journey's prose preconditions into runnable setup. Some
+preconditions are phrased as deletions — "no existing draft", "an empty cart". At setup time, by definition,
+nothing has been created yet, so any deletion at that point necessarily targets **pre-existing data** — the
+user's real data, in the app the user pointed Cairn at.
+
+Both had to be closed before any stateful or destructive automation went further, not after.
+
+## Decision
+
+**Two rules, both unconditional, both pure functions in `src/safety/guardrails.ts`.**
+
+### 1. A verdict that names an entity must prove it
+
+`PilotSchema` gains an `entity` field, and the prompt asks for it (with an explicit instruction not to invent
+names). `checkProvenance` then compares that entity against the run's **session log** — case titles, steps,
+and observed element names. A `pass` naming an entity that does not appear there is **downgraded to
+`needs-work`**, with the reason recorded rather than silently swallowed.
+
+The asymmetry is intentional. A verdict is never upgraded by this check, only downgraded. It cannot make a
+result better than the model said; it can only refuse to believe the model on a claim the run does not
+support.
+
+### 2. Only self-created data is disposable
+
+`guardDeletion` refuses a deletion that targets pre-existing data or the resource under the current URL. Only
+items the run itself created may be deleted. `isDeletionIntent` is the shared classifier, so "delete",
+"clear", "remove" are recognised in one place rather than at each call site.
+
+In the setup planner, `enforceDataProtection` sits alongside `enforceSafeStrategies` and forces **any**
+deletion-intent precondition to the `manual` fallback — documented for a human to satisfy, and `test.skip`ped
+in generated code. At setup time nothing is self-created, so there is no case where such a deletion is safe.
+
+### Why these live as pure functions
+
+`checkProvenance`, `guardDeletion` and `isDeletionIntent` are side-effect-free and take their inputs
+explicitly. That is what makes each one testable in isolation — and each test was verified to **go red when
+its guardrail is removed**, which is the only evidence that a guardrail is actually load-bearing rather than
+decorative.
+
+## Consequences
+
+- **Some true passes are downgraded.** A model that names an entity using different words than the session log
+  gets a `needs-work` it did not deserve. Accepted deliberately: an unnecessary review is cheap, a believed
+  false pass corrupts the score and the dataset it feeds.
+- **The Pilot prompt now has a required field to fill honestly.** Asking for `entity` is also a mild
+  hallucination check by itself — a model with nothing to name should name nothing.
+- **`--setup` cannot fully automate a class of preconditions**, by design. A journey needing a clean slate
+  gets a documented manual step instead of a fabricated deletion.
+- **These are not flags.** ADR-0017 makes new capabilities opt-in; these are the explicit exception, because a
+  safety rule with an off switch is a safety rule with an off switch.
+- **The provenance check is a heuristic, and should be read as one.** It is substring/name matching over a
+  session log, not a proof of causation. It catches the invented-entity failure; it does not verify that the
+  entity was created *correctly*.
+
+## Rejected alternatives
+
+- **Trust the Pilot and catch false passes downstream in scoring.** The score is computed *from* the verdict;
+  a false pass corrupts the very signal that would have detected it, and it lands in the dataset used for
+  regression experiments.
+- **Prompt the model harder not to hallucinate.** A prompt is a request. A provenance check is a check.
+- **Ask for confirmation before a destructive setup step.** Cairn runs unattended (CI, MCP, batch). An
+  interactive prompt is not available where the risk is highest.
+- **A `--allow-destructive` escape hatch.** The one legitimate use — deleting what the run itself created —
+  is already permitted by the rule. A flag would exist only to enable the illegitimate case.
+- **Put the guards inside the Pilot and the setup planner directly.** They would then be untestable without
+  an LLM, and the deletion-intent classifier would exist in two drifting copies.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,108 @@
+# Architecture Decision Records — index
+
+**20 records.** All of them live here, in `docs/adr/`, one file per decision, numbered in the order they
+were made. There is no second location.
+
+> Verified by command: `ls docs/adr/[0-9]*.md | wc -l` → `20`. If that number and this page disagree,
+> the command is right. *Checked 2026-08-02.*
+
+An ADR states what was decided, when, why, and what was rejected. It is not a design doc and not a changelog:
+if a change did not close off an option, it does not get one. The second half of this page is the reverse
+view — **what shipped without an ADR, and why that was the right call** — because "no ADR" should be a
+recorded judgement, not an omission.
+
+Conventions: `NNNN-short-title.md`, next free number, never renumbered. Statuses: `Accepted`, `Superseded by
+ADR-NNNN`, `Partially superseded by ADR-NNNN`. A decision that is revised rather than replaced keeps its
+number and gains a `Revised:` date in its header (see ADR-0002, ADR-0006).
+
+---
+
+## The records
+
+| # | Decision | Date | Status |
+|---|---|---|---|
+| [0001](0001-language-and-agent-framework.md) | TypeScript + plain async pipeline (originally LangGraph.js v1) | 2026-06-08 | Accepted · partially superseded by 0013 |
+| [0002](0002-llm-anthropic-tiering.md) | Multi-provider LLM layer (Anthropic + OpenRouter + Groq), tier × provider | 2026-06-08 | Accepted · revised 2026-06-13 |
+| [0003](0003-browser-gateway-hybrid.md) | Hybrid `BrowserGateway`: playwright-lib PRIMARY + playwright-cli SECONDARY | 2026-06-08 | Accepted |
+| [0004](0004-prompts-in-langfuse.md) | Prompts as a versioned artifact in Langfuse, with a local fallback | 2026-06-08 | Accepted |
+| [0005](0005-test-output-format.md) | Output is `@playwright/test` — POM + `getByRole` + ARIA assertions | 2026-06-08 | Accepted |
+| [0006](0006-observability-langfuse-v5-otel.md) | Observability and self-improvement on Langfuse v5 (OTel), self-hosted | 2026-06-08 | Accepted · revised 2026-06-08 |
+| [0007](0007-single-package-not-monorepo.md) | One layered npm package, not a monorepo | 2026-06-08 | Accepted |
+| [0008](0008-methodology-port-from-qa-skills.md) | The methodology is ported from `AZANIR/qa-skills` | 2026-06-08 | Accepted |
+| [0009](0009-tui-ink.md) | Interactive TUI on Ink (React-for-CLI) | 2026-06-10 | Accepted · Ink optional since 0013 |
+| [0010](0010-rename-to-cairn.md) | Rename Lex-Bot → Cairn (product name only) | 2026-06-13 | Accepted |
+| [0011](0011-per-role-model-routing.md) | Per-role model routing (worker/reasoner) + per-run cost reporting | 2026-06-13 | Accepted |
+| [0012](0012-relicense-to-apache-2.0.md) | Relicense GPL-3.0-only → Apache-2.0 | 2026-06-14 | Accepted |
+| [0013](0013-drop-langgraph.md) | Drop `@langchain/langgraph`; telemetry at the LLM layer; Ink optional | 2026-06-19 | Accepted |
+| [0014](0014-versioned-artifact-contract.md) | The run artifact is a versioned, self-describing contract | 2026-07-30 | Accepted |
+| [0015](0015-api-modality-schema-driven.md) | The `api` modality generates from the spec, not from an LLM | 2026-06-30 | Accepted |
+| [0016](0016-integration-surfaces-thin-adapters.md) | MCP, CI/PR bot and `--into-project` are thin adapters over the core | 2026-06-24 | Accepted |
+| [0017](0017-opt-in-pipeline-passes.md) | The pipeline grows by opt-in passes; a flag-off run is byte-identical | 2026-06-22 | Accepted |
+| [0018](0018-documentarian-page-understanding-cache.md) | Page understanding is an artifact, cached by ARIA fingerprint | 2026-06-29 | Accepted |
+| [0019](0019-adversarial-styles-port-taxonomy-not-mechanism.md) | Adversarial styles — port the taxonomy, not the mechanism | 2026-07-01 | Accepted |
+| [0020](0020-untrusted-llm-verdicts-and-data-protection.md) | An LLM verdict is untrusted; only self-created data is disposable | 2026-06-23 | Accepted |
+
+Note the dates: 0014 is numbered after 0015–0020 but was decided later. Numbers are assigned when an ADR is
+**written**; the `Date` field is when the decision was **made**. Records 0015–0020 were written on 2026-08-02
+to cover decisions taken between 2026-06-22 and 2026-07-01 — see the next section for why they were owed.
+
+### Reading order for a newcomer
+
+1. [0013](0013-drop-langgraph.md) — there is no graph framework, just async functions. Everything else assumes this.
+2. [0003](0003-browser-gateway-hybrid.md) + [0005](0005-test-output-format.md) — what Cairn drives, and what it emits.
+3. [0002](0002-llm-anthropic-tiering.md) + [0011](0011-per-role-model-routing.md) — how a model gets picked for a step, and what it costs.
+4. [0014](0014-versioned-artifact-contract.md) — what a run leaves behind, and who reads it.
+5. [0012](0012-relicense-to-apache-2.0.md) — why Apache-2.0, and where the monetisation boundary sits.
+
+---
+
+## What shipped between 0013 and today, and whether it needed an ADR
+
+Records stopped at **0013 (2026-06-19)** while releases did not: `v0.4.0 → v0.7.0` is **45 commits, 28 of them
+`feat:`**. That gap is what the list below closes. Each entry is a verdict, not a description.
+
+> Verified by command: `git rev-list v0.4.0..HEAD --count` → `45`;
+> `git log v0.4.0..HEAD --pretty=%s | grep -c '^feat'` → `28`. *Checked 2026-08-02.*
+
+### Needed one — now written
+
+| Shipped | Date | ADR | Because |
+|---|---|---|---|
+| `--critique`, `--flow`, `--setup`, `--gaps`; later `--goal`, `--screencast` | 06-22 → 06-30 | [0017](0017-opt-in-pipeline-passes.md) | Six passes could each have become the default. Making them opt-in — with a byte-identical flag-off run — is what keeps regressions attributable and cost predictable. That is a rule, and rules are what ADRs are for. |
+| Provenance-checked Pilot verdicts + data-protection guardrails | 06-23 | [0020](0020-untrusted-llm-verdicts-and-data-protection.md) | Establishes that an LLM verdict is an untrusted input and that only self-created data may be deleted. A safety invariant nobody should be able to remove without finding out why it exists. |
+| MCP server (`cairn mcp`), CI/PR bot + GitHub Action (`cairn ci`), `--into-project` | 06-24 → 06-25 | [0016](0016-integration-surfaces-thin-adapters.md) | Three surfaces, one rule: a thin adapter over the public core, optional deps, side effects behind an injectable seam. Three parallel implementations was the live risk. |
+| Documentarian — cached page-understanding artifact | 06-29 | [0018](0018-documentarian-page-understanding-cache.md) | Introduces cross-run persistent state (`.cairn-cache/`) and an invalidation rule (ARIA fingerprint). A cache with the wrong key is worse than no cache. |
+| The `api` modality, API-1…API-10 | 06-30 → 07-01 | [0015](0015-api-modality-schema-driven.md) | A second real modality that deliberately generates **without** an LLM, and reuses the web ATC artifact boundary so Plune needs no second ingest path. Both are choices with rejected alternatives. |
+| Adversarial styles (normal/curious/psycho/hacker) | 07-01 | [0019](0019-adversarial-styles-port-taxonomy-not-mechanism.md) | The taxonomy is borrowed from `testomatio/explorbot`, the mechanism explicitly is not — and `hacker`'s IDOR/priv-esc half is knowingly unshipped. A scope cut that needs to stay visible. |
+| Versioned artifact contract (`schemaVersion`, `mode`, `stableId`) | 07-30 | [0014](0014-versioned-artifact-contract.md) | `report.json` is what `plune ingest` reads (Plune's `ADR-CI-02`), so its shape stopped being Cairn's internal business. |
+
+### Did not need one, and why
+
+| Shipped | Date | Verdict |
+|---|---|---|
+| `--fresh` — ignore prior-run experience for clean A/B runs | 06-19 | **No.** An escape hatch on the existing experience tracker. The general rule it obeys is now in ADR-0017. |
+| Metrics legend inline in `report.md` / console / README | 06-19 | **No.** Presentation of numbers ADR-0006 already decided to collect. No option was closed off. |
+| Externalised prompts + house-style packs (`--style`) | 06-22 | **No.** Extends ADR-0004's local fallback into user-editable files. Worth a `Revised:` line on 0004, not a record. |
+| Provider-safe strict JSON schemas for structured invokes | 06-23 | **No.** Provider-compatibility fix inside the ADR-0002 layer. |
+| Tiered transient-error recovery for navigation | 06-23 | **No.** Resilience inside `BrowserGateway` (ADR-0003); the seam is unchanged. |
+| SPA link-following, per-page crawl snapshots, Windows `EBUSY` cleanup | 06-24 | **No.** Bug fixes in the `--flow` crawler and the validator sandbox. |
+| Step timeout (`STEP_TIMEOUT_MS`) + `volume-fast` routing preset | 06-25 | **No.** A third row in the preset table ADR-0011 already defines, plus a timeout wrapper. Worth a `Revised:` line on 0011. |
+| Scope-aware knowledge injection (`web` \| `api` \| `all`) | 06-29 | **No.** A directory-and-front-matter convention for `knowledge/`, documented in `docs/configuration.md`. Plumbing ahead of ADR-0015, with no alternative rejected. |
+| Dependabot configuration (four commits tuning it) | 06-29 → 06-30 | **No.** Repository housekeeping. |
+| Publish job no longer chases `npm@latest` onto an unsupported engine | 07-30 | **No.** CI fix. |
+
+### Known gap, older than this list
+
+The **modality registry** (`src/core/registry.ts`, 2026-06-14, C1-01 / L-G2) — one list of modalities, with
+`ui`/`unit`/`docs` shipping as *gated stubs* pulled one at a time by named demand — has no ADR of its own. It
+predates this review window and is described in the file's own header, but it is a real structural decision
+and the natural next record if anyone touches it.
+
+---
+
+## Elsewhere
+
+Cairn is one of several repositories under `plune-ai`. **Plune** (the private platform) keeps its own ADRs and
+its own index; the one that matters at this boundary is its `ADR-CI-02` — *read `report.json` only, and do not
+depend on the Cairn package* — which is exactly why [ADR-0014](0014-versioned-artifact-contract.md) exists on
+this side.


### PR DESCRIPTION
Closes #167, closes #168. Documentation only — no source file is touched.

## Why

Two gaps with one cause, both found in an end-to-end audit on 2026-08-02.

**There was no way into the documentation.** `docs/adr/` had no README, and the one entry point that existed — `docs/README.md` — was in `.gitignore`. A published Apache-2.0 package shipped without a documentation index.

That ignore rule turns out to have been a workaround rather than an oversight, which is worth recording: the file indexed `sprints/`, `tasks/`, `research/`, `prompts/`, `PLAN.md` and `traceability.md` — none of them published — so in the public repository it would have rendered as a page of dead links. Ignoring it was the cheapest fix at the time. It has been rewritten to reference only published paths and unignored, with a comment in `.gitignore` explaining why. It also still called the product *QA Explorer Bot*, pointed at a local path from a previous machine, and listed sprints S0–S6.

**Decisions stopped being recorded.** ADRs end at `0013`, dated 2026-06-19. Between `v0.4.0` and `HEAD` there are 45 commits, 28 of them `feat:` — including the entire `api` modality, the MCP server, the CI/PR bot, and the versioned artifact contract. None left a record.

## What changed

Reviewed all 28 and split them, with the verdict recorded **per item** in the index — including the ten that did *not* warrant an ADR, and why (fixes inside layers already documented, a third row in an existing preset table, a folder convention, Dependabot, a CI fix). Recording the negatives matters: it is the difference between "we decided this needs no ADR" and "we forgot".

Seven did warrant one:

| ADR | Decision | Date |
|---|---|---|
| [0014](docs/adr/0014-versioned-artifact-contract.md) | The run artifact is a versioned contract | 2026-07-30 |
| [0015](docs/adr/0015-api-modality-schema-driven.md) | The `api` modality is schema-driven, no LLM in the loop | 2026-06-30 |
| [0016](docs/adr/0016-integration-surfaces-thin-adapters.md) | Integration surfaces are thin adapters | 2026-06-24 |
| [0017](docs/adr/0017-opt-in-pipeline-passes.md) | Pipeline passes are opt-in | 2026-06-22 |
| [0018](docs/adr/0018-documentarian-page-understanding-cache.md) | Page understanding is cached by ARIA fingerprint | 2026-06-29 |
| [0019](docs/adr/0019-adversarial-styles-port-taxonomy-not-mechanism.md) | Adversarial styles port a taxonomy, not a mechanism | 2026-07-01 |
| [0020](docs/adr/0020-untrusted-llm-verdicts-and-data-protection.md) | An LLM verdict is untrusted; data-protection guardrails | 2026-06-23 |

Dates are the **actual decision dates from `git log`**, not today's.

**0014 is deliberately first.** `report.json` stopped being Cairn's internal business the moment `plune ingest` began reading it — see `ADR-CI-02` in the platform repository. A format another product parses is a contract, and it needed to be written down as one before it changes by accident.

## Verification

```
git check-ignore docs/README.md docs/adr/README.md   → empty (was: .gitignore:58)
ls docs/adr/[0-9]*.md | wc -l                        → 20 (was 13)
git rev-list v0.4.0..HEAD --count                    → 45
git log v0.4.0..HEAD --pretty=%s | grep -c '^feat'   → 28
```

Every number claimed in the index is annotated with the command that verifies it.

## Language

Prose is English. The umbrella convention prefers Ukrainian for human prose, but it also defers to a sub-repository's own convention, and this one is unambiguous: `git ls-files | xargs grep -lP '\p{Cyrillic}'` returns nothing, and all thirteen existing ADRs are English. This is a published package whose docs are read by its users.

## Not in this change

Three existing ADRs (0002, 0004, 0011) have earned a `Revised:` line from later work. That is noted in the index rather than done here — editing the header of an accepted decision is its own call.
