### PR TITLE
chore(deps): pin @types/node major to the engines floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,13 @@ updates:
         update-types:
           - version-update:semver-minor
           - version-update:semver-patch
+      # @types/node's major tracks a Node release line, so it is pinned by `engines`, not by what
+      # npm calls latest. Taking a major above the lowest supported runtime lets `tsc` accept an API
+      # that does not exist there — the type error #171 hit was the symptom, not the reason to say no.
+      # Raise `engines` first, then drop this entry.
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
 
   # CI / publish workflows (.github/workflows/*.yml).
   - package-ecosystem: github-actions


### PR DESCRIPTION
Closes #171 by making the answer a standing rule instead of a decision re-taken every major.

## Why

`@types/node`'s major tracks a Node release line. It is therefore pinned by `engines` (`>=20`), not by whatever npm calls latest. Accepting a major above the lowest supported runtime lets `tsc` type-check against an API that is absent on that floor — a compile-time guarantee turned into a runtime surprise for the users the package claims to support.

#171 (22 → 26) is the case in point. It failed on:

```
src/api/runner.ts(247,49): error TS2322: Type 'Buffer<ArrayBufferLike>' is not assignable to type 'BlobPart'.
```

That is the symptom. Patching the assignability would have bought a green build and a type surface describing Node 26 — the wrong trade for a project whose `engines` say 20.

Without an ignore entry this recurs on every `@types/node` major, and each time the cheap move is to fix the type error and merge. The rule is written down so the next person meets the reasoning rather than the symptom.

## What changed

Four lines in `.github/dependabot.yml`, plus the comment explaining when to remove them. Minor and patch updates to `@types/node` are already ignored repo-wide, so this only closes the major channel.

Raising `engines` is the trigger to drop the entry — the comment says so at the site.

## Not in this change

`engines` stays at `>=20`. Moving the floor is a support decision, not a dependency one.
