### PR TITLE
docs(adr): record 0021 — a human-authored case is a first-class input

### DIFF
--- a/docs/adr/0021-human-authored-case-as-input-boundary-unchanged.md
+++ b/docs/adr/0021-human-authored-case-as-input-boundary-unchanged.md
@@ -1,0 +1,61 @@
+# ADR-0021: A human-authored case is a first-class input; the platform boundary stays where it is
+
+- **Status:** Accepted · **Date:** 2026-09-02
+- **Decision in code:** *not yet* — this ADR precedes the implementation (planned as `cairn automate --case <file>`, see umbrella plan `AI-documents/plune/plune-ai/06-plan.md`, epic C-1)
+- **Relationship to prior ADRs:** extends ADR-0010 (Cairn does not know about the platform) and ADR-0014 (versioned artifact contract, `stableId`); does not change ADR-0005 (output is `@playwright/test`, POM + `getByRole`)
+- **Platform side:** Plune ADR 0024 (platform invokes Cairn as a tool)
+
+## Context
+
+Cairn's inputs are a URL (UI modality) or an OpenAPI document (API modality). Cairn designs the
+cases itself. The Plune platform now wants the reverse direction as well: a person writes a
+scenario — Gherkin-style or free-form Markdown — and Cairn turns it into a Playwright spec, runs
+it, heals it, and hands the result back for review.
+
+The tempting shape is "Cairn as a bot inside the platform": read cases from the API, write
+proposals into the review queue. That breaks ADR-0010 — the rule that keeps Cairn useful without
+an account, keeps the contract from drifting from two sides, and keeps a single ingestion path
+(`plune ingest`, Plune ADR-CI-01).
+
+The market went through this already. Tools that started with "natural language executed by an
+LLM at run time" (testRigor, early Momentic) converged on "a human approves the plan → locators
+are resolved and cached → real code is exported to the repo" (KaneAI, Shiplight, Checksum,
+Playwright's own planner/generator/healer). That is Cairn's existing architecture; the only
+missing piece is the input.
+
+## Decision
+
+1. **A human-authored case is a third input**, next to URL and OpenAPI. Cairn reads it from a
+   file (the same Markdown case format Cairn already emits, ADR-0014, with `style: gherkin | free`),
+   never from a network.
+2. **The boundary from ADR-0010 is unchanged.** No `PLUNE_*` variable, no token, no HTTP call to
+   the platform. The platform (through `@plune-ai/cli`) writes the case file, invokes Cairn,
+   and ingests `runs/<id>/`. Direction of dependency: platform → Cairn.
+3. **Steps compile to cached, deterministic actions.** Each scenario step maps to a
+   `test.step()` whose locator is resolved once (intent + resolved locator stored alongside the
+   spec) and re-resolved only on failure. The LLM is used at generation and repair time, never on
+   the green path.
+4. **Repo-resident project memory is an input, not a service.** Cairn reads
+   `plune/memory/*.md` (or `CAIRN.md`) from the target repo — conventions, data sources, page
+   objects, prohibitions — the same way Playwright agents read `.github/` agent files. It does
+   not write there; the platform proposes memory changes through review.
+5. **Healing stays conservative and visible.** The healer reads `git diff base..head` before
+   deciding intent vs. drift; unfixable tests get `test.fixme` with a diagnosis; every heal is a
+   diff in `runs/<id>/`, never a silent rewrite.
+
+## Rejected
+
+- *Cairn talks to the platform API.* Breaks ADR-0010; makes the account mandatory; duplicates
+  the ingestion path.
+- *Execute natural-language steps at run time.* Non-deterministic, slow, expensive; the
+  category moved away from it.
+- *Strict Gherkin with step definitions as the only style.* Keeps the "step-definition tax"
+  users complain about (BlinqIO); free-form Markdown stays the default, Gherkin is a style.
+
+## Consequences
+
+- New CLI surface: `cairn automate --case <file> [--repo <dir>] [--memory <dir>]`; output
+  contract unchanged (`report.json`, `testcases/`, `tests/`, `stableId` carried through).
+- Traceability gains one link: scenario step ↔ `test.step()` ↔ resolved locator.
+- The ISO 29119-4 design layer is bypassed for human cases by default (the human already
+  designed the case); `--gaps` can still propose additional cases through the same review path.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,10 +1,10 @@
 # Architecture Decision Records — index
 
-**20 records.** All of them live here, in `docs/adr/`, one file per decision, numbered in the order they
+**21 records.** All of them live here, in `docs/adr/`, one file per decision, numbered in the order they
 were made. There is no second location.
 
-> Verified by command: `ls docs/adr/[0-9]*.md | wc -l` → `20`. If that number and this page disagree,
-> the command is right. *Checked 2026-08-02.*
+> Verified by command: `ls docs/adr/[0-9]*.md | wc -l` → `21`. If that number and this page disagree,
+> the command is right. *Checked 2026-09-02.*
 
 An ADR states what was decided, when, why, and what was rejected. It is not a design doc and not a changelog:
 if a change did not close off an option, it does not get one. The second half of this page is the reverse
@@ -41,6 +41,7 @@ number and gains a `Revised:` date in its header (see ADR-0002, ADR-0006).
 | [0018](0018-documentarian-page-understanding-cache.md) | Page understanding is an artifact, cached by ARIA fingerprint | 2026-06-29 | Accepted |
 | [0019](0019-adversarial-styles-port-taxonomy-not-mechanism.md) | Adversarial styles — port the taxonomy, not the mechanism | 2026-07-01 | Accepted |
 | [0020](0020-untrusted-llm-verdicts-and-data-protection.md) | An LLM verdict is untrusted; only self-created data is disposable | 2026-06-23 | Accepted |
+| [0021](0021-human-authored-case-as-input-boundary-unchanged.md) | A human-authored case is a first-class input; platform boundary (ADR-0010) unchanged; steps compile to cached deterministic actions | 2026-09-02 | Accepted |
 
 Note the dates: 0014 is numbered after 0015–0020 but was decided later. Numbers are assigned when an ADR is
 **written**; the `Date` field is when the decision was **made**. Records 0015–0020 were written on 2026-08-02
@@ -62,7 +63,7 @@ Records stopped at **0013 (2026-06-19)** while releases did not: `v0.4.0 → v0.
 `feat:`**. That gap is what the list below closes. Each entry is a verdict, not a description.
 
 > Verified by command: `git rev-list v0.4.0..HEAD --count` → `45`;
-> `git log v0.4.0..HEAD --pretty=%s | grep -c '^feat'` → `28`. *Checked 2026-08-02.*
+> `git log v0.4.0..HEAD --pretty=%s | grep -c '^feat'` → `28`. *Checked 2026-09-02.*
 
 ### Needed one — now written
 


### PR DESCRIPTION
The file was written on 2026-09-02 during the platform's ADR sprint and never committed — it sat untracked while the umbrella plan already recorded the sprint as closed. Found by the same A-3 pass that checked what else that sprint left behind.

ADR-0021 records the decision epic C-1 builds on: Cairn accepts a written scenario (Gherkin-style or free-form Markdown) as a first-class input, and **the platform boundary does not move** — ADR-0010 stays, so Cairn still knows nothing about Plune, and ingestion keeps going through `plune ingest`.

The index is updated with it: 20 → 21 records, verification date refreshed.
